### PR TITLE
search_metadata now can use full url

### DIFF
--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -371,10 +371,10 @@ def search_metadata(search, key=None, ff_env=None, page_limit=50, is_generator=F
     if search.startswith('/'):
         search = search[1:]
     parsed_search = urlparse(search)
-    if ((parsed_search.scheme == '') and (parsed_search.netloc == '')): # both will be empty for non-urls
+    if ((parsed_search.scheme == '') and (parsed_search.netloc == '')):  # both will be empty for non-urls
         search_url = '/'.join([auth['server'], search])
     else:
-        search_url = search # assume full url is correct?
+        search_url = search  # assume full url is correct
     search_generator = get_search_generator(search_url, auth=auth, page_limit=page_limit)
     if is_generator:
         # yields individual items from search result

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -366,10 +366,15 @@ def search_metadata(search, key=None, ff_env=None, page_limit=50, is_generator=F
     Either takes a dictionary form authentication (MUST include 'server')
     or a string fourfront-environment.
     """
+    from urllib.parse import urlparse
     auth = get_authentication_with_server(key, ff_env)
     if search.startswith('/'):
         search = search[1:]
-    search_url = '/'.join([auth['server'], search])
+    parsed_search = urlparse(search)
+    if ((parsed_search.scheme == '') and (parsed_search.netloc == '')): # both will be empty for non-urls
+        search_url = '/'.join([auth['server'], search])
+    else:
+        search_url = search # assume full url is correct?
     search_generator = get_search_generator(search_url, auth=auth, page_limit=page_limit)
     if is_generator:
         # yields individual items from search result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 pytest
 pytest-cov
 pytest-mock
+flaky
 
 # Build tasks
 invoke

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -124,6 +124,7 @@ def test_url_params_functions():
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_unified_authentication(integrated_ff):
     key1 = ff_utils.unified_authentication(integrated_ff['ff_key'], integrated_ff['ff_env'])
     assert len(key1) == 2
@@ -139,6 +140,7 @@ def test_unified_authentication(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_authentication_with_server(integrated_ff):
     import copy
     key1 = ff_utils.get_authentication_with_server(integrated_ff['ff_key'], None)
@@ -155,6 +157,7 @@ def test_get_authentication_with_server(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_stuff_in_queues(integrated_ff):
     """
     Gotta index a bunch of stuff to make this work
@@ -169,6 +172,7 @@ def test_stuff_in_queues(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_authorized_request_integrated(integrated_ff):
     """
     Cover search case explicitly since it uses a different retry fxn by default
@@ -203,6 +207,7 @@ def test_authorized_request_integrated(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_metadata(integrated_ff, basestring):
     # use this test biosource
     test_item = '331111bc-8535-4448-903e-854af460b254'
@@ -240,6 +245,7 @@ def test_get_metadata(integrated_ff, basestring):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_patch_metadata(integrated_ff):
     test_item = '331111bc-8535-4448-903e-854af460a254'
     original_res = ff_utils.get_metadata(test_item, key=integrated_ff['ff_key'])
@@ -256,6 +262,7 @@ def test_patch_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_post_delete_purge_links_metadata(integrated_ff):
     """
     Combine all of these tests because they logically fit
@@ -320,6 +327,7 @@ def test_post_delete_purge_links_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_upsert_metadata(integrated_ff):
     test_data = {'biosource_type': 'immortalized cell line',
                  'award': '1U01CA200059-01', 'lab': '4dn-dcic-lab'}
@@ -338,6 +346,7 @@ def test_upsert_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 @pytest.mark.parametrize('url', ['', 'to_become_full_url'])
 def test_search_metadata(integrated_ff, url):
     from types import GeneratorType
@@ -372,6 +381,7 @@ def test_search_metadata(integrated_ff, url):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_search_generator(integrated_ff):
     search_url = integrated_ff['ff_key']['server'] + '/search/?type=FileFastq'
     generator1 = ff_utils.get_search_generator(search_url, auth=integrated_ff['ff_key'], page_limit=25)
@@ -401,6 +411,7 @@ def test_get_search_generator(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_es_metadata(integrated_ff):
     from dcicutils import es_utils
     from types import GeneratorType
@@ -510,6 +521,7 @@ def test_get_es_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_es_search_generator(integrated_ff):
     from dcicutils import es_utils
     # get es_client info from the health page
@@ -535,6 +547,7 @@ def test_get_es_search_generator(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_health_page(integrated_ff):
     health_res = ff_utils.get_health_page(key=integrated_ff['ff_key'])
     assert health_res and 'error' not in health_res
@@ -551,6 +564,7 @@ def test_get_health_page(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_get_schema_names(integrated_ff):
     schema_names = ff_utils.get_schema_names(key=integrated_ff['ff_key'],
                                              ff_env=integrated_ff['ff_env'])
@@ -561,6 +575,7 @@ def test_get_schema_names(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_expand_es_metadata(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
@@ -576,6 +591,7 @@ def test_expand_es_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_expand_es_metadata_frame_object_embedded(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
@@ -594,6 +610,7 @@ def test_expand_es_metadata_frame_object_embedded(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_expand_es_metadata_add_wfrs(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
@@ -604,6 +621,7 @@ def test_expand_es_metadata_add_wfrs(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_expand_es_metadata_complain_wrong_frame(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']
     key = integrated_ff['ff_key']
@@ -613,6 +631,7 @@ def test_expand_es_metadata_complain_wrong_frame(integrated_ff):
 
 
 @pytest.mark.integrated
+@pytest.mark.flaky
 def test_expand_es_metadata_ignore_fields(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
@@ -626,6 +645,7 @@ def test_expand_es_metadata_ignore_fields(integrated_ff):
 
 
 @pytest.mark.file_operation
+@pytest.mark.flaky
 def test_dump_results_to_json(integrated_ff):
     import shutil
     import os

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -4,8 +4,6 @@ import time
 from dcicutils import ff_utils
 pytestmark = pytest.mark.working
 
-MASTERTEST_URL = 'http://fourfront-mastertest.9wzadzju3p.us-east-1.elasticbeanstalk.com/'
-
 
 @pytest.fixture
 def eset_json():
@@ -340,9 +338,11 @@ def test_upsert_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
-@pytest.mark.parametrize('url', ['', MASTERTEST_URL])
+@pytest.mark.parametrize('url', ['', 'to_become_full_url'])
 def test_search_metadata(integrated_ff, url):
     from types import GeneratorType
+    if (url != ''):  # replace stub with actual url from integrated_ff
+        url = integrated_ff['ff_key']['server'] + '/'
     search_res = ff_utils.search_metadata(url + 'search/?limit=all&type=File', key=integrated_ff['ff_key'])
     assert isinstance(search_res, list)
     # this will fail if items have not yet been indexed

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -6,6 +6,7 @@ pytestmark = pytest.mark.working
 
 MASTERTEST_URL = 'http://fourfront-mastertest.9wzadzju3p.us-east-1.elasticbeanstalk.com/'
 
+
 @pytest.fixture
 def eset_json():
     return {

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -294,7 +294,8 @@ def test_post_delete_purge_links_metadata(integrated_ff):
     # test get_metadata_links function (this will ensure everything is indexed, as well)
     links = []
     while not links or ff_utils.stuff_in_queues(integrated_ff['ff_env'], True):
-        time.sleep(2)
+        print("Waiting on Indexing")  # So Travis does not timeout
+        time.sleep(15)
         post_links = ff_utils.get_metadata_links(post_item['uuid'], key=integrated_ff['ff_key'])
         links = post_links.get('uuids_linking_to', [])
     assert len(links) == 1
@@ -312,7 +313,8 @@ def test_post_delete_purge_links_metadata(integrated_ff):
 
     # wait for indexing to catch up
     while len(links) > 0 or ff_utils.stuff_in_queues(integrated_ff['ff_env'], True):
-        time.sleep(2)
+        print("Waiting on Indexing")  # So Travis does not timeout
+        time.sleep(15)
         post_links = ff_utils.get_metadata_links(post_item['uuid'], key=integrated_ff['ff_key'])
         links = post_links.get('uuids_linking_to', [])
     assert len(links) == 0


### PR DESCRIPTION
This small PR adds full url functionality to the search_metadata function in ff_utils.py. Now one is able to pass either a search path like: 
_search/?limit=all&type=File_
or a full url path like: 
_http://fourfront-mastertest.9wzadzju3p.us-east-1.elasticbeanstalk.com/search/?limit=all&type=File_

To test, test_search_metadata is now parameterized on the empty string and the mastertest url, so the test will now verify both the original and full url paths function correctly.