### PR TITLE
Shipping logs to ES

### DIFF
--- a/dcicutils/log_utils.py
+++ b/dcicutils/log_utils.py
@@ -179,6 +179,10 @@ def set_logging(es_server=None, in_prod=False, level=logging.INFO, log_name=None
         cache_logger_on_first_use=True,
     )
 
+    if log_name is None:
+        log_name = __name__
+    logger = logging.getLogger(log_name)
+
     # add the handler responsible for posting the logs to ES
     import pdb; pdb.set_trace()
     if es_server:
@@ -214,12 +218,9 @@ def set_logging(es_server=None, in_prod=False, level=logging.INFO, log_name=None
     '''
 
     # below could be used ot redirect logging to a file if desired
-    if log_name is None:
-        log_name = __name__
     if log_dir and log_name:
         import os
         log_file = os.path.join(log_dir, log_name + ".log")
-        logger = logging.getLogger(log_name)
         hdlr = logging.FileHandler(log_file)
         formatter = logging.Formatter('')
         hdlr.setFormatter(formatter)

--- a/dcicutils/log_utils.py
+++ b/dcicutils/log_utils.py
@@ -6,7 +6,7 @@ import uuid
 from threading import Timer, Lock
 from dcicutils import es_utils
 from structlog.threadlocal import wrap_dict
-from elasticsearch import eshelpers
+from elasticsearch import helpers
 
 
 class ElasticsearchHandler(logging.Handler):
@@ -67,7 +67,7 @@ class ElasticsearchHandler(logging.Handler):
                 }
                 for record in records_copy
             )
-            for ok, resp in eshelpers.streaming_bulk(self.es_client, actions):
+            for ok, resp in helpers.streaming_bulk(self.es_client, actions):
                 print('RESEND RESP: %s' % resp)
                 if not ok:
                     self.records_to_resend.append(resp)

--- a/dcicutils/log_utils.py
+++ b/dcicutils/log_utils.py
@@ -101,16 +101,19 @@ class ElasticsearchLoggerFactory(structlog.stdlib.LoggerFactory):
     def __call__(self, *args):
         """
         Overload the original __call__ function and add the custom handler
+        The args used to structlog.get_logger should be <logger name> and
+        <es server>, in that order
         """
         if args:
             name = args[0]
+            es_server = args[1]
         else:
             _, name = _find_first_app_frame_and_name(self._ignore)
         import pdb; pdb.set_trace()
         logger = logging.getLogger(name)
-        # always add the ElasticsearchHandler
-        es_handler = ElasticsearchHandler(es_server)
-        logger.addHandler(es_handler)
+        if es_server:
+            es_handler = ElasticsearchHandler(es_server)
+            logger.addHandler(es_handler)
         return logger
 
 

--- a/dcicutils/log_utils.py
+++ b/dcicutils/log_utils.py
@@ -181,7 +181,7 @@ def set_logging(es_server=None, in_prod=False, level=logging.INFO, log_name=None
 
     if log_name is None:
         log_name = __name__
-    logger = logging.getLogger(log_name)
+    logger = structlog.get_logger(log_name)
 
     # add the handler responsible for posting the logs to ES
     import pdb; pdb.set_trace()

--- a/dcicutils/log_utils.py
+++ b/dcicutils/log_utils.py
@@ -102,7 +102,7 @@ class ElasticsearchLoggerFactory(structlog.stdlib.LoggerFactory):
         """
         Set self.es_server and call __init__ of parent
         """
-        self.es_server = es_server()
+        self.es_server = es_server
         structlog.stdlib.LoggerFactory.__init__(self, ignore_frame_names)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ botocore==1.10.42
 elasticsearch==5.5.2
 aws_requests_auth==0.4.1
 urllib3==1.22
+structlog==18.1.0
 pytest-runner

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -383,6 +383,7 @@ def test_get_es_metadata(integrated_ff):
     assert set(all_es_uuids) == set(all_uuids)
 
 
+@pytest.mark.integrated
 def test_get_es_search_generator(integrated_ff):
     from dcicutils import es_utils
     # get es_client info from the health page
@@ -407,6 +408,7 @@ def test_get_es_search_generator(integrated_ff):
     assert all_es_uuids == search_uuids
 
 
+@pytest.mark.integrated
 def test_get_health_page(integrated_ff):
     health_res = ff_utils.get_health_page(key=integrated_ff['ff_key'])
     assert health_res and 'error' not in health_res

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -1,0 +1,68 @@
+from dcicutils import log_utils, ff_utils, es_utils
+import pytest
+import structlog
+import time
+pytestmark = pytest.mark.working
+
+
+# TODO:
+# TEST RETRY LOGIC (?)
+# TEST skip_es parameter with in_prod
+
+
+def test_set_logging_not_prod(caplog):
+    # setting in_prod to False will invalidate es_server setting
+    log_utils.set_logging(es_server='not_a_real_server', in_prod=False)
+    log = structlog.getLogger(__name__)
+    log.error('bleh', foo='baz')
+    assert len(caplog.records) == 1
+    log_record = caplog.records[0]
+    # make sure there are no handlers and the message is non-dictionary
+    assert len(log_record._logger.handlers) == 0
+    assert 'baz' in log_record.__dict__['msg']
+    assert 'error' in log_record.__dict__['msg']
+    assert 'log_uuid' in log_record.__dict__['msg']
+    assert not isinstance(log_record.__dict__['msg'], dict)
+
+
+def test_set_logging_prod_but_no_es(caplog):
+    # omitting es_server while using in_prod=True will cause dictionary
+    # log messages but no additional Elasticsearch logging handlers
+    log_utils.set_logging(es_server=None, in_prod=True)
+    log = structlog.getLogger(__name__)
+    log.error('bleh', foo='bean')
+    assert len(caplog.records) == 1
+    log_record = caplog.records[0]
+    assert isinstance(log_record.__dict__['msg'], dict)
+    assert 'log_uuid' in log_record.__dict__['msg']
+    assert len(log_record._logger.handlers) == 0
+
+
+@pytest.mark.integrated
+def test_set_logging_in_prod(caplog, integrated_ff):
+    # get es_client info from the health page
+    es_url = ff_utils.get_health_page(key=integrated_ff['ff_key'])['elasticsearch']
+    log_utils.set_logging(es_server=es_url, in_prod=True)
+    log = structlog.getLogger(__name__)
+    log.warning('meh', foo='bar')
+    es_log_idx = log_utils.calculate_log_index()
+    assert 'logs-' in es_log_idx
+    assert len(caplog.records) == 1
+    log_record = caplog.records[0]
+    # make sure the ES handler is present
+    assert len(log_record._logger.handlers) == 1
+    assert 'log_uuid' in caplog.records[0].__dict__['msg']
+    assert caplog.records[0].__dict__['msg']['event'] == 'meh'
+    assert caplog.records[0].__dict__['msg']['foo'] == 'bar'
+    assert caplog.records[0].__dict__['msg']['level'] == 'warning'
+    log_uuid = caplog.records[0].__dict__['msg']['log_uuid']
+    # make sure the log was written successfully to mastertest ES
+    time.sleep(3)
+    es_client = es_utils.create_es_client(es_url, use_aws_auth=True)
+    es_res = ff_utils.get_es_metadata([log_uuid], es_client=es_client,
+                                      key=integrated_ff['ff_key'])
+    assert len(es_res) == 1
+    assert es_res[0]['event'] == 'meh'
+    assert es_res[0]['foo'] == 'bar'
+    assert es_res[0]['log_uuid'] == log_uuid
+    assert es_res[0]['level'] == 'warning'


### PR DESCRIPTION
Used the pre-existing Elasticsearch utils combined with some logging/structlog magic to make logs automatically ship to ES when `set_logging` is called with an `es_server` and `in_prod`