### PR TITLE
Torb refactor

### DIFF
--- a/dcicutils/_version.py
+++ b/dcicutils/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.6.4"
+__version__ = "0.7.0"

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -471,7 +471,7 @@ def is_travis_started(request_url):
     if resp.ok:
         logger.info("Travis request response (okay): %s" % resp.json())
         details = resp.json()
-        if len(resp.json().get('builds', []) == 1):
+        if len(resp.json().get('builds', [])) == 1:
             is_ready = True
     return is_ready, details
 

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -899,6 +899,7 @@ def clone_bs_env(old, new, load_prod, db_endpoint, es_url):
                            '--envvars', env,
                            '--exact', '--nohang'])
 
+
 def delete_bs_env(env_name):
     """
     Use the eb command line client to remove an ElasticBeanstalk environment

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -55,7 +55,7 @@ def delete_db(db_identifier, take_snapshot=True, allow_delete_prod=False):
                 SkipFinalSnapshot=False,
                 FinalDBSnapshotIdentifier=db_identifier + "-final-" + timestamp
             )
-        except:
+        except:  # noqa: E722
             # Snapshot cannot be made. Likely a date conflict
             resp = client.delete_db_instance(
                 DBInstanceIdentifier=db_identifier,
@@ -1006,7 +1006,6 @@ def copy_s3_buckets(new, old):
         try:
             s3.create_bucket(Bucket=bucket)
         except:  # noqa: E722
-
             print("bucket already created....")
 
     # now copy them

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -5,7 +5,6 @@ This includes, but is not limited to: ES, s3, RDS, Auth0, and Foursight.
 from __future__ import print_function
 import subprocess
 import logging
-import argparse
 import boto3
 import os
 import json
@@ -294,7 +293,7 @@ def is_snapshot_ready(snapshot_name):
     client = boto3.client('rds', region_name=REGION)
     resp = client.describe_db_snapshots(DBSnapshotIdentifier=snapshot_name)
     db_status = resp['DBSnapshots'][0]['Status']
-    is_ready = status.lower() == 'available'
+    is_ready = db_status.lower() == 'available'
     return is_ready, resp['DBSnapshots'][0]['DBSnapshotIdentifier']
 
 
@@ -880,6 +879,7 @@ def clone_bs_env(old, new, load_prod, db_endpoint, es_url):
     subprocess.check_call(['./eb', 'clone', old, '-n', new,
                            '--envvars', env,
                            '--exact', '--nohang'])
+
 
 def create_s3_buckets(new):
     """

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -1,5 +1,4 @@
-'''
-Utilities related to ElasticBeanstalk deployment and management.
+'''Utilities related to ElasticBeanstalk deployment and management.
 This includes, but is not limited to: ES, s3, RDS, Auth0, and Foursight.
 '''
 from __future__ import print_function
@@ -132,14 +131,14 @@ def is_indexing_finished(env, prev_version=None, travis_build_id=None):
                 else:
                     raise WaitingForBoto3("EB version has not updated from %s. "
                                           "Encountered error when getting build"
-                                          " %s from Travis. Error: %s" %s "
+                                          " %s from Travis. Error: %s"
                                           % (prev_version, travis_build_id, exc))
             else:
                 # Travis build is running/has passed
                 if trav_done is True:
                     logger.info("EB version has not updated from %s."
                                 "Associated travis build %s has finished."
-                                % (prev_version, travis_build_id)))
+                                % (prev_version, travis_build_id))
                 else:
                     raise WaitingForBoto3("EB version has not updated from %s."
                                           "Associated travis build is %s and "

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -11,7 +11,8 @@ import logging
 ###########################
 # Config
 ###########################
-LOG = logging.getLogger(__name__)
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 class s3Utils(object):
@@ -83,7 +84,7 @@ class s3Utils(object):
 
     def read_s3(self, filename):
         response = self.s3.get_object(Bucket=self.outfile_bucket, Key=filename)
-        LOG.info(str(response))
+        logger.info(str(response))
         return response['Body'].read()
 
     def does_key_exist(self, key, bucket=None, print_error=True):


### PR DESCRIPTION
Lots and lots of changes to `dcicutils.beanstalk_utils`, which hadn't been refactored in a long time. For the most part, it's best to just look at the diff. But here are some significant/new functions:
- Remove a handful of functions that were not being used anywhere/were redundant
- Added `is_travis_started`, which is used with torb `waitfor`
- Removed `__main__` usage and replaced `clone_beanstalk_command_line`
- Added `delete_beanstalk_command_line `, which hasn't yet be run. The original code was in Torb