### PR TITLE
Annual Meeting Features

### DIFF
--- a/dcicutils/_version.py
+++ b/dcicutils/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -404,7 +404,19 @@ def get_item_facets(item_type, key=None, ff_env=None):
     return facets
 
 
-def search_facets(**kwargs):
+def get_item_facet_values(item_type, key=None, ff_env=None):
+    """ Gets all facets and returns all possible values for each one """
+    resp = get_metadata('/search/?type=' + item_type, key=key, ff_env=ff_env)['facets']
+    facets = {}
+    for facet in resp:
+        name = facet['title']
+        facets[name] = {}
+        for term in facet['terms']:
+            facets[name][term['key']] = term['doc_count']
+    return facets
+
+
+def faceted_search(**kwargs):
     """
     Wrapper method for `search_metadata` that provides an easier way to search
     items based on facets
@@ -425,10 +437,8 @@ def search_facets(**kwargs):
                    'ff_env': ff_env,
                    'base_url': base_url,
                    'item_type': 'ExperimentSetReplicate' }
-        results = search_facets(base_url, kwargs=kwargs)
+        results = search_facets(**kwargs)
     """
-    kwargs = kwargs['kwargs']
-    base_url = kwargs['base_url']  # only required field
     key = kwargs.get('key', None)
     ff_env = kwargs.get('ff_env', None)
     item_facets = kwargs.get('item_facets', None)
@@ -441,7 +451,7 @@ def search_facets(**kwargs):
             if facet in item_facets:
                 for value in values.split('|'):
                     search = search + '&' + item_facets[facet] + '=' + '+'.join(value.split())
-    return search_metadata(base_url + search, ff_env=ff_env, key=None)
+    return search_metadata(search, ff_env=ff_env, key=None)
 
 
 def get_associated_qc_metrics(uuid, key=None, ff_env=None):

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -395,39 +395,56 @@ def search_experiment_sets(base_url, ff_env=None, key=None, project=None, lab=No
                            status=None, warnings=None):
     """
     Wrapper method for `search_metadata` that provides an easier way to search
-    experiment sets based on facets
+    experiment sets based on facets.
+    Search terms are pipe (|) seperated
     """
     search = '?type=ExperimentSetReplicate'
     if project:
-        search = search + '&award.project=' + project
+        for p in project.split('|'):
+            search = search + '&award.project=' + p
     if lab:
-        search = search + '&lab.display_title=' + '+'.join(lab.split())
+        for l in lab.split('|'):
+            search = search + '&lab.display_title=' + '+'.join(l.split())
     if experiment_category:
-        search = search + '&experiments_in_set.experiment_type.experiment_category=' + '+'.join(experiment_category.split())
+        for c in experiment_category.split('|'):
+            search = search + '&experiments_in_set.experiment_type.experiment_category=' + '+'.join(c.split())
     if experiment_type:
-        search = search + '&experiments_in_set.experiment_type.display_title=' + '+'.join(experiment_type.split())
+        for t in experiment_type.split('|'):
+            search = search + '&experiments_in_set.experiment_type.display_title=' + '+'.join(t.split())
     if dataset:
-        search = search + '&dataset_label=' + '+'.join(dataset.split())
+        for d in dataset.split('|'):
+            search = search + '&dataset_label=' + '+'.join(d.split())
     if sample_type:
-        search = search + '&experiments_in_set.biosample.biosample_type=' + '+'.join(sample_type.split())
+        for s in sample_type.split('|'):
+            search = search + '&experiments_in_set.biosample.biosample_type=' + '+'.join(s.split())
     if sample_category:
-        search = search + '&experiments_in_set.biosample.biosample_category=' + '+'.join(sample_category.split())
+        for s in sample_category.split('|'):
+            search = search + '&experiments_in_set.biosample.biosample_category=' + '+'.join(s.split())
     if sample:
-        search = search + '&experiments_in_set.biosample.biosource_summary=' + '+'.join(sample.split())
+        for s in sample.split('|'):
+            search = search + '&experiments_in_set.biosample.biosource_summary=' + '+'.join(s.split())
     if tissue_source:
-        search = search + '&aggregated_items.tissue.item.preferred_name=' + '+'.join(tissue_source.split())
+        for t in tissue_source.split('|'):
+            search = search + '&aggregated_items.tissue.item.preferred_name=' + '+'.join(t.split())
     if publication:
-        search = search + '&publications_of_set.display_title=' + '+'.join(publication.split())
+        for p in publication.split('|'):
+            search = search + '&publications_of_set.display_title=' + '+'.join(p.split())
     if modifications:
-        search = search + '&experiments_in_set.biosample.modifications.modification_type=' + '+'.join(modifications.split())
+        for m in modifications.split('|'):
+            search = search + '&experiments_in_set.biosample.modifications.modification_type=' + '+'.join(m.split())
     if treatments:
-        search = search + '&experiments_in_set.biosample.treatments.treatment_type=' + '+'.join(treatments.split())
+        for t in treatments.split('|'):
+            search = search + '&experiments_in_set.biosample.treatments.treatment_type=' + '+'.join(t.split())
     if assay_details: # ':' is difficult to handle here
-        search = search + '&experiments_in_set.experiment_categorizer.combined=' + '+'.join(assay_details.split())
+        for d in assay_details.split('|'):
+            d = d.replace(':', '%3A')
+            search = search + '&experiments_in_set.experiment_categorizer.combined=' + '+'.join(d.split())
     if status:
-        search = search + '&status=' + '+'.join(status.split())
+        for s in status.split('|'):
+            search = search + '&status=' + '+'.join(s.split())
     if warnings:
-        search = search + '&aggregated_items.badges.item.badge.warning=' + '+'.join(warnings.split())
+        for w in warnings.split('|'):
+            search = search + '&aggregated_items.badges.item.badge.warning=' + '+'.join(w.split())
     return search_metadata(base_url + search, ff_env=ff_env, key=None)
 
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -462,14 +462,16 @@ def get_associated_qc_metrics(uuid, **kwargs):
     """
     Given a uuid of an experiment set, return a list of associated qc metrics
     """
-    store, _ = expand_es_metadata([uuid], key=kwargs.get('key', None),
-                                              ff_env=kwargs.get('ff_env', None),
-                                              store_frame='embedded',
-                                              add_pc_wfr=True,
-                                              ignore_field=['experiment_relation',
-                                              'biosample_relation', 'references',
-                                              'reference_pubs'])
-    all_qc_items = [item for key in  store for item in store[key] if key.startswith('quality_metric')]
+    store, _ = expand_es_metadata([uuid],
+                                  key=kwargs.get('key', None),
+                                  ff_env=kwargs.get('ff_env', None),
+                                  store_frame='embedded',
+                                  add_pc_wfr=True,
+                                  ignore_field=['experiment_relation',
+                                                'biosample_relation',
+                                                'references',
+                                                'reference_pubs'])
+    all_qc_items = [item for key in store for item in store[key] if key.startswith('quality_metric')]
     return all_qc_items
 
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -455,7 +455,7 @@ def faceted_search(**kwargs):
                         search = search + '&' + item_facets[facet] + '!=' + fmt_value[1:]
                     else:
                         search = search + '&' + item_facets[facet] + '=' + fmt_value
-    return search_metadata(search, ff_env=ff_env, key=None)
+    return search_metadata(search, ff_env=ff_env, key=key)
 
 
 def get_associated_qc_metrics(uuid, key=None, ff_env=None):

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -418,7 +418,7 @@ def get_item_facet_values(item_type, key=None, ff_env=None):
     return facets
 
 
-def faceted_search(**kwargs):
+def faceted_search(key=None, ff_env=None, item_type=None, **kwargs):
     """
     Wrapper method for `search_metadata` that provides an easier way to search
     items based on facets
@@ -439,10 +439,8 @@ def faceted_search(**kwargs):
                    'item_type': 'ExperimentSetReplicate' }
         results = faceted_search(**kwargs)
     """
-    key = kwargs.get('key', None)
-    ff_env = kwargs.get('ff_env', None)
     item_facets = kwargs.get('item_facets', None)
-    item_type = kwargs.get('item_type', 'ExperimentSetReplicate')
+    item_type = 'ExperimentSetReplicate' if item_type is None else item_type
     search = '/search/?type=' + item_type
     if item_facets is None:
         item_facets = get_item_facets(item_type, key=key, ff_env=ff_env)
@@ -458,7 +456,9 @@ def faceted_search(**kwargs):
     return search_metadata(search, ff_env=ff_env, key=key)
 
 
-def get_associated_qc_metrics(uuid, **kwargs):
+def get_associated_qc_metrics(uuid, key=None, ff_env=None, 
+                              exclude_raw_files=True, 
+                              exclude_supplementary_files=True):
     """
     Given a uuid of an experiment set, return a dictionary of uuid : item
     mappings of quality metric items.
@@ -470,10 +470,6 @@ def get_associated_qc_metrics(uuid, **kwargs):
                                      non-processed files. Default: True
     """
     result = {}
