### PR TITLE
C4-24 Give ff_utils a lucene API

### DIFF
--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -56,3 +56,21 @@ def create_snapshot_repo(client, repo_name,  s3_bucket):
                       }
                      }
     return client.snapshot.create_repository(repository=repo_name, body=snapshot_body)
+
+
+def execute_lucene_query_on_es(client, index, query):
+    """
+        Executes the given lucene query (in dictionary form)
+
+        :arg client: elasticsearch client
+        :arg index: index to search under
+        :arg query: dictionary of query
+
+        :returns: result of query or None
+    """
+    try:
+        result = client.search(body=query, index=index)['hits']['hits']
+        return result
+    except Exception as e:  # XXX: What exceptions to catch?
+        print('Failed to execute search on index %s with query %s' % (index, query))
+        return None

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -77,7 +77,7 @@ def execute_lucene_query_on_es(client, index, query):
     """
     try:
         raw_result = client.search(body=query, index=index)
-    except Exception as e:  # XXX: What exceptions to catch?
+    except Exception as e:
         logger.error('Failed to execute search on index %s with query %s.\n Exception: %s' % (index, query, str(e)))
         return None
     try:
@@ -86,4 +86,3 @@ def execute_lucene_query_on_es(client, index, query):
     except KeyError:
         logger.error('Searching index %s with query %s gave no results' % (index, query))
         return None
-

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -72,5 +72,5 @@ def execute_lucene_query_on_es(client, index, query):
         result = client.search(body=query, index=index)['hits']['hits']
         return result
     except Exception as e:  # XXX: What exceptions to catch?
-        print('Failed to execute search on index %s with query %s' % (index, query))
+        print('Failed to execute search on index %s with query %s.\n Exception: %s' % (index, query, str(e)))
         return None

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -1,10 +1,11 @@
+import logging
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
-'''
-info about snapshots on AWS
-https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html
-'''
+
+logging.basicConfig()
+logger = logging.getLogger('logger')
+logger.setLevel(logging.INFO)
 
 
 def create_es_client(es_url, use_aws_auth=True, **options):
@@ -48,6 +49,12 @@ def get_index_list(client, name, days_old=0, timestring='%Y.%m.%d', ilo=None):
 
 
 def create_snapshot_repo(client, repo_name,  s3_bucket):
+    """
+    Creates a repo to store ES snapshots on
+
+    info about snapshots on AWS
+    https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html
+    """
     snapshot_body = {'type': 's3',
                      'settings': {
                          'bucket': s3_bucket,
@@ -69,8 +76,14 @@ def execute_lucene_query_on_es(client, index, query):
         :returns: result of query or None
     """
     try:
-        result = client.search(body=query, index=index)['hits']['hits']
-        return result
+        raw_result = client.search(body=query, index=index)
     except Exception as e:  # XXX: What exceptions to catch?
-        print('Failed to execute search on index %s with query %s.\n Exception: %s' % (index, query, str(e)))
+        logger.error('Failed to execute search on index %s with query %s.\n Exception: %s' % (index, query, str(e)))
         return None
+    try:
+        result = raw_result['hits']['hits']
+        return result
+    except KeyError:
+        logger.error('Searching index %s with query %s gave no results' % (index, query))
+        return None
+

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -891,23 +891,27 @@ class SearchESMetadataHandler(object):
     """
 
     def __init__(self, key=None, ff_env=None):
-        self.health = get_health_page(key, ff_env)
+        self.health = get_health_page(key, ff_env)  # expensive - do not call repeatedly!
         self.es_url = self.health['elasticsearch']
         self.client = es_utils.create_es_client(self.es_url)
 
-    def execute_search(self, index, query):
+    def execute_search(self, index, query, is_generator=False, page_size=200):
         """
         Executes lucene query on this client's index.
 
         :arg index: index to search under
         :arg query: query to run
