### PR TITLE
Gzip for jh

### DIFF
--- a/dcicutils/_version.py
+++ b/dcicutils/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -259,14 +259,14 @@ def open_4dn_file(obj_id, format=None, local=True):
             ff_file = gzip.open(file_info['full_path'])
         else:
             ff_file = open(file_info['full_path'])
-        # see if the file is binary (needs to opened with 'rb' mode)
-        # try to read a line from the file; if it is read, reset with seek()
-        try:
-            ff_file.readline()
-        except UnicodeDecodeError:
-            ff_file = open(file_info['full_path'], 'rb')
-        else:
-            ff_file.seek(0)
+            # see if the file is binary (needs to opened with 'rb' mode)
+            # try to read a line from the file; if it is read, reset with seek()
+            try:
+                ff_file.readline()
+            except UnicodeDecodeError:
+                ff_file = open(file_info['full_path'], 'rb')
+            else:
+                ff_file.seek(0)
     f = gzip.open(ff_file) if gz else ff_file
     try:
         yield f

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -1,4 +1,5 @@
 import functools
+import gzip
 import types
 import os
 import sys
@@ -247,23 +248,32 @@ def open_4dn_file(obj_id, format=None, local=True):
     """
     file_info = find_valid_file_or_extra_file(obj_id, format)
     # this will be the base case in the future...
+    gz = False
     if not local:
         # this seems to handle both binary and non-binary files
         ff_file = use_urllib.urlopen(file_info['full_href'])
+        if file_info.get('full_href', '').endswith('.gz'):
+            gz = True
     else:
-        ff_file = open(file_info['full_path'])
+        if file_info.get('full_path', '').endswith('.gz'):
+            ff_file = gzip.open(file_info['full_path'])
+        else:
+            ff_file = open(file_info['full_path'])
         # see if the file is binary (needs to opened with 'rb' mode)
         # try to read a line from the file; if it is read, reset with seek()
         try:
             ff_file.readline()
-        except UnicodeDecodeError:
+        except UnicodeDecodeError as e:
             ff_file = open(file_info['full_path'], 'rb')
         else:
             ff_file.seek(0)
+    f = gzip.open(ff_file) if gz else ff_file
     try:
-        yield ff_file
+        yield f
     finally:
-        ff_file.close()
+        if gz:
+            ff_file.close()
+        f.close()
 
 
 # LASTLY, do setup that requires the above functions to be defined

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -263,7 +263,7 @@ def open_4dn_file(obj_id, format=None, local=True):
         # try to read a line from the file; if it is read, reset with seek()
         try:
             ff_file.readline()
-        except UnicodeDecodeError as e:
+        except UnicodeDecodeError:
             ff_file = open(file_info['full_path'], 'rb')
         else:
             ff_file.seek(0)

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -267,7 +267,7 @@ def open_4dn_file(obj_id, format=None, local=True):
                 ff_file = open(file_info['full_path'], 'rb')
             else:
                 ff_file.seek(0)
-    f = gzip.open(ff_file) if gz else ff_file
+    f = gzip.open(ff_file, 'rt') if gz else ff_file
     try:
         yield f
     finally:


### PR DESCRIPTION
changes to jh_utils.open_4dn_file
- if file ends in .gz, will open with gzip.open
- works with local=True or local=False
- if file is gzipped but doesn't end in .gz, gzip.open won't be used, but nested context managers will still work in the notebook.