-    key = kwargs.get('key', None)
-    ff_env = kwargs.get('ff_env', None)
-    exclude_raw_files = kwargs.get('exclude_raw_files', True)
-    exclude_supplementary_files = kwargs.get('exclude_supplementary_files', True)
     resp = get_metadata(uuid, key=key, ff_env=ff_env)
 
     # handle all 'processed_files' by default

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -460,8 +460,8 @@ def faceted_search(**kwargs):
 
 def get_associated_qc_metrics(uuid, **kwargs):
     """
-    Given a uuid of an experiment set, return a dictionary of uuid : item 
-    mappings of quality metric items. 
+    Given a uuid of an experiment set, return a dictionary of uuid : item
+    mappings of quality metric items.
 
     Args:
         exclude_raw_files: if False will provide QC metrics on raw files as well
@@ -475,7 +475,7 @@ def get_associated_qc_metrics(uuid, **kwargs):
     exclude_raw_files = kwargs.get('exclude_raw_files', True)
     exclude_supplementary_files = kwargs.get('exclude_supplementary_files', True)
     resp = get_metadata(uuid, key=key, ff_env=ff_env)
-    
+
     # handle all 'processed_files' by default
     if 'processed_files' in resp:
         for entry in resp['processed_files']:
@@ -483,7 +483,7 @@ def get_associated_qc_metrics(uuid, **kwargs):
                 continue
             uuid = entry['quality_metric']['uuid']
             result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-    
+
     # handle 'other_processed_files' if we are doing supplementary files
     if 'other_processed_files' in resp and not exclude_supplementary_files:
         for entry in resp['processed_files']:
@@ -491,19 +491,19 @@ def get_associated_qc_metrics(uuid, **kwargs):
                 continue
             uuid = entry['quality_metric']['uuid']
             result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-    
+
     # check 'experiment_in_set' as these can contain things too
     if 'experiments_in_set' in resp:
         for exp in resp['experiments_in_set']:
-            
+
             # handle all 'processed_files' by default
             if 'processed_files' in exp:
                 for entry in exp['processed_files']:
-                   if 'quality_metric' not in entry:
-                       continue
-                   uuid = entry['quality_metric']['uuid']
-                   result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-            
+                    if 'quality_metric' not in entry:
+                        continue
+                    uuid = entry['quality_metric']['uuid']
+                    result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
+
             # handle 'other_processed_files' if we're doing supplementary files
             if 'other_processed_files' in exp and not exclude_supplementary_files:
                 for entry in exp['processed_files']:
@@ -511,15 +511,16 @@ def get_associated_qc_metrics(uuid, **kwargs):
                         continue
                     uuid = entry['quality_metric']['uuid']
                     result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-            
+
             # handle 'files' only if we are doing raw files
             if 'files' in exp and not exclude_raw_files:
-                for entry in exp['files']: 
+                for entry in exp['files']:
                     if 'quality_metric' not in entry:
                         continue
                     uuid = entry['quality_metric']['uuid']
                     result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
     return result
+
 
 def get_metadata_links(obj_id, key=None, ff_env=None):
     """

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -389,7 +389,7 @@ def search_metadata(search, key=None, ff_env=None, page_limit=50, is_generator=F
 
 def get_item_facets(item_type, key=None, ff_env=None):
     """
-    Gets facet information for the given item type from the given env
+    Gets facet query string information ie: mapping from facet to query string
     """
     resp = get_metadata('/profiles/' + item_type + '.json', key=key, ff_env=ff_env)
     facets = {}
@@ -405,7 +405,9 @@ def get_item_facets(item_type, key=None, ff_env=None):
 
 
 def get_item_facet_values(item_type, key=None, ff_env=None):
-    """ Gets all facets and returns all possible values for each one """
+    """
+    Gets all facets and returns all possible values for each one with counts
+    """
     resp = get_metadata('/search/?type=' + item_type, key=key, ff_env=ff_env)['facets']
     facets = {}
     for facet in resp:
@@ -450,7 +452,11 @@ def faceted_search(**kwargs):
         if facet != 'item_type':
             if facet in item_facets:
                 for value in values.split('|'):
-                    search = search + '&' + item_facets[facet] + '=' + '+'.join(value.split())
+                    fmt_value = '+'.join(value.split())
+                    if fmt_value[0] == '-':  # handle negative
+                        search = search + '&' + item_facets[facet] + '!=' + fmt_value[1:]
+                    else:
+                        search = search + '&' + item_facets[facet] + '=' + fmt_value
     return search_metadata(search, ff_env=ff_env, key=None)
 
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -456,8 +456,8 @@ def faceted_search(key=None, ff_env=None, item_type=None, **kwargs):
     return search_metadata(search, ff_env=ff_env, key=key)
 
 
-def get_associated_qc_metrics(uuid, key=None, ff_env=None, 
-                              exclude_raw_files=True, 
+def get_associated_qc_metrics(uuid, key=None, ff_env=None,
+                              exclude_raw_files=True,
                               exclude_supplementary_files=True):
     """
     Given a uuid of an experiment set, return a dictionary of uuid : item

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -458,15 +458,14 @@ def faceted_search(**kwargs):
     return search_metadata(search, ff_env=ff_env, key=key)
 
 
-def get_associated_qc_metrics(uuid, key=None, ff_env=None, **kwargs):
+def get_associated_qc_metrics(uuid, **kwargs):
     """
     Given a uuid of an experiment set, return a dictionary of uuid : item mappings
     with all data associated with all the QC metrics
     """
-    # get experiment set info from uuid
     result = {}
-    key = kwargs.get('key', None) if key is None else key
-    ff_env = kwargs.get('ff_env', None) if ff_env is None else ff_env
+    key = kwargs.get('key', None)
+    ff_env = kwargs.get('ff_env', None)
     resp = get_metadata(uuid, key=key, ff_env=ff_env)
     if 'processed_files' in resp:
         for entry in resp['processed_files']:

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -426,7 +426,6 @@ def faceted_search(**kwargs):
     kwargs should contain the following 5 things:
         - key (if not using built in aws auth)
         - ff_env (if not using build in aws auth)
-        - base_url (REQUIRED) ex: data.4dnucleome.org/
         - item_type (if not searching for experiment sets)
         - item_facets (if you don't want to resolve these in this function)
         + any facets (| seperated values) you'd like to search on (see example below)
@@ -437,7 +436,6 @@ def faceted_search(**kwargs):
                    'Experiment Type': 'Dilution Hi-C',
                    'key': key,
                    'ff_env': ff_env,
-                   'base_url': base_url,
                    'item_type': 'ExperimentSetReplicate' }
         results = search_facets(**kwargs)
     """

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -387,6 +387,50 @@ def search_metadata(search, key=None, ff_env=None, page_limit=50, is_generator=F
         return search_res
 
 
+def search_experiment_sets(base_url, ff_env=None, key=None, project=None, lab=None,
+                           experiment_category=None, experiment_type=None,
+                           dataset=None, sample_type=None, sample_category=None,
+                           sample=None, tissue_source=None, publication=None,
+                           modifications=None, treatments=None, assay_details=None,
+                           status=None, warnings=None):
+    """
+    Wrapper method for `search_metadata` that provides an easier way to search
+    experiment sets based on facets
+    """
+    search = '?type=ExperimentSetReplicate'
+    if project:
+        search = search + '&award.project=' + project
+    if lab:
+        search = search + '&lab.display_title=' + '+'.join(lab.split())
+    if experiment_category:
+        search = search + '&experiments_in_set.experiment_type.experiment_category=' + '+'.join(experiment_category.split())
+    if experiment_type:
+        search = search + '&experiments_in_set.experiment_type.display_title=' + '+'.join(experiment_type.split())
+    if dataset:
+        search = search + '&dataset_label=' + '+'.join(dataset.split())
+    if sample_type:
+        search = search + '&experiments_in_set.biosample.biosample_type=' + '+'.join(sample_type.split())
+    if sample_category:
+        search = search + '&experiments_in_set.biosample.biosample_category=' + '+'.join(sample_category.split())
+    if sample:
+        search = search + '&experiments_in_set.biosample.biosource_summary=' + '+'.join(sample.split())
+    if tissue_source:
+        search = search + '&aggregated_items.tissue.item.preferred_name=' + '+'.join(tissue_source.split())
+    if publication:
+        search = search + '&publications_of_set.display_title=' + '+'.join(publication.split())
+    if modifications:
+        search = search + '&experiments_in_set.biosample.modifications.modification_type=' + '+'.join(modifications.split())
+    if treatments:
+        search = search + '&experiments_in_set.biosample.treatments.treatment_type=' + '+'.join(treatments.split())
+    if assay_details: # ':' is difficult to handle here
+        search = search + '&experiments_in_set.experiment_categorizer.combined=' + '+'.join(assay_details.split())
+    if status:
+        search = search + '&status=' + '+'.join(status.split())
+    if warnings:
+        search = search + '&aggregated_items.badges.item.badge.warning=' + '+'.join(warnings.split())
+    return search_metadata(base_url + search, ff_env=ff_env, key=None)
+
+
 def get_metadata_links(obj_id, key=None, ff_env=None):
     """
     Given standard key/ff_env authentication, return result for @@links view

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -448,6 +448,37 @@ def search_experiment_sets(base_url, ff_env=None, key=None, project=None, lab=No
     return search_metadata(base_url + search, ff_env=ff_env, key=None)
 
 
+def get_associated_qc_metrics(uuid, key=None, ff_env=None):
+    """
+    Given a uuid of an experiment set, return a dictionary of uuid : item mappings
+    with all data associated with all the QC metrics
+    """
+    # get experiment set info from uuid
+    result = {}
+    resp = get_metadata(uuid, key=key, ff_env=ff_env)
+    if 'processed_files' in resp:
+        for entry in resp['processed_files']:
+            if 'quality_metric' not in entry:
+                continue
+            uuid = entry['quality_metric']['uuid']
+            result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
+    if 'experiments_in_set' in resp:
+        for exp in resp['experiments_in_set']:
+            if 'files' in exp:
+                for entry in exp['files']:
+                    if 'quality_metric' not in entry:
+                        continue
+                    uuid = entry['quality_metric']['uuid']
+                    result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
+            if 'processed_files' in exp:
+                for entry in exp['processed_files']:
+                    if 'quality_metric' not in entry:
+                        continue
+                    uuid = entry['quality_metric']['uuid']
+                    result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
+    return result
+
+
 def get_metadata_links(obj_id, key=None, ff_env=None):
     """
     Given standard key/ff_env authentication, return result for @@links view

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -393,20 +393,20 @@ def get_item_facets(item_type, key=None, ff_env=None):
     """
     resp = get_metadata('/profiles/' + item_type + '.json', key=key, ff_env=ff_env)
     facets = {}
-
-    # get direct facets
     for query_url, info in resp.get('facets', {}).items():
         facets[info['title']] = query_url
 
     # status is hardcoded in search.py, so the same must be done here
     facets['Status'] = 'status'
-
     return facets
 
 
 def get_item_facet_values(item_type, key=None, ff_env=None):
     """
     Gets all facets and returns all possible values for each one with counts
+    ie: dictionary of facets mapping to a dictionary containing all possible values
+    for that facet mapping to the count for that value
+    format: {'Project': {'4DN': 2, 'Other': 6}, 'Lab': {...}}
     """
     resp = get_metadata('/search/?type=' + item_type, key=key, ff_env=ff_env)['facets']
     facets = {}
@@ -437,7 +437,7 @@ def faceted_search(**kwargs):
                    'key': key,
                    'ff_env': ff_env,
                    'item_type': 'ExperimentSetReplicate' }
-        results = search_facets(**kwargs)
+        results = faceted_search(**kwargs)
     """
     key = kwargs.get('key', None)
     ff_env = kwargs.get('ff_env', None)

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -428,7 +428,7 @@ def search_facets(**kwargs):
         results = search_facets(base_url, kwargs=kwargs)
     """
     kwargs = kwargs['kwargs']
-    base_url = kwargs['base_url'] # only required field
+    base_url = kwargs['base_url']  # only required field
     key = kwargs.get('key', None)
     ff_env = kwargs.get('ff_env', None)
     item_facets = kwargs.get('item_facets', None)

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -395,8 +395,9 @@ def search_experiment_sets(base_url, ff_env=None, key=None, project=None, lab=No
                            status=None, warnings=None):
     """
     Wrapper method for `search_metadata` that provides an easier way to search
-    experiment sets based on facets.
-    Search terms are pipe (|) seperated
+    experiment sets based on facets
+    All arguments are optional and can contain pipe | separated values where all
+    provided will be searched for. Negative searches are not possible at this time.
     """
     search = '?type=ExperimentSetReplicate'
     if project:
@@ -435,9 +436,9 @@ def search_experiment_sets(base_url, ff_env=None, key=None, project=None, lab=No
     if treatments:
         for t in treatments.split('|'):
             search = search + '&experiments_in_set.biosample.treatments.treatment_type=' + '+'.join(t.split())
-    if assay_details: # ':' is difficult to handle here
+    if assay_details:
         for d in assay_details.split('|'):
-            d = d.replace(':', '%3A')
+            d = d.replace(':', '%3A')  # encode ':' into hex
             search = search + '&experiments_in_set.experiment_categorizer.combined=' + '+'.join(d.split())
     if status:
         for s in status.split('|'):

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -460,34 +460,17 @@ def faceted_search(**kwargs):
 
 def get_associated_qc_metrics(uuid, **kwargs):
     """
-    Given a uuid of an experiment set, return a dictionary of uuid : item mappings
-    with all data associated with all the QC metrics
+    Given a uuid of an experiment set, return a list of associated qc metrics
     """
-    result = {}
-    key = kwargs.get('key', None)
-    ff_env = kwargs.get('ff_env', None)
-    resp = get_metadata(uuid, key=key, ff_env=ff_env)
-    if 'processed_files' in resp:
-        for entry in resp['processed_files']:
-            if 'quality_metric' not in entry:
-                continue
-            uuid = entry['quality_metric']['uuid']
-            result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-    if 'experiments_in_set' in resp:
-        for exp in resp['experiments_in_set']:
-            if 'files' in exp:
-                for entry in exp['files']:
-                    if 'quality_metric' not in entry:
-                        continue
-                    uuid = entry['quality_metric']['uuid']
-                    result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-            if 'processed_files' in exp:
-                for entry in exp['processed_files']:
-                    if 'quality_metric' not in entry:
-                        continue
-                    uuid = entry['quality_metric']['uuid']
-                    result[uuid] = get_metadata(uuid, key=key, ff_env=ff_env)
-    return result
+    store, _ = expand_es_metadata([uuid], key=kwargs.get('key', None),
+                                              ff_env=kwargs.get('ff_env', None),
+                                              store_frame='embedded',
+                                              add_pc_wfr=True,
+                                              ignore_field=['experiment_relation',
+                                              'biosample_relation', 'references',
+                                              'reference_pubs'])
+    all_qc_items = [item for key in  store for item in store[key] if key.startswith('quality_metric')]
+    return all_qc_items
 
 
 def get_metadata_links(obj_id, key=None, ff_env=None):

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -458,13 +458,15 @@ def faceted_search(**kwargs):
     return search_metadata(search, ff_env=ff_env, key=key)
 
 
-def get_associated_qc_metrics(uuid, key=None, ff_env=None):
+def get_associated_qc_metrics(uuid, key=None, ff_env=None, **kwargs):
     """
     Given a uuid of an experiment set, return a dictionary of uuid : item mappings
     with all data associated with all the QC metrics
     """
     # get experiment set info from uuid
     result = {}
+    key = kwargs.get('key', None) if key is None else key
+    ff_env = kwargs.get('ff_env', None) if ff_env is None else ff_env
     resp = get_metadata(uuid, key=key, ff_env=ff_env)
     if 'processed_files' in resp:
         for entry in resp['processed_files']:

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -36,7 +36,8 @@ HANDLED_FUNCTIONS = [
     'faceted_search',
     'delete_field',
     'get_item_facets',
-    'get_item_facet_values'
+    'get_item_facet_values',
+    'get_associated_qc_metrics'
 ]
 
 

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -34,7 +34,9 @@ HANDLED_FUNCTIONS = [
     'purge_metadata',
     'get_metadata_links',
     'faceted_search',
-    'delete_field'
+    'delete_field',
+    'get_item_facets',
+    'get_item_facet_values'
 ]
 
 

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -33,6 +33,7 @@ HANDLED_FUNCTIONS = [
     'delete_metadata',
     'purge_metadata',
     'get_metadata_links',
+    'faceted_search',
     'delete_field'
 ]
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -121,7 +121,7 @@ In addition to ``search_metadata``, we also provide ``faceted_search`` which all
     'item_type' = 'user',
     'Affiliation' = '4DN Testing Lab'
   }
-  results = faceted_search(kwargs)
+  results = faceted_search(**kwargs)
 
   # you can also perform negative searches by pre-pending '-' to your desired value
   # ie: get all users not affiliated with the 4DN Testing Lab

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,12 +1,12 @@
 ========
-Examples 
+Examples
 ========
 
 See `getting started <'./getting_started.md'>`_ for help with getting up and running with dcicutils.
 
 As a first step, we will import our modules from the dcicutils package.
 
-.. code-block::
+.. code-block:: python
 
    from dcicutils import ff_utils
 
@@ -15,13 +15,13 @@ Making Your key
 
 Authentication methods differ if you are an external user or an internal 4DN team member. If you are an external user, create a Python dictionary called ``key`` using your access key. This will be used in the examples below.
 
-.. code-block::
+.. code-block:: python
 
-   key = {'key': <YOUR KEY>, 'secret' <YOUR SECRET>, 'server': 'https://data.4dnucleome.org/'}
+   key = {'key': YOUR_KEY, 'secret' YOUR_SECRET, 'server': 'https://data.4dnucleome.org/'}
 
 If you are an internal user, you may simply use the string Fourfront environment name for your metadata functions to get administrator access. For faster requests or if you want to emulate another user, you can also pass in keys manually. The examples below will use ``key``\ , but could also use ``ff_env``. It assumes you want to use the data Fourfront environment.
 
-.. code-block::
+.. code-block:: python
 
    key = ff_utils.get_authentication_with_server(ff_env='data')
 
@@ -30,7 +30,7 @@ Metadata Function Examples
 
 You can use ``get_metadata`` to get the metadata for a single object. It returns a dictionary of metadata on a successful get request. In our example, we get a publicly available HEK293 biosource, which has an internal accession of 4DNSRVF4XB1F.
 
-.. code-block::
+.. code-block:: python
 
    metadata = ff_utils.get_metadata('4DNSRVF4XB1F', key=key)
 
@@ -40,7 +40,7 @@ You can use ``get_metadata`` to get the metadata for a single object. It returns
 
 To post new data to the system, use the ``post_metadata`` function. You need to provide the body of data you want to post, as well as the schema name for the object. We want to post a fastq file.
 
-.. code-block::
+.. code-block:: python
 
    post_body = {
        'file_format': 'fastq',
@@ -57,7 +57,7 @@ To post new data to the system, use the ``post_metadata`` function. You need to 
 
 If you want to edit data, use the ``patch_metadata`` function. Let's say that the fastq file you just made has an accession of ``4DNFIP74UWGW`` and we want to add a description to it.
 
-.. code-block::
+.. code-block:: python
 
    patch_body = {'description': 'My cool fastq file'}
    # you can explicitly pass the object ID (in this case accession)...
@@ -72,7 +72,7 @@ If you want to edit data, use the ``patch_metadata`` function. Let's say that th
 
 Similar to ``post_metadata`` you can "UPSERT" metadata, which will perform a POST if the metadata doesn't yet exist within the system and will PATCH if it does. The ``upsert_metadata`` function takes the exact same arguments as ``post_metadata`` but will not raise an error on a metadata conflict.
 
-.. code-block::
+.. code-block:: python
 
    upsert_body = {
        'file_format': 'fastq',
@@ -88,7 +88,7 @@ Similar to ``post_metadata`` you can "UPSERT" metadata, which will perform a POS
 
 You can use ``search_metadata`` to easily search through metadata in Fourfront. This function takes a string search url starting with 'search', as well as the the same authorization information as the other metadata functions. It returns a list of metadata results. Optionally, the ``page_limit`` parameter can be used to internally adjust the size of the pagination used in underlying generator used to get search results.
 
-.. code-block::
+.. code-block:: python
 
    # let's search for all biosamples
    # hits is a list of metadata dictionaries
@@ -97,3 +97,42 @@ You can use ``search_metadata`` to easily search through metadata in Fourfront. 
    # you can also specify a limit on the number of results for your search
    # other valid query params are also allowed, including sorts and filters
    hits = ff_utils.search_metadata('search/?type=Biosample&limit=10', key=key)
+
+In addition to ``search_metadata``, we also provide ``faceted_search`` which allows you to more cleanly construct search queries without worrying about the query string format. This function utilizes ``search_metadata`` with default arguments and thus acts as a wrapper. Users on JupyterHub should not need to configure ``key`` or ``ff_env``. See below for example usage. See doc-strings and tests for more advanced information/usage.
+
+.. code-block:: python
+
+  # Let's work with experiment sets (the default). We should grab facet information
+  # first though. 'facet_info' keys will be the possible facets and each key contains
+  # the possible values with their counts
+  facet_info = get_item_facet_values('ExperimentSetReplicate')
+
+  # now specify kwargs - say we want to search for all experiments under the 4DN
+  # project that are of experiment type 'Dilution Hi-C'
+  kwargs = {
+    'Project': '4DN',
+    'Experiment Type': 'Dilution Hi-C'
+  }
+  results = faceted_search(**kwargs)
+
+  # you can also search other types by specifying 'item_type' in kwargs
+  # say we'd like to search for all users affiliated with the 4DN Testing Lab
+  kwargs = {
+    'item_type' = 'user',
+    'Affiliation' = '4DN Testing Lab'
+  }
+  results = faceted_search(kwargs)
+
+  # you can also perform negative searches by pre-pending '-' to your desired value
+  # ie: get all users not affiliated with the 4DN Testing Lab
+  # note that you can combine this with 'positive' searches as well
+  kwargs = {
+  'item_type' = 'user',
+  'Affiliation' = '-4DN Testing Lab'
+  }
+
+  # You can also specify multiple pipe (|) seperated values for a field
+  # ie: get all experiments sets from 4DN or External
+  kwargs = {
+    'Project': '4DN|External'
+  }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+  working: test should work
+  integrated: this is an integrated test
+  file_operation: this test utilizes files

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -604,74 +604,133 @@ def test_expand_es_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
-def test_experiment_set_search(integrated_ff):
+def test_get_item_facets(integrated_ff):
+    """ Tests that we can resolve information on facets """
+    key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
+    item_type = 'experiment_set_replicate'
+    facets = ff_utils.get_item_facets(item_type, key=key, ff_env=ff_env)
+    assert 'Lab' in facets
+    assert 'Center' in facets
+    assert 'Set Type' in facets
+    assert 'Internal Release Date' in facets
+
+
+@pytest.mark.integrated
+def test_search_facets_exp_set(integrated_ff):
     """ Tests the experiment set search features using mastertest """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
-    url = integrated_ff['ff_key']['server'] + '/search/'
-    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN', ff_env=ff_env, key=key)
+    url = integrated_ff['ff_key']['server']
+    all_facets = ff_utils.get_item_facets('experiment_set_replicate', key=key, ff_env=ff_env)
+    for_all = {'base_url': url, 'key': key, 'ff_env': ff_env, 'item_facets': all_facets}
+    project = { 'Project': '4DN' }
+    project.update(for_all)
+    resp = ff_utils.search_facets(kwargs=project)
     assert len(resp) == 8
-    resp = ff_utils.search_experiment_sets(base_url=url, lab='4DN Testing Lab', ff_env=ff_env, key=key)
+    lab = { 'Lab': '4DN Testing Lab' }
+    lab.update(for_all)
+    resp = ff_utils.search_facets(kwargs=lab)
     assert len(resp) == 12
-    resp = ff_utils.search_experiment_sets(base_url=url, experiment_category='Microscopy', ff_env=ff_env, key=key)
+    exp_cat = { 'Experiment Category' : 'Microscopy' }
+    exp_cat.update(for_all)
+    resp = ff_utils.search_facets(kwargs=exp_cat)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url, experiment_type='Dilution Hi-C', ff_env=ff_env, key=key)
+    exp_type = { 'Experiment Type': 'Dilution Hi-C' }
+    exp_type.update(for_all)
+    resp = ff_utils.search_facets(kwargs=exp_type)
     assert len(resp) == 3
-    resp = ff_utils.search_experiment_sets(base_url=url, dataset='No value', ff_env=ff_env, key=key)
+    dataset = { 'Dataset': 'No value' }
+    dataset.update(for_all)
+    resp = ff_utils.search_facets(kwargs=dataset)
     assert len(resp) == 9
-    resp = ff_utils.search_experiment_sets(base_url=url, sample_type='immortalized cells', ff_env=ff_env, key=key)
+    sample_type = { 'Sample Type': 'immortalized cells' }
+    sample_type.update(for_all)
+    resp = ff_utils.search_facets(kwargs=sample_type)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           sample_category='In vitro Differentiation',
-                                           ff_env=ff_env, key=key)
+    sample_cat = { 'Sample Category': 'In vitro Differentiation' }
+    sample_cat.update(for_all)
+    resp = ff_utils.search_facets(kwargs=sample_cat)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url, sample='GM12878', ff_env=ff_env, key=key)
+    sample = { 'Sample': 'GM12878' }
+    sample.update(for_all)
+    resp = ff_utils.search_facets(kwargs=sample)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url, tissue_source='endoderm', ff_env=ff_env, key=key)
+    tissue_src = { 'Tissue Source': 'endoderm' }
+    tissue_src.update(for_all)
+    resp = ff_utils.search_facets(kwargs=tissue_src)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url, publication='No value', ff_env=ff_env, key=key)
+    pub = { 'Publication': 'No value' }
+    pub.update(for_all)
+    resp = ff_utils.search_facets(kwargs=pub)
     assert len(resp) == 10
-    resp = ff_utils.search_experiment_sets(base_url=url, modifications='Stable Transfection', ff_env=ff_env, key=key)
+    mods = { 'Modifications': 'Stable Transfection' }
+    mods.update(for_all)
+    resp = ff_utils.search_facets(kwargs=mods)
     assert len(resp) == 7
-    resp = ff_utils.search_experiment_sets(base_url=url, treatments='RNAi', ff_env=ff_env, key=key)
+    treats = { 'Treatments': 'RNAi' }
+    treats.update(for_all)
+    resp = ff_utils.search_facets(kwargs=treats)
     assert len(resp) == 7
-    resp = ff_utils.search_experiment_sets(base_url=url, assay_details='No value', ff_env=ff_env, key=key)
+    assay_details = { 'Assay Details': 'No value' }
+    assay_details.update(for_all)
+    resp = ff_utils.search_facets(kwargs=assay_details)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url, status='released', ff_env=ff_env, key=key)
+    status = { 'Status': 'released' }
+    status.update(for_all)
+    resp = ff_utils.search_facets(base_url=url, ff_env=ff_env, key=key, kwargs=status)
     assert len(resp) == 12
-    resp = ff_utils.search_experiment_sets(base_url=url, warnings='No value', ff_env=ff_env, key=key)
+    warnings = { 'Warnings': 'No value' }
+    warnings.update(for_all)
+    resp = ff_utils.search_facets(kwargs=warnings)
     assert len(resp) == 4
-    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', ff_env=ff_env, key=key)
+    both_projects = { 'Project': '4DN|External' }
+    both_projects.update(for_all)
+    resp = ff_utils.search_facets(kwargs=both_projects)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           lab='4DN Testing Lab|Some Other Guys lab',
-                                           ff_env=ff_env, key=key)
+    both_labs = { 'Lab': '4DN Testing Lab|Some Other Guys lab'}
+    both_labs.update(for_all)
+    resp = ff_utils.search_facets(kwargs=both_labs)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           project='4DN',
-                                           experiment_type='Dilution Hi-C',
-                                           ff_env=ff_env, key=key)
+    proj_exp_type = { 'Project': '4DN', 'Experiment Type': 'Dilution Hi-C' }
+    proj_exp_type.update(for_all)
+    resp = ff_utils.search_facets(kwargs=proj_exp_type)
     assert len(resp) == 2
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           project='4DN|External',
-                                           experiment_type='Dilution Hi-C|2-stage Repli-seq',
-                                           ff_env=ff_env, key=key)
+    proj_exp_type = { 'Project': '4DN|External', 'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq' }
+    proj_exp_type.update(for_all)
+    resp = ff_utils.search_facets(kwargs=proj_exp_type)
     assert len(resp) == 5
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           project='4DN|External',
-                                           experiment_type='Dilution Hi-C|2-stage Repli-seq',
-                                           sample_type='in vitro differentiated cells',
-                                           ff_env=ff_env, key=key)
+    proj_exp_sam = { 'Project': '4DN|External',
+                     'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq',
+                     'Sample Type': 'in vitro differentiated cells'
+    }
+    proj_exp_sam.update(for_all)
+    resp = ff_utils.search_facets(kwargs=proj_exp_sam)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           experiment_type='ATAC-seq',
-                                           sample='GM12878', ff_env=ff_env, key=key)
+    exp_sam = { 'Experiment Type': 'ATAC-seq', 'Sample': 'GM12878' }
+    exp_sam.update(for_all)
+    resp = ff_utils.search_facets(kwargs=exp_sam)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url,
-                                           experiment_category='Sequencing',
-                                           sample_category='GM12878',
-                                           dataset='Z et al. 2-Stage Repliseq',
-                                           ff_env=ff_env, key=key)
+    exp_sam_data = { 'Experiment Category': 'Sequencing', 'Sample': 'GM12878',
+                     'Dataset': 'Z et al. 2-Stage Repliseq'
+    }
+    exp_sam_data.update(for_all)
+    resp = ff_utils.search_facets(kwargs=exp_sam_data)
     assert len(resp) == 2
+
+
+@pytest.mark.integrated
+def test_search_facets_users(integrated_ff):
+    """ Tests search_facets with users intead of experiment set """
+    key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
+    url = integrated_ff['ff_key']['server']
+    all_facets = ff_utils.get_item_facets('user', key=key, ff_env=ff_env)
+    affiliation = { 'item_type': 'user',
+                    'Affiliation': '4DN Testing Lab',
+                    'key': key,
+                    'ff_env': ff_env,
+                    'base_url': url,
+                    'item_facets': all_facets }
+    resp = ff_utils.search_facets(kwargs=affiliation)
+    assert len(resp) == 4
 
 
 @pytest.mark.integrated

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -741,7 +741,7 @@ def test_faceted_search_exp_set(integrated_ff):
 
 @pytest.mark.integrated
 def test_faceted_search_users(integrated_ff):
-    """ 
+    """
     Tests faceted_search with users intead of experiment set
     Tests a negative search as well
     """
@@ -776,6 +776,8 @@ def test_get_qc_metrics(integrated_ff):
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, key=key, ff_env=ff_env)
     assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics
     assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
+    assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
+    assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
 
 
 @pytest.mark.integrated

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -788,6 +788,7 @@ def test_get_qc_metrics(integrated_ff):
     assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
     assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
 
+
 @pytest.mark.integrated
 @pytest.mark.flaky
 def test_expand_es_metadata_frame_object_embedded(integrated_ff):

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -775,19 +775,20 @@ def test_get_qc_metrics(integrated_ff):
     uuid = '331106bc-8535-3338-903e-854af460b544'
     expected_qc_uuids = ['4c9dabc6-61d6-4054-a951-c4fdd0023800', '131106bc-8535-4448-903e-854abbbbbbbb']
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, key=key, ff_env=ff_env)
-    assert len(qc_metrics) == 2
-    for entry in qc_metrics:
-        assert entry['uuid'] in expected_qc_uuids
-        assert 'QualityMetric' in entry['@type']
-    kwargs = {  # do same as above w/ kwargs instead
+    assert len(qc_metrics.keys()) == 1 
+    assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
+    assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
+    kwargs = {  # do same as above w/ kwargs, specify to include raw files this time 
         'key': key,
-        'ff_env': ff_env
+        'ff_env': ff_env,
+        'exclude_raw_files': False
     }
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, **kwargs)
-    assert len(qc_metrics) == 2
-    for entry in qc_metrics:
-        assert entry['uuid'] in expected_qc_uuids
-        assert 'QualityMetric' in entry['@type']
+    assert len(qc_metrics.keys()) == 2
+    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics 
+    assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
+    assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
+    assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
 
 
 @pytest.mark.integrated

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -638,6 +638,18 @@ def test_experiment_set_search(integrated_ff):
     assert len(resp) == 12
     resp = ff_utils.search_experiment_sets(base_url=url, warnings='No value', ff_env=ff_env, key=key)
     assert len(resp) == 4
+    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', ff_env=ff_env, key=key)
+    assert len(resp) == 13
+    resp = ff_utils.search_experiment_sets(base_url=url, lab='4DN Testing Lab|Some Other Guys lab', ff_env=ff_env, key=key)
+    assert len(resp) == 13
+    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN', experiment_type='Dilution Hi-C', ff_env=ff_env, key=key)
+    assert len(resp) == 2
+    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', experiment_type='Dilution Hi-C|2-stage Repli-seq', ff_env=ff_env, key=key)
+    assert len(resp) == 5
+    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', experiment_type='Dilution Hi-C|2-stage Repli-seq', sample_type='in vitro differentiated cells', ff_env=ff_env, key=key)
+    assert len(resp) == 1
+    resp = ff_utils.search_experiment_sets(base_url=url, experiment_type='ATAC-seq', sample='GM12878', ff_env=ff_env, key=key)
+    assert len(resp) == 1
 
 
 @pytest.mark.integrated

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -612,15 +612,17 @@ def test_experiment_set_search(integrated_ff):
     assert len(resp) == 8
     resp = ff_utils.search_experiment_sets(base_url=url, lab='4DN Testing Lab', ff_env=ff_env, key=key)
     assert len(resp) == 12
-    resp = ff_utils.search_experiment_sets(base_url=url, experiment_category='No value', ff_env=ff_env, key=key)
-    assert len(resp) == 10
+    resp = ff_utils.search_experiment_sets(base_url=url, experiment_category='Microscopy', ff_env=ff_env, key=key)
+    assert len(resp) == 1
     resp = ff_utils.search_experiment_sets(base_url=url, experiment_type='Dilution Hi-C', ff_env=ff_env, key=key)
     assert len(resp) == 3
     resp = ff_utils.search_experiment_sets(base_url=url, dataset='No value', ff_env=ff_env, key=key)
     assert len(resp) == 9
     resp = ff_utils.search_experiment_sets(base_url=url, sample_type='immortalized cells', ff_env=ff_env, key=key)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url, sample_category='In vitro Differentiation', ff_env=ff_env, key=key)
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           sample_category='In vitro Differentiation',
+                                           ff_env=ff_env, key=key)
     assert len(resp) == 1
     resp = ff_utils.search_experiment_sets(base_url=url, sample='GM12878', ff_env=ff_env, key=key)
     assert len(resp) == 13