+        :arg is_generator: boolean on whether or not to use a generator
+        :arg page_size: if using a generator, how many results to give per request
 
         :returns: result of query or None
         """
-        return es_utils.execute_lucene_query_on_es(self.client, index=index, query=query)
+        if not is_generator:
+            return es_utils.execute_lucene_query_on_es(self.client, index=index, query=query)
+        return get_es_search_generator(self.client, index, query, page_size=page_size)
 
 
-def search_es_metadata(index, query, key=None, ff_env=None):
+def search_es_metadata(index, query, key=None, ff_env=None, is_generator=False):
     """
         Executes a lucene search query on on the ES Instance for this
         environment.
@@ -919,11 +923,12 @@ def search_es_metadata(index, query, key=None, ff_env=None):
         :arg query: dictionary of query
         :arg key: optional, 2-tuple authentication key (access_key_id, secret)
         :arg ff_env: ff_env to use
+        :arg is_generator: boolean on whether or not to use a generator
 
         :returns: result of query or None
     """
     search_handler = SearchESMetadataHandler(key, ff_env)
-    return search_handler.execute_search(index, query)
+    return search_handler.execute_search(index, query, is_generator)
 
 
 #####################

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -879,6 +879,39 @@ def get_health_page(key=None, ff_env=None):
     return ret
 
 
+class SearchESMetadataHandler(object):
+    """
+    Wrapper class for executing lucene queries directly on ES.
+    Resolves ES instance location via health page of the given 
+    environment. Requires AWS permissions to use.
+    Can be used directly but is used through search_es_metadata
+    """
+
+    def __init__(self, key=None, ff_env=None):
+        self.health = get_health_page(key, ff_env)
+        self.es_url = self.health['elasticsearch']
+        self.client = es_utils.create_es_client(self.es_url)
+
+    def execute_search(self, index, query):
+        """
+        Executes lucene query on this client's index.
+        """
+        return es_utils.execute_lucene_query_on_es(self.client, index=index, query=query)
+
+
+def search_es_metadata(index, query, key=None, ff_env=None):
+    """
+        Executes a lucene search query on on the ES Instance for this
+        environment.
+
+        :arg index: index to search under
+        :arg query: dictionary of query
+        :arg key: optional, 2-tuple authentication key
+        :arg ff_env: ff_env to 
+    """
+    search_handler = SearchESMetadataHandler(key, ff_env)
+    return search_handler.execute_search(index, query)
+
 #####################
 # Utility functions #
 #####################

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -884,7 +884,10 @@ class SearchESMetadataHandler(object):
     Wrapper class for executing lucene queries directly on ES.
     Resolves ES instance location via health page of the given
     environment. Requires AWS permissions to use.
-    Can be used directly but is used through search_es_metadata
+    Can be used directly but is used through search_es_metadata.
+
+    NOTE: use this class directly if you plan on making multiple subsequent requests
+    to the same environment.
     """
 
     def __init__(self, key=None, ff_env=None):
@@ -895,6 +898,11 @@ class SearchESMetadataHandler(object):
     def execute_search(self, index, query):
         """
         Executes lucene query on this client's index.
+
+        :arg index: index to search under
+        :arg query: query to run
+
+        :returns: result of query or None
         """
         return es_utils.execute_lucene_query_on_es(self.client, index=index, query=query)
 
@@ -904,10 +912,15 @@ def search_es_metadata(index, query, key=None, ff_env=None):
         Executes a lucene search query on on the ES Instance for this
         environment.
 
+        NOTE: It is okay to use this function directly but for repeat usage please use
+        SearchESMetadataHandler as it caches an expensive API request to AWS
+
         :arg index: index to search under
         :arg query: dictionary of query
-        :arg key: optional, 2-tuple authentication key
+        :arg key: optional, 2-tuple authentication key (access_key_id, secret)
         :arg ff_env: ff_env to use
+
+        :returns: result of query or None
     """
     search_handler = SearchESMetadataHandler(key, ff_env)
     return search_handler.execute_search(index, query)

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -904,11 +904,11 @@ class SearchESMetadataHandler(object):
         :arg is_generator: boolean on whether or not to use a generator
         :arg page_size: if using a generator, how many results to give per request
 
-        :returns: result of query or None
+        :returns: list of results of query or None
         """
         if not is_generator:
             return es_utils.execute_lucene_query_on_es(self.client, index=index, query=query)
