### PR TITLE
Namespace fix

### DIFF
--- a/dcicutils/_version.py
+++ b/dcicutils/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -5,6 +5,7 @@ from dcicutils import ff_utils
 pytestmark = pytest.mark.working
 INDEX_NAMESPACE = 'fourfront-mastertest'
 
+
 @pytest.fixture
 def eset_json():
     return {

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -3,7 +3,6 @@ import json
 import time
 from dcicutils import ff_utils
 pytestmark = pytest.mark.working
-INDEX_NAMESPACE = 'fourfront-mastertest'
 
 
 @pytest.fixture
@@ -537,11 +536,12 @@ def test_get_es_metadata(integrated_ff):
 def test_get_es_search_generator(integrated_ff):
     from dcicutils import es_utils
     # get es_client info from the health page
-    es_url = ff_utils.get_health_page(key=integrated_ff['ff_key'])['elasticsearch']
+    health = ff_utils.get_health_page(key=integrated_ff['ff_key'])
+    es_url = health['elasticsearch']
     es_client = es_utils.create_es_client(es_url, use_aws_auth=True)
     es_query = {'query': {'match_all': {}}, 'sort': [{'_uid': {'order': 'desc'}}]}
     # search for all fastqs with a low pagination size
-    index = INDEX_NAMESPACE + 'file_fastq'
+    index = health['namespace'] + 'file_fastq'
     es_gen = ff_utils.get_es_search_generator(es_client, index,
                                               es_query, page_size=7)
     list_gen = list(es_gen)

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -3,7 +3,7 @@ import json
 import time
 from dcicutils import ff_utils
 pytestmark = pytest.mark.working
-
+INDEX_NAMESPACE = 'fourfront-mastertest'
 
 @pytest.fixture
 def eset_json():
@@ -540,7 +540,8 @@ def test_get_es_search_generator(integrated_ff):
     es_client = es_utils.create_es_client(es_url, use_aws_auth=True)
     es_query = {'query': {'match_all': {}}, 'sort': [{'_uid': {'order': 'desc'}}]}
     # search for all fastqs with a low pagination size
-    es_gen = ff_utils.get_es_search_generator(es_client, 'file_fastq',
+    index = INDEX_NAMESPACE + 'file_fastq'
+    es_gen = ff_utils.get_es_search_generator(es_client, index,
                                               es_query, page_size=7)
     list_gen = list(es_gen)
     assert len(list_gen) > 0

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -92,7 +92,7 @@ def test_set_logging_in_prod(caplog, integrated_ff):
 def test_logging_retry(caplog, integrated_ff):
     # get es_client info from the health page
     es_url = ff_utils.get_health_page(key=integrated_ff['ff_key'])['elasticsearch']
-    log_utils.set_logging(es_server=es_url, in_prod=True)
+    log_utils.set_logging(env='fourfront-mastertest', es_server=es_url, in_prod=True)
     log = structlog.getLogger(__name__)
     log.warning('test_retry', _test_log_utils=True)
     assert len(caplog.records) == 1

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -6,11 +6,6 @@ import logging
 pytestmark = pytest.mark.working
 
 
-def test_es_log_idx():
-    es_log_idx = log_utils.calculate_log_index()
-    assert 'logs-' in es_log_idx
-
-
 def test_set_logging_not_prod(caplog):
     # setting in_prod to False will invalidate es_server setting
     log_utils.set_logging(es_server='not_a_real_server', in_prod=False)
@@ -52,8 +47,9 @@ def test_set_logging_level(caplog, integrated_ff):
 @pytest.mark.integrated
 def test_set_logging_in_prod(caplog, integrated_ff):
     # get es_client info from the health page
-    es_url = ff_utils.get_health_page(key=integrated_ff['ff_key'])['elasticsearch']
-    log_utils.set_logging(es_server=es_url, in_prod=True)
+    health = ff_utils.get_health_page(key=integrated_ff['ff_key'])
+    es_url = health['elasticsearch']
+    log_utils.set_logging(env='fourfront-mastertest',es_server=es_url, in_prod=True)
     log = structlog.getLogger(__name__)
     log.warning('meh', foo='bar')
     assert len(caplog.records) == 1

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -49,7 +49,7 @@ def test_set_logging_in_prod(caplog, integrated_ff):
     # get es_client info from the health page
     health = ff_utils.get_health_page(key=integrated_ff['ff_key'])
     es_url = health['elasticsearch']
-    log_utils.set_logging(env='fourfront-mastertest',es_server=es_url, in_prod=True)
+    log_utils.set_logging(env='fourfront-mastertest', es_server=es_url, in_prod=True)
     log = structlog.getLogger(__name__)
     log.warning('meh', foo='bar')
     assert len(caplog.records) == 1


### PR DESCRIPTION
- Makes dcic_utils namespace aware in some scenarios where it needs to be
- `_get_es_metadata` will now fetch index namespace from the associated health page
- Test that utilizes mastertest ES now utilizes the correct namespace