@@ -640,27 +642,49 @@ def test_experiment_set_search(integrated_ff):
     assert len(resp) == 4
     resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', ff_env=ff_env, key=key)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url, lab='4DN Testing Lab|Some Other Guys lab', ff_env=ff_env, key=key)
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           lab='4DN Testing Lab|Some Other Guys lab',
+                                           ff_env=ff_env, key=key)
     assert len(resp) == 13
-    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN', experiment_type='Dilution Hi-C', ff_env=ff_env, key=key)
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           project='4DN',
+                                           experiment_type='Dilution Hi-C',
+                                           ff_env=ff_env, key=key)
     assert len(resp) == 2
-    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', experiment_type='Dilution Hi-C|2-stage Repli-seq', ff_env=ff_env, key=key)
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           project='4DN|External',
+                                           experiment_type='Dilution Hi-C|2-stage Repli-seq',
+                                           ff_env=ff_env, key=key)
     assert len(resp) == 5
-    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN|External', experiment_type='Dilution Hi-C|2-stage Repli-seq', sample_type='in vitro differentiated cells', ff_env=ff_env, key=key)
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           project='4DN|External',
+                                           experiment_type='Dilution Hi-C|2-stage Repli-seq',
+                                           sample_type='in vitro differentiated cells',
+                                           ff_env=ff_env, key=key)
     assert len(resp) == 1
