### PR TITLE
Better handling of new environment names in s3utils

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -5,10 +5,18 @@ CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cg
 
 
 def is_cgap_env(envname):
+    """
+    Returns True of the given string looks like a CGAP elasticbeanstalk environment name.
+    Otherwise returns False.
+    """
     return 'cgap' in envname
 
 
 def is_fourfront_env(envname):
+    """
+    Returns True of the given string looks like a Fourfront elasticbeanstalk environment name.
+    Otherwise returns False.
+    """
     return 'cgap' not in envname
 
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -13,6 +13,12 @@ def is_fourfront_env(envname):
 
 
 def is_stg_or_prd_env(envname):
+    """
+    Returns True if the given envname is the name of something that might be either live data or something
+    that is ready to be swapped in as live.  So things like 'staging' and either of 'blue/green' will return
+    True whether or not they are actually the currently live instance. (This function doesn't change its
+    state as blue or green is deployed, in other words.)
+    """
     stg_or_prd_tokens = CGAP_STG_OR_PRD_TOKENS if is_cgap_env(envname) else FOURFRONT_STG_OR_PRD_TOKENS
     stg_or_prd_names = CGAP_STG_OR_PRD_NAMES if is_cgap_env(envname) else FOURFRONT_STG_OR_PRD_NAMES
     if envname in stg_or_prd_names:

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -7,6 +7,7 @@ CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cg
 def is_cgap_env(envname):
     return 'cgap' in envname
 
+
 def is_fourfront_env(envname):
     return 'cgap' not in envname
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,0 +1,21 @@
+FOURFRONT_STG_OR_PRD_TOKENS = ['webprod', 'blue', 'green']
+FOURFRONT_STG_OR_PRD_NAMES = ['staging', 'stagging', 'data']
+CGAP_STG_OR_PRD_TOKENS = []
+CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cgap-blue']
+
+
+def is_cgap_env(envname):
+    return 'cgap' in envname
+
+def is_fourfront_env(envname):
+    return 'cgap' not in envname
+
+
+def is_stg_or_prd_env(envname):
+    stg_or_prd_tokens = CGAP_STG_OR_PRD_TOKENS if is_cgap_env(envname) else FOURFRONT_STG_OR_PRD_TOKENS
+    stg_or_prd_names = CGAP_STG_OR_PRD_NAMES if is_cgap_env(envname) else FOURFRONT_STG_OR_PRD_NAMES
+    if envname in stg_or_prd_names:
+        return True
+    elif any(token in envname for token in stg_or_prd_tokens):
+        return True
+    return False

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -6,6 +6,7 @@ import mimetypes
 from zipfile import ZipFile
 from io import BytesIO
 import logging
+from .env_utils import is_stg_or_prd_env
 
 
 ###########################
@@ -29,7 +30,7 @@ class s3Utils(object):
         if sys_bucket is None:
             # staging and production share same buckets
             if env:
-                if 'webprod' in env or env in ['staging', 'stagging', 'data']:
+                if is_stg_or_prd_env(env):
                     self.url = get_beanstalk_real_url(env)
                     env = 'fourfront-webprod'
             # we use standardized naming schema, so s3 buckets always have same prefix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.9.6"
+version = "0.10.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["William Ronchetti <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -1,0 +1,39 @@
+import pytest
+
+from dcicutils.env_utils import is_stg_or_prd_env, is_cgap_env, is_fourfront_env
+
+
+def test_is_cgap_env():
+
+    assert is_cgap_env('fourfront-cgap') is True
+    assert is_cgap_env('cgap-prod') is True
+    assert is_cgap_env('fourfront-blue') is False
+
+
+def test_is_fourfront_env():
+
+    assert is_fourfront_env('fourfront-cgap') is False
+    assert is_fourfront_env('cgap-prod') is False
+    assert is_fourfront_env('fourfront-blue') is True
+
+
+def test_is_stg_or_prd_env():
+
+    assert is_stg_or_prd_env("fourfront-green") is True
+    assert is_stg_or_prd_env("fourfront-blue") is True
+    assert is_stg_or_prd_env("fourfront-blue-1") is True
+    assert is_stg_or_prd_env("fourfront-webprod") is True
+    assert is_stg_or_prd_env("fourfront-webprod2") is True
+
+    assert is_stg_or_prd_env("fourfront-yellow") is False
+    assert is_stg_or_prd_env("fourfront-mastertest") is False
+    assert is_stg_or_prd_env("fourfront-mastertest-1") is False
+    assert is_stg_or_prd_env("fourfront-wolf") is False
+
+    assert is_stg_or_prd_env("fourfront-cgap") is True
+    assert is_stg_or_prd_env("fourfront-cgap-blue") is True
+    assert is_stg_or_prd_env("fourfront-cgap-green") is True
+
+    assert is_stg_or_prd_env("fourfront-cgap-yellow") is False
+    assert is_stg_or_prd_env("fourfront-cgapwolf") is False
+    assert is_stg_or_prd_env("fourfront-cgaptest") is False


### PR DESCRIPTION
This addresses the problem in C4-95.

This also adds a `dcicutils.env_utils` with
* `is_cgap_env`
* `is_foufront_env`
* `is_stg_or_prd_env`

Bumps minor version to `0.10.0` for new functionality in addition to the bug fix.