-        return get_es_search_generator(self.client, index, query, page_size=page_size)
+        return search_result_generator(get_es_search_generator(self.client, index, query, page_size=page_size))
 
 
 def search_es_metadata(index, query, key=None, ff_env=None, is_generator=False):
@@ -925,7 +925,7 @@ def search_es_metadata(index, query, key=None, ff_env=None, is_generator=False):
         :arg ff_env: ff_env to use
         :arg is_generator: boolean on whether or not to use a generator
 
-        :returns: result of query or None
+        :returns: list of results of query or None
     """
     search_handler = SearchESMetadataHandler(key, ff_env)
     return search_handler.execute_search(index, query, is_generator)

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -882,7 +882,7 @@ def get_health_page(key=None, ff_env=None):
 class SearchESMetadataHandler(object):
     """
     Wrapper class for executing lucene queries directly on ES.
-    Resolves ES instance location via health page of the given 
+    Resolves ES instance location via health page of the given
     environment. Requires AWS permissions to use.
     Can be used directly but is used through search_es_metadata
     """
@@ -907,10 +907,11 @@ def search_es_metadata(index, query, key=None, ff_env=None):
         :arg index: index to search under
         :arg query: dictionary of query
         :arg key: optional, 2-tuple authentication key
-        :arg ff_env: ff_env to 
+        :arg ff_env: ff_env to use
     """
     search_handler = SearchESMetadataHandler(key, ff_env)
     return search_handler.execute_search(index, query)
+
 
 #####################
 # Utility functions #

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,6 +27,8 @@ def integrated_ff():
     integrated['ff_key'] = s3.get_access_keys()
     integrated['higlass_key'] = s3.get_higlass_key()
     integrated['ff_env'] = INTEGRATED_ENV
+    # XXX: Read from config? Somewhere else?
+    integrated['es_url'] = 'https://search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com'
     # do this to make sure env is up (will error if not)
     res = authorized_request(integrated['ff_key']['server'], auth=integrated['ff_key'])
     if res.status_code != 200:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,8 +4,9 @@ import os
 from dcicutils.s3_utils import s3Utils
 from dcicutils.ff_utils import authorized_request
 
-# this is the ff_env we use for integrated tests
+# XXX: Refactor to config
 INTEGRATED_ENV = 'fourfront-mastertest'
+INTEGRATED_ES = 'https://search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com'
 
 
 @pytest.fixture(scope='session')
@@ -27,8 +28,7 @@ def integrated_ff():
     integrated['ff_key'] = s3.get_access_keys()
     integrated['higlass_key'] = s3.get_higlass_key()
     integrated['ff_env'] = INTEGRATED_ENV
-    # XXX: Read from config? Somewhere else?
-    integrated['es_url'] = 'https://search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com'
+    integrated['es_url'] = INTEGRATED_ES
     # do this to make sure env is up (will error if not)
     res = authorized_request(integrated['ff_key']['server'], auth=integrated['ff_key'])
     if res.status_code != 200:

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -9,6 +9,7 @@ def es_client_fixture(integrated_ff):
     return create_es_client(integrated_ff['es_url'])
 
 
+@pytest.mark.integrated
 def test_lucene_query_basic(es_client_fixture):
     """ Tests basic lucene queries via the endpoint on mastertest """
     q = {}

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -11,7 +11,19 @@ def es_client_fixture(integrated_ff):
 
 @pytest.mark.integrated
 def test_lucene_query_basic(es_client_fixture):
-    """ Tests basic lucene queries via the endpoint on mastertest """
-    q = {}
-    results = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query=q)
+    """ Tests basic lucene queries via the underlying endpoint on mastertest """
+    results = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
     assert len(results) == 10
+    test_query = {
+        'query': {
+            'bool': {
+                'must': [  # search for will's user insert
+                    {'terms': {'_id': ['1a12362f-4eb6-4a9c-8173-776667226988']}}
+                ],
+                'must_not': []
+            }
+        },
+        'sort': [{'_uid': {'order': 'desc'}}]
+    }
+    results = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query=test_query)
+    assert len(results) == 1

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from dcicutils.es_utils import create_es_client, execute_lucene_query_on_es
+
+
+@pytest.fixture
+def es_client_fixture(integrated_ff):
+    """ Fixture that creates an es client to mastertest """
+    return create_es_client(integrated_ff['es_url'])
+
+
+def test_lucene_query_basic(es_client_fixture):
+    """ Tests basic lucene queries via the endpoint on mastertest """
+    q = {}
+    results = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query=q)
+    assert len(results) == 10

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -961,9 +961,8 @@ def test_search_es_metadata_generator(integrated_ff):
                                       key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
     res = handler.execute_search('fourfront-mastertestuser', {'size': '1000'}, is_generator=True, page_size=5)
     count = 0