-    resp = ff_utils.search_experiment_sets(base_url=url, experiment_type='ATAC-seq', sample='GM12878', ff_env=ff_env, key=key)
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           experiment_type='ATAC-seq',
+                                           sample='GM12878', ff_env=ff_env, key=key)
     assert len(resp) == 1
+    resp = ff_utils.search_experiment_sets(base_url=url,
+                                           experiment_category='Sequencing',
+                                           sample_category='GM12878',
+                                           dataset='Z et al. 2-Stage Repliseq',
+                                           ff_env=ff_env, key=key)
+    assert len(resp) == 2
 
 
 @pytest.mark.integrated
 def test_get_qc_metrics(integrated_ff):
-    """ XXX: How to test? """
+    """
+    Tests that we correctly extract qc metric uuids (and therefore items) from the helper
+    """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
-    resp = ff_utils.search_metadata('/search/?type=ExperimentSetReplicate', key=key, ff_env=ff_env)
-    for entry in resp:
-        res = ff_utils.get_associated_qc_metrics(entry['uuid'], key=key, ff_env=ff_env)
-        if res != {}:
-            pass # yay we found one, test more later
+    uuid = '331106bc-8535-3338-903e-854af460b544'
+    qc_metrics = ff_utils.get_associated_qc_metrics(uuid, key=key, ff_env=ff_env)
+    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics
+    assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
+
 
 @pytest.mark.integrated
 @pytest.mark.flaky

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -653,6 +653,16 @@ def test_experiment_set_search(integrated_ff):
 
 
 @pytest.mark.integrated
