### PR TITLE
Add env_utils.blue_green_mirror_env.

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -5,6 +5,10 @@ CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cg
 
 
 def blue_green_mirror_env(envname):
+    """
+    Given a blue envname, returns its green counterpart, or vice versa.
+    For other envnames that aren't blue/green participants, this returns None.
+    """
     if 'blue' in envname:
         return envname.replace('blue', 'green')
     elif 'green' in envname:

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -4,6 +4,15 @@ CGAP_STG_OR_PRD_TOKENS = []
 CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cgap-blue']
 
 
+def blue_green_mirror_env(envname):
+    if 'blue' in envname:
+        return envname.replace('blue', 'green')
+    elif 'green' in envname:
+        return envname.replace('green', 'blue')
+    else:
+        return None
+
+
 def is_cgap_env(envname):
     """
     Returns True of the given string looks like a CGAP elasticbeanstalk environment name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.10.0"
+version = "0.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["William Ronchetti <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -1,6 +1,32 @@
 import pytest
 
-from dcicutils.env_utils import is_stg_or_prd_env, is_cgap_env, is_fourfront_env
+from dcicutils.env_utils import is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env
+
+
+def test_blue_green_mirror_env():
+
+    # Should work for basic fourfront
+    assert blue_green_mirror_env('fourfront-blue') == 'fourfront-green'
+    assert blue_green_mirror_env('fourfront-green') == 'fourfront-blue'
+
+    # Should work for basic cgap
+    assert blue_green_mirror_env('cgap-blue') == 'cgap-green'
+    assert blue_green_mirror_env('cgap-green') == 'cgap-blue'
+
+    # Anticipated future cases
+    assert blue_green_mirror_env('cgap-test-blue') == 'cgap-test-green'
+    assert blue_green_mirror_env('cgap-test-green') == 'cgap-test-blue'
+
+    # Things with no mirror have no blue/green in them
+    assert blue_green_mirror_env('fourfront-cgap') is None
+    assert blue_green_mirror_env('fourfront-mastertest') is None
+    assert blue_green_mirror_env('fourfront-yellow') is None
+
+    # Edge cases
+    assert blue_green_mirror_env('xyz-green-1') == 'xyz-blue-1'
+    assert blue_green_mirror_env('xyz-blue-1') == 'xyz-green-1'
+    assert blue_green_mirror_env('xyz-blueish') == 'xyz-greenish'
+    assert blue_green_mirror_env('xyz-greenish') == 'xyz-blueish'
 
 
 def test_is_cgap_env():


### PR DESCRIPTION
This adds `env_utils.blue_green_mirror_env` as a way to compute what the name is of the blue/green mirror of a beanstalk environment. One more bit of common vocabulary/functionality centralized.