-    for grouped_hits in res:
-        for _ in grouped_hits:
-            count += 1
+    for _ in res:
+        count += 1
     assert count == len(no_gen_res)
 
 

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -934,8 +934,23 @@ def test_dump_results_to_json(integrated_ff):
 @pytest.mark.integrated
 def test_search_es_metadata(integrated_ff):
     """ Tests search_es_metadata on mastertest """
-    res = ff_utils.search_es_metadata('fourfront-mastertestuser', {}, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+    res = ff_utils.search_es_metadata('fourfront-mastertestuser', {},
+                                      key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
     assert len(res) == 10
+    test_query = {
+        'query': {
+            'bool': {
+                'must': [  # search for will's user insert
+                    {'terms': {'_id': ['1a12362f-4eb6-4a9c-8173-776667226988']}}
+                ],
+                'must_not': []
+            }
+        },
+        'sort': [{'_uid': {'order': 'desc'}}]
+    }
+    res = ff_utils.search_es_metadata('fourfront-mastertestuser', test_query,
+                                      key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+    assert len(res) == 1
 
 
 def test_convert_param():

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -215,7 +215,7 @@ def test_authorized_request_integrated(integrated_ff):
 
 
 @pytest.mark.integrated
-@pytest.mark.flaky
+@pytest.mark.flaky(max_runs=3)  # very flaky for some reason
 def test_get_metadata(integrated_ff, basestring):
     # use this test biosource
     test_item = '331111bc-8535-4448-903e-854af460b254'

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -934,9 +934,9 @@ def test_dump_results_to_json(integrated_ff):
 @pytest.mark.integrated
 def test_search_es_metadata(integrated_ff):
     """ Tests search_es_metadata on mastertest """
-    res = ff_utils.search_es_metadata('fourfront-mastertestuser', {},
+    res = ff_utils.search_es_metadata('fourfront-mastertestuser', {'size': '1000'},
                                       key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
-    assert len(res) == 10
+    assert len(res) == 27
     test_query = {
         'query': {
             'bool': {
@@ -951,6 +951,20 @@ def test_search_es_metadata(integrated_ff):
     res = ff_utils.search_es_metadata('fourfront-mastertestuser', test_query,
                                       key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
     assert len(res) == 1
+
+
+@pytest.mark.integrated
+def test_search_es_metadata_generator(integrated_ff):
+    """ Tests SearchESMetadataHandler both normally and with a generator, verifies consistent results """
+    handler = ff_utils.SearchESMetadataHandler(key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+    no_gen_res = ff_utils.search_es_metadata('fourfront-mastertestuser', {'size': '1000'},
+                                      key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+    res = handler.execute_search('fourfront-mastertestuser', {'size': '1000'}, is_generator=True, page_size=5)
+    count = 0
+    for grouped_hits in res:
+        for _ in grouped_hits:
+            count += 1
+    assert count == len(no_gen_res)
 
 
 def test_convert_param():

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -931,6 +931,13 @@ def test_dump_results_to_json(integrated_ff):
     clear_folder(test_folder)
 
 
+@pytest.mark.integrated
+def test_search_es_metadata(integrated_ff):
+    """ Tests search_es_metadata on mastertest """
+    res = ff_utils.search_es_metadata('fourfront-mastertestuser', {}, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+    assert len(res) == 10
+
+
 def test_convert_param():
     """ Very basic test that illustrates what convert_param should do """
     params = {'param1': 5}


### PR DESCRIPTION
- Implements `search_es_metadata` allowing one to run a lucene query on the given `ff_env` by accessing ES directly
- NOTE: For repeat usage, see `SearchESMetadataHandler`