+def test_get_qc_metrics(integrated_ff):
+    """ XXX: How to test? """
+    key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
+    resp = ff_utils.search_metadata('/search/?type=ExperimentSetReplicate', key=key, ff_env=ff_env)
+    for entry in resp:
+        res = ff_utils.get_associated_qc_metrics(entry['uuid'], key=key, ff_env=ff_env)
+        if res != {}:
+            pass # yay we found one, test more later
+
+@pytest.mark.integrated
 @pytest.mark.flaky
 def test_expand_es_metadata_frame_object_embedded(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -616,108 +616,132 @@ def test_get_item_facets(integrated_ff):
 
 
 @pytest.mark.integrated
-def test_search_facets_exp_set(integrated_ff):
+def test_get_item_facet_values(integrated_ff):
+    """ Tests that we correctly grab facets and all their possible values """
+    key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
+    item_type = 'experiment_set_replicate'
+    facets = ff_utils.get_item_facet_values(item_type, key=key, ff_env=ff_env)
+    assert 'Project' in facets
+    assert '4DN' in facets['Project']
+    assert 'Assay Details' in facets
+    assert 'Target: YFG protein' in facets['Assay Details']
+    assert 'Status' in facets
+
+
+@pytest.mark.integrated
+def test_faceted_search_exp_set(integrated_ff):
     """ Tests the experiment set search features using mastertest """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
-    url = integrated_ff['ff_key']['server']
     all_facets = ff_utils.get_item_facets('experiment_set_replicate', key=key, ff_env=ff_env)
-    for_all = {'base_url': url, 'key': key, 'ff_env': ff_env, 'item_facets': all_facets}
+    for_all = {'key': key, 'ff_env': ff_env, 'item_facets': all_facets}
+
+    # helper method that verifies a top level facet value
+    def validate_items(items, facet, expected):
+        facet_levels = facet.split('.')
+        for item in items:
+            it = item
+            for level in facet_levels:
+                it = it[level]
+            assert it == expected
+
     project = {'Project': '4DN'}
     project.update(for_all)
-    resp = ff_utils.search_facets(kwargs=project)
+    resp = ff_utils.faceted_search(**project)
     assert len(resp) == 8
+    validate_items(resp, all_facets['Project'], '4DN')
     lab = {'Lab': '4DN Testing Lab'}
     lab.update(for_all)
-    resp = ff_utils.search_facets(kwargs=lab)
+    resp = ff_utils.faceted_search(**lab)
     assert len(resp) == 12
+    validate_items(resp, all_facets['Lab'], '4DN Testing Lab')
     exp_cat = {'Experiment Category': 'Microscopy'}
     exp_cat.update(for_all)
-    resp = ff_utils.search_facets(kwargs=exp_cat)
+    resp = ff_utils.faceted_search(**exp_cat)
     assert len(resp) == 1
     exp_type = {'Experiment Type': 'Dilution Hi-C'}
     exp_type.update(for_all)
-    resp = ff_utils.search_facets(kwargs=exp_type)
+    resp = ff_utils.faceted_search(**exp_type)
     assert len(resp) == 3
     dataset = {'Dataset': 'No value'}
     dataset.update(for_all)
-    resp = ff_utils.search_facets(kwargs=dataset)
+    resp = ff_utils.faceted_search(**dataset)
     assert len(resp) == 9
     sample_type = {'Sample Type': 'immortalized cells'}
     sample_type.update(for_all)
-    resp = ff_utils.search_facets(kwargs=sample_type)
+    resp = ff_utils.faceted_search(**sample_type)
     assert len(resp) == 13
     sample_cat = {'Sample Category': 'In vitro Differentiation'}
     sample_cat.update(for_all)
-    resp = ff_utils.search_facets(kwargs=sample_cat)
+    resp = ff_utils.faceted_search(**sample_cat)
     assert len(resp) == 1
     sample = {'Sample': 'GM12878'}
     sample.update(for_all)
-    resp = ff_utils.search_facets(kwargs=sample)
+    resp = ff_utils.faceted_search(**sample)
     assert len(resp) == 13
     tissue_src = {'Tissue Source': 'endoderm'}
     tissue_src.update(for_all)
-    resp = ff_utils.search_facets(kwargs=tissue_src)
+    resp = ff_utils.faceted_search(**tissue_src)
     assert len(resp) == 1
     pub = {'Publication': 'No value'}
     pub.update(for_all)
-    resp = ff_utils.search_facets(kwargs=pub)
+    resp = ff_utils.faceted_search(**pub)
     assert len(resp) == 10
     mods = {'Modifications': 'Stable Transfection'}
     mods.update(for_all)
-    resp = ff_utils.search_facets(kwargs=mods)
+    resp = ff_utils.faceted_search(**mods)
     assert len(resp) == 7
     treats = {'Treatments': 'RNAi'}
     treats.update(for_all)
-    resp = ff_utils.search_facets(kwargs=treats)
+    resp = ff_utils.faceted_search(**treats)
     assert len(resp) == 7
     assay_details = {'Assay Details': 'No value'}
     assay_details.update(for_all)
-    resp = ff_utils.search_facets(kwargs=assay_details)
+    resp = ff_utils.faceted_search(**assay_details)
     assert len(resp) == 1
     status = {'Status': 'released'}
     status.update(for_all)
-    resp = ff_utils.search_facets(base_url=url, ff_env=ff_env, key=key, kwargs=status)
+    resp = ff_utils.faceted_search(**status)
     assert len(resp) == 12
     warnings = {'Warnings': 'No value'}
     warnings.update(for_all)
-    resp = ff_utils.search_facets(kwargs=warnings)
+    resp = ff_utils.faceted_search(**warnings)
     assert len(resp) == 4
     both_projects = {'Project': '4DN|External'}
     both_projects.update(for_all)
-    resp = ff_utils.search_facets(kwargs=both_projects)
+    resp = ff_utils.faceted_search(**both_projects)
     assert len(resp) == 13
     both_labs = {'Lab': '4DN Testing Lab|Some Other Guys lab'}
     both_labs.update(for_all)
-    resp = ff_utils.search_facets(kwargs=both_labs)
+    resp = ff_utils.faceted_search(**both_labs)
     assert len(resp) == 13
     proj_exp_type = {'Project': '4DN', 'Experiment Type': 'Dilution Hi-C'}
     proj_exp_type.update(for_all)
-    resp = ff_utils.search_facets(kwargs=proj_exp_type)
+    resp = ff_utils.faceted_search(**proj_exp_type)
     assert len(resp) == 2
     proj_exp_type = {'Project': '4DN|External', 'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq'}
     proj_exp_type.update(for_all)
-    resp = ff_utils.search_facets(kwargs=proj_exp_type)
+    resp = ff_utils.faceted_search(**proj_exp_type)
     assert len(resp) == 5
     proj_exp_sam = {'Project': '4DN|External',
                     'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq',
                     'Sample Type': 'in vitro differentiated cells'}
     proj_exp_sam.update(for_all)
-    resp = ff_utils.search_facets(kwargs=proj_exp_sam)
+    resp = ff_utils.faceted_search(**proj_exp_sam)
     assert len(resp) == 1
     exp_sam = {'Experiment Type': 'ATAC-seq', 'Sample': 'GM12878'}
     exp_sam.update(for_all)
-    resp = ff_utils.search_facets(kwargs=exp_sam)
+    resp = ff_utils.faceted_search(**exp_sam)
     assert len(resp) == 1
     exp_sam_data = {'Experiment Category': 'Sequencing', 'Sample': 'GM12878',
                     'Dataset': 'Z et al. 2-Stage Repliseq'}
     exp_sam_data.update(for_all)
-    resp = ff_utils.search_facets(kwargs=exp_sam_data)
+    resp = ff_utils.faceted_search(**exp_sam_data)
     assert len(resp) == 2
 
 
 @pytest.mark.integrated
-def test_search_facets_users(integrated_ff):
-    """ Tests search_facets with users intead of experiment set """
+def test_faceted_search_users(integrated_ff):
+    """ Tests faceted_search with users intead of experiment set """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     url = integrated_ff['ff_key']['server']
     all_facets = ff_utils.get_item_facets('user', key=key, ff_env=ff_env)
@@ -727,7 +751,7 @@ def test_search_facets_users(integrated_ff):
                    'ff_env': ff_env,
                    'base_url': url,
                    'item_facets': all_facets}
-    resp = ff_utils.search_facets(kwargs=affiliation)
+    resp = ff_utils.faceted_search(**affiliation)
     assert len(resp) == 4
 
 

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -604,6 +604,43 @@ def test_expand_es_metadata(integrated_ff):
 
 
 @pytest.mark.integrated
+def test_experiment_set_search(integrated_ff):
+    """ Tests the experiment set search features using mastertest """
+    key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
+    url = integrated_ff['ff_key']['server'] + '/search/'
+    resp = ff_utils.search_experiment_sets(base_url=url, project='4DN', ff_env=ff_env, key=key)
+    assert len(resp) == 8
+    resp = ff_utils.search_experiment_sets(base_url=url, lab='4DN Testing Lab', ff_env=ff_env, key=key)
+    assert len(resp) == 12
+    resp = ff_utils.search_experiment_sets(base_url=url, experiment_category='No value', ff_env=ff_env, key=key)
+    assert len(resp) == 10
+    resp = ff_utils.search_experiment_sets(base_url=url, experiment_type='Dilution Hi-C', ff_env=ff_env, key=key)
+    assert len(resp) == 3
+    resp = ff_utils.search_experiment_sets(base_url=url, dataset='No value', ff_env=ff_env, key=key)
+    assert len(resp) == 9
+    resp = ff_utils.search_experiment_sets(base_url=url, sample_type='immortalized cells', ff_env=ff_env, key=key)
+    assert len(resp) == 13
+    resp = ff_utils.search_experiment_sets(base_url=url, sample_category='In vitro Differentiation', ff_env=ff_env, key=key)
+    assert len(resp) == 1
+    resp = ff_utils.search_experiment_sets(base_url=url, sample='GM12878', ff_env=ff_env, key=key)
+    assert len(resp) == 13
+    resp = ff_utils.search_experiment_sets(base_url=url, tissue_source='endoderm', ff_env=ff_env, key=key)
+    assert len(resp) == 1
+    resp = ff_utils.search_experiment_sets(base_url=url, publication='No value', ff_env=ff_env, key=key)
+    assert len(resp) == 10
+    resp = ff_utils.search_experiment_sets(base_url=url, modifications='Stable Transfection', ff_env=ff_env, key=key)
+    assert len(resp) == 7
+    resp = ff_utils.search_experiment_sets(base_url=url, treatments='RNAi', ff_env=ff_env, key=key)
+    assert len(resp) == 7
+    resp = ff_utils.search_experiment_sets(base_url=url, assay_details='No value', ff_env=ff_env, key=key)
+    assert len(resp) == 1
+    resp = ff_utils.search_experiment_sets(base_url=url, status='released', ff_env=ff_env, key=key)
+    assert len(resp) == 12
+    resp = ff_utils.search_experiment_sets(base_url=url, warnings='No value', ff_env=ff_env, key=key)
+    assert len(resp) == 4
+
+
+@pytest.mark.integrated
 @pytest.mark.flaky
 def test_expand_es_metadata_frame_object_embedded(integrated_ff):
     test_list = ['7f9eb396-5c1a-4c5e-aebf-28ea39d6a50f']

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -633,7 +633,6 @@ def test_faceted_search_exp_set(integrated_ff):
     """ Tests the experiment set search features using mastertest """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     all_facets = ff_utils.get_item_facets('experiment_set_replicate', key=key, ff_env=ff_env)
-    import pdb; pdb.set_trace()
     for_all = {'key': key, 'ff_env': ff_env, 'item_facets': all_facets}
 
     # helper method that verifies a top level facet value

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -773,19 +773,18 @@ def test_get_qc_metrics(integrated_ff):
     """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     uuid = '331106bc-8535-3338-903e-854af460b544'
-    expected_qc_uuids = ['4c9dabc6-61d6-4054-a951-c4fdd0023800', '131106bc-8535-4448-903e-854abbbbbbbb']
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, key=key, ff_env=ff_env)
-    assert len(qc_metrics.keys()) == 1 
+    assert len(qc_metrics.keys()) == 1
     assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
     assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
-    kwargs = {  # do same as above w/ kwargs, specify to include raw files this time 
+    kwargs = {  # do same as above w/ kwargs, specify to include raw files this time
         'key': key,
         'ff_env': ff_env,
         'exclude_raw_files': False
     }
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, **kwargs)
     assert len(qc_metrics.keys()) == 2
-    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics 
+    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics
     assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
     assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
     assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -778,7 +778,15 @@ def test_get_qc_metrics(integrated_ff):
     assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
     assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
     assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
-
+    kwargs = {  # do same as above w/ kwargs instead
+        'key': key,
+        'ff_env': ff_env
+    }
+    qc_metrics = ff_utils.get_associated_qc_metrics(uuid, **kwargs)
+    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics
+    assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
+    assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
+    assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
 
 @pytest.mark.integrated
 @pytest.mark.flaky

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -741,7 +741,10 @@ def test_faceted_search_exp_set(integrated_ff):
 
 @pytest.mark.integrated
 def test_faceted_search_users(integrated_ff):
-    """ Tests faceted_search with users intead of experiment set """
+    """ 
+    Tests faceted_search with users intead of experiment set
+    Tests a negative search as well
+    """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     url = integrated_ff['ff_key']['server']
     all_facets = ff_utils.get_item_facets('user', key=key, ff_env=ff_env)
@@ -753,6 +756,14 @@ def test_faceted_search_users(integrated_ff):
                    'item_facets': all_facets}
     resp = ff_utils.faceted_search(**affiliation)
     assert len(resp) == 4
+    neg_affiliation = {'item_type': 'user',
+                       'Affiliation': '-4DN Testing Lab',
+                       'key': key,
+                       'ff_env': ff_env,
+                       'base_url': url,
+                       'item_facets': all_facets}
+    resp = ff_utils.faceted_search(**neg_affiliation)
+    assert len(resp) == 19
 
 
 @pytest.mark.integrated

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -622,96 +622,94 @@ def test_search_facets_exp_set(integrated_ff):
     url = integrated_ff['ff_key']['server']
     all_facets = ff_utils.get_item_facets('experiment_set_replicate', key=key, ff_env=ff_env)
     for_all = {'base_url': url, 'key': key, 'ff_env': ff_env, 'item_facets': all_facets}
-    project = { 'Project': '4DN' }
+    project = {'Project': '4DN'}
     project.update(for_all)
     resp = ff_utils.search_facets(kwargs=project)
     assert len(resp) == 8
-    lab = { 'Lab': '4DN Testing Lab' }
+    lab = {'Lab': '4DN Testing Lab'}
     lab.update(for_all)
     resp = ff_utils.search_facets(kwargs=lab)
     assert len(resp) == 12
-    exp_cat = { 'Experiment Category' : 'Microscopy' }
+    exp_cat = {'Experiment Category': 'Microscopy'}
     exp_cat.update(for_all)
     resp = ff_utils.search_facets(kwargs=exp_cat)
     assert len(resp) == 1
-    exp_type = { 'Experiment Type': 'Dilution Hi-C' }
+    exp_type = {'Experiment Type': 'Dilution Hi-C'}
     exp_type.update(for_all)
     resp = ff_utils.search_facets(kwargs=exp_type)
     assert len(resp) == 3
-    dataset = { 'Dataset': 'No value' }
+    dataset = {'Dataset': 'No value'}
     dataset.update(for_all)
     resp = ff_utils.search_facets(kwargs=dataset)
     assert len(resp) == 9
-    sample_type = { 'Sample Type': 'immortalized cells' }
+    sample_type = {'Sample Type': 'immortalized cells'}
     sample_type.update(for_all)
     resp = ff_utils.search_facets(kwargs=sample_type)
     assert len(resp) == 13
-    sample_cat = { 'Sample Category': 'In vitro Differentiation' }
+    sample_cat = {'Sample Category': 'In vitro Differentiation'}
     sample_cat.update(for_all)
     resp = ff_utils.search_facets(kwargs=sample_cat)
     assert len(resp) == 1
-    sample = { 'Sample': 'GM12878' }
+    sample = {'Sample': 'GM12878'}
     sample.update(for_all)
     resp = ff_utils.search_facets(kwargs=sample)
     assert len(resp) == 13
-    tissue_src = { 'Tissue Source': 'endoderm' }
+    tissue_src = {'Tissue Source': 'endoderm'}
     tissue_src.update(for_all)
     resp = ff_utils.search_facets(kwargs=tissue_src)
     assert len(resp) == 1
-    pub = { 'Publication': 'No value' }
+    pub = {'Publication': 'No value'}
     pub.update(for_all)
     resp = ff_utils.search_facets(kwargs=pub)
     assert len(resp) == 10
-    mods = { 'Modifications': 'Stable Transfection' }
+    mods = {'Modifications': 'Stable Transfection'}
     mods.update(for_all)
     resp = ff_utils.search_facets(kwargs=mods)
     assert len(resp) == 7
-    treats = { 'Treatments': 'RNAi' }
+    treats = {'Treatments': 'RNAi'}
     treats.update(for_all)
     resp = ff_utils.search_facets(kwargs=treats)
     assert len(resp) == 7
-    assay_details = { 'Assay Details': 'No value' }
+    assay_details = {'Assay Details': 'No value'}
     assay_details.update(for_all)
     resp = ff_utils.search_facets(kwargs=assay_details)
     assert len(resp) == 1
-    status = { 'Status': 'released' }
+    status = {'Status': 'released'}
     status.update(for_all)
     resp = ff_utils.search_facets(base_url=url, ff_env=ff_env, key=key, kwargs=status)
     assert len(resp) == 12
-    warnings = { 'Warnings': 'No value' }
+    warnings = {'Warnings': 'No value'}
     warnings.update(for_all)
     resp = ff_utils.search_facets(kwargs=warnings)
     assert len(resp) == 4
-    both_projects = { 'Project': '4DN|External' }
+    both_projects = {'Project': '4DN|External'}
     both_projects.update(for_all)
     resp = ff_utils.search_facets(kwargs=both_projects)
     assert len(resp) == 13
-    both_labs = { 'Lab': '4DN Testing Lab|Some Other Guys lab'}
+    both_labs = {'Lab': '4DN Testing Lab|Some Other Guys lab'}
     both_labs.update(for_all)
     resp = ff_utils.search_facets(kwargs=both_labs)
     assert len(resp) == 13
-    proj_exp_type = { 'Project': '4DN', 'Experiment Type': 'Dilution Hi-C' }
+    proj_exp_type = {'Project': '4DN', 'Experiment Type': 'Dilution Hi-C'}
     proj_exp_type.update(for_all)
     resp = ff_utils.search_facets(kwargs=proj_exp_type)
     assert len(resp) == 2
-    proj_exp_type = { 'Project': '4DN|External', 'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq' }
+    proj_exp_type = {'Project': '4DN|External', 'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq'}
     proj_exp_type.update(for_all)
     resp = ff_utils.search_facets(kwargs=proj_exp_type)
     assert len(resp) == 5
-    proj_exp_sam = { 'Project': '4DN|External',
-                     'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq',
-                     'Sample Type': 'in vitro differentiated cells'
-    }
+    proj_exp_sam = {'Project': '4DN|External',
+                    'Experiment Type': 'Dilution Hi-C|2-stage Repli-seq',
+                    'Sample Type': 'in vitro differentiated cells'}
     proj_exp_sam.update(for_all)
     resp = ff_utils.search_facets(kwargs=proj_exp_sam)
     assert len(resp) == 1
-    exp_sam = { 'Experiment Type': 'ATAC-seq', 'Sample': 'GM12878' }
+    exp_sam = {'Experiment Type': 'ATAC-seq', 'Sample': 'GM12878'}
     exp_sam.update(for_all)
     resp = ff_utils.search_facets(kwargs=exp_sam)
     assert len(resp) == 1
-    exp_sam_data = { 'Experiment Category': 'Sequencing', 'Sample': 'GM12878',
-                     'Dataset': 'Z et al. 2-Stage Repliseq'
-    }
+    exp_sam_data = {'Experiment Category': 'Sequencing', 'Sample': 'GM12878',
+                    'Dataset': 'Z et al. 2-Stage Repliseq'}
     exp_sam_data.update(for_all)
     resp = ff_utils.search_facets(kwargs=exp_sam_data)
     assert len(resp) == 2
@@ -723,12 +721,12 @@ def test_search_facets_users(integrated_ff):
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     url = integrated_ff['ff_key']['server']
     all_facets = ff_utils.get_item_facets('user', key=key, ff_env=ff_env)
-    affiliation = { 'item_type': 'user',
-                    'Affiliation': '4DN Testing Lab',
-                    'key': key,
-                    'ff_env': ff_env,
-                    'base_url': url,
-                    'item_facets': all_facets }
+    affiliation = {'item_type': 'user',
+                   'Affiliation': '4DN Testing Lab',
+                   'key': key,
+                   'ff_env': ff_env,
+                   'base_url': url,
+                   'item_facets': all_facets}
     resp = ff_utils.search_facets(kwargs=affiliation)
     assert len(resp) == 4
 

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -633,6 +633,7 @@ def test_faceted_search_exp_set(integrated_ff):
     """ Tests the experiment set search features using mastertest """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     all_facets = ff_utils.get_item_facets('experiment_set_replicate', key=key, ff_env=ff_env)
+    import pdb; pdb.set_trace()
     for_all = {'key': key, 'ff_env': ff_env, 'item_facets': all_facets}
 
     # helper method that verifies a top level facet value
@@ -773,20 +774,21 @@ def test_get_qc_metrics(integrated_ff):
     """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     uuid = '331106bc-8535-3338-903e-854af460b544'
+    expected_qc_uuids = ['4c9dabc6-61d6-4054-a951-c4fdd0023800', '131106bc-8535-4448-903e-854abbbbbbbb']
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, key=key, ff_env=ff_env)
-    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics
-    assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
-    assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
-    assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
+    assert len(qc_metrics) == 2
+    for entry in qc_metrics:
+        assert entry['uuid'] in expected_qc_uuids
+        assert 'QualityMetric' in entry['@type']
     kwargs = {  # do same as above w/ kwargs instead
         'key': key,
         'ff_env': ff_env
     }
     qc_metrics = ff_utils.get_associated_qc_metrics(uuid, **kwargs)
-    assert '4c9dabc6-61d6-4054-a951-c4fdd0023800' in qc_metrics
-    assert '131106bc-8535-4448-903e-854abbbbbbbb' in qc_metrics
-    assert 'QualityMetric' in qc_metrics['4c9dabc6-61d6-4054-a951-c4fdd0023800']['@type']
-    assert 'QualityMetric' in qc_metrics['131106bc-8535-4448-903e-854abbbbbbbb']['@type']
+    assert len(qc_metrics) == 2
+    for entry in qc_metrics:
+        assert entry['uuid'] in expected_qc_uuids
+        assert 'QualityMetric' in entry['@type']
 
 
 @pytest.mark.integrated

--- a/test/test_jh_utils.py
+++ b/test/test_jh_utils.py
@@ -48,6 +48,8 @@ def test_some_decorated_methods_work(integrated_ff):
     patch_res = jh_utils.patch_metadata({'other_tracking': {'test_field': 'test_value'}},
                                         post_res['@graph'][0]['uuid'])
     assert patch_res['@graph'][0]['other_tracking']['test_field'] == 'test_value'
+    faceted_search_res = jh_utils.faceted_search(**{'Project': '4DN'})
+    assert len(faceted_search_res) == 8
 
 
 @pytest.mark.integrated


### PR DESCRIPTION
- Implements and tests two features we'd like to have available for the annual meeting, described below.
- Implements a 'nicer' search utility for searching based on facets seen on the portal UI. It can replace `search_metadata` if used correctly, but at the moment still cannot do AND searches.
- Implements a utility function to grab all QC metrics associated with a given experiment set (passed in by uuid).
- Adds `pytest.ini` to fix our `pytest.mark` warnings