### PR TITLE
More backported deployment stuff for env_utils and beanstalk_utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: test
+
+configure:  # does any pre-requisite installs
+	pip install poetry
+
+build:  # builds
+	make configure
+	poetry install
+
+test:
+	pytest -vv
+
+info:
+	@: $(info Here are some 'make' options:)
+	   $(info - Use 'make configure' to install poetry, though 'make build' will do it automatically.)
+	   $(info - Use 'make build' to install dependencies using poetry.)
+	   $(info - Use 'make test' to run tests with the normal options we use on travis)

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -8,6 +8,7 @@ import boto3
 import os
 import json
 import requests
+import sys
 import time
 from datetime import datetime
 from dcicutils import ff_utils
@@ -17,11 +18,19 @@ logging.basicConfig()
 logger = logging.getLogger('logger')
 logger.setLevel(logging.INFO)
 
-# input vs. raw_input for python 2/3
-try:
-    use_input = raw_input
-except NameError:
-    use_input = input
+# In Python 2, the safe 'input' function was called 'raw_input'.  Also in Python 2, there was a function
+# named 'input' that did eval(raw_input(...)).  Python 3 made an incompatible change, renaming 'raw_input'
+# to 'input', and it no longer has a function that does an unsafe eval.  When we supported both Python 2 & 3,
+# use a 'try' expression to sort things out and call the safe function 'use_input' to avoid confusion.
+# But PyCharm found that 'try' expression confusing, so now that we are Python 3 only, we're phasing that
+# out. For a time, we'll retain the transitional naming, though, along with an affirmative error check, so
+# we don't open any security holes. We can remove this naming and check once we're we're only using Python 3.
+# -kmp 27-Mar-2020
+
+_python_major_version = sys.version_info[0]
+if _python_major_version < 3:
+    raise EnvironmentError("The 'dcicutils.beanstalk_utils' package only works in Python 3.")
+use_input = input  # In Python 3, this does 'safe' input reading.
 
 FOURSIGHT_URL = 'https://foursight.4dnucleome.org/'
 # magic CNAME corresponds to data.4dnucleome
@@ -648,6 +657,29 @@ def create_bs(envname, load_prod, db_endpoint, es_url, for_indexing=False):
         res = update_bs_config(envname, template=template, keep_env_vars=True,
                                env_override=env_vars)
     return res
+
+
+
+# location of environment variables on elasticbeanstalk
+BEANSTALK_ENV_PATH = "/opt/python/current/env"
+
+
+def source_beanstalk_env_vars(config_file=BEANSTALK_ENV_PATH):
+    """
+    set environment variables if we are on Elastic Beanstalk
+    AWS_ACCESS_KEY_ID is indicative of whether or not env vars are sourced
+
+    Args:
+        config_file (str): filepath to load env vars from
+    """
+    if os.path.exists(config_file) and not os.environ.get("AWS_ACCESS_KEY_ID"):
+        command = ['bash', '-c', 'source ' + config_file + ' && env']
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True)
+        for line in proc.stdout:
+            key, _, value = line.partition("=")
+            print("key=", key, "value=", value)
+            os.environ[key] = value[:-1]
+        proc.communicate()
 
 
 def log_to_foursight(event, lambda_name='', overrides=None):

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -659,7 +659,6 @@ def create_bs(envname, load_prod, db_endpoint, es_url, for_indexing=False):
     return res
 
 
-
 # location of environment variables on elasticbeanstalk
 BEANSTALK_ENV_PATH = "/opt/python/current/env"
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,11 +1,7 @@
 import os
 
 
-FOURFRONT_STG_OR_PRD_TOKENS = ['webprod', 'blue', 'green']
-FOURFRONT_STG_OR_PRD_NAMES = ['staging', 'stagging', 'data']
-CGAP_STG_OR_PRD_TOKENS = []
-CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cgap-blue']
-
+FF_ENV_DEV = 'fourfront-dev'  # Maybe not used
 FF_ENV_HOTSEAT = 'fourfront-hotseat'
 FF_ENV_MASTERTEST = 'fourfront-mastertest'
 FF_ENV_PRODUCTION_BLUE = 'fourfront-blue'
@@ -16,15 +12,36 @@ FF_ENV_WEBPROD = 'fourfront-webprod'
 FF_ENV_WEBPROD2 = 'fourfront-webprod2'
 FF_ENV_WOLF = 'fourfront-wolf'
 
-CGAP_ENV_HOTSEAT = 'fourfront-cgaphot'
+CGAP_ENV_DEV = 'fourfront-cgapdev'
+CGAP_ENV_HOTSEAT = 'fourfront-cgaphotseat'  # Maybe not used
 CGAP_ENV_MASTERTEST = 'fourfront-cgaptest'
-CGAP_ENV_PRODUCTION_BLUE = 'fourfront-cgapblue'
-CGAP_ENV_PRODUCTION_GREEN = 'fourfront-cgapgreen'
+CGAP_ENV_PRODUCTION_BLUE = 'fourfront-cgap-blue'  # reserved for transition use
+CGAP_ENV_PRODUCTION_GREEN = 'fourfront-cgap-green'  # reserved for transition use
 CGAP_ENV_STAGING = 'fourfront-cgapstaging'
-CGAP_ENV_WEBDEV = 'fourfront-cgapdev'
+CGAP_ENV_WEBDEV = 'fourfront-cgapwebdev'  # Maybe not used
 CGAP_ENV_WEBPROD = 'fourfront-cgap'
-# CGAP_ENV_WEBPROD2 doesn't have meaning in old CGAP naming. See ENV_STAGING.
-CGAP_ENV_WOLF = 'fourfront-cgapwolf'
+# CGAP_ENV_WEBPROD2 is meaningless here. See CGAP_ENV_STAGING.
+CGAP_ENV_WOLF = 'fourfront-cgapwolf'  # Maybe not used
+
+CGAP_ENV_DEV_NEW = 'cgap-dev'
+CGAP_ENV_HOTSEAT_NEW = 'cgap-hotseat'
+CGAP_ENV_MASTERTEST_NEW = 'cgap-test'
+CGAP_ENV_PRODUCTION_BLUE_NEW = 'cgap-blue'
+CGAP_ENV_PRODUCTION_GREEN_NEW = 'cgap-green'
+CGAP_ENV_STAGING_NEW = 'cgap-staging'
+CGAP_ENV_WEBDEV_NEW = 'cgap-webdev'  # Maybe not used
+CGAP_ENV_WEBPROD_NEW = 'cgap-green'
+# CGAP_ENV_WEBPROD2_NEW is meaningless here. See CGAP_ENV_STAGING_NEW.
+CGAP_ENV_WOLF_NEW = 'cgap-wolf'  # Maybe not used
+
+
+# Done this way to get maximally compatible behavior.
+FOURFRONT_STG_OR_PRD_TOKENS = ['webprod', 'blue', 'green']
+FOURFRONT_STG_OR_PRD_NAMES = ['staging', 'stagging', 'data']
+
+# Done this way because it's safer going forward.
+CGAP_STG_OR_PRD_TOKENS = []
+CGAP_STG_OR_PRD_NAMES = [CGAP_ENV_WEBPROD, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_PRODUCTION_BLUE]
 
 
 # These operate as pairs. Don't add extras.
@@ -39,7 +56,11 @@ BEANSTALK_PROD_MIRRORS = {
     CGAP_ENV_PRODUCTION_GREEN: CGAP_ENV_PRODUCTION_BLUE,
     CGAP_ENV_WEBPROD: None,
 
+    CGAP_ENV_PRODUCTION_BLUE_NEW: CGAP_ENV_PRODUCTION_GREEN_NEW,
+    CGAP_ENV_PRODUCTION_GREEN_NEW: CGAP_ENV_PRODUCTION_BLUE_NEW,
+
 }
+
 
 BEANSTALK_TEST_ENVS = [
 
@@ -52,6 +73,11 @@ BEANSTALK_TEST_ENVS = [
     CGAP_ENV_MASTERTEST,
     CGAP_ENV_WEBDEV,
     CGAP_ENV_WOLF,
+
+    CGAP_ENV_HOTSEAT_NEW,
+    CGAP_ENV_MASTERTEST_NEW,
+    CGAP_ENV_WEBDEV_NEW,
+    CGAP_ENV_WOLF_NEW,
 
 ]
 
@@ -109,7 +135,10 @@ def is_hotseat_env(envname):
     return 'hot' in envname
 
 
-def get_env_from_context(settings, allow_environ=False):
+ALLOW_ENVIRON_BY_DEFAULT = True
+
+
+def get_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT):
     if allow_environ:
         environ_env_name = os.environ.get('ENV_NAME')
         if environ_env_name:
@@ -117,7 +146,7 @@ def get_env_from_context(settings, allow_environ=False):
     return settings.get('env.name')
 
 
-def get_mirror_env_from_context(settings, allow_environ=False, allow_guess=True, ):
+def get_mirror_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT, allow_guess=True, ):
     # TODO: I added allow_environ featurism here but did not yet enable it.
     #       Want to talk to Will about whether we should consider that a compatible or breaking hcange.
     #       -kmp 27-Mar-2020

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,7 +1,59 @@
+import os
+
+
 FOURFRONT_STG_OR_PRD_TOKENS = ['webprod', 'blue', 'green']
 FOURFRONT_STG_OR_PRD_NAMES = ['staging', 'stagging', 'data']
 CGAP_STG_OR_PRD_TOKENS = []
 CGAP_STG_OR_PRD_NAMES = ['fourfront-cgap', 'fourfront-cgap-green', 'fourfront-cgap-blue']
+
+FF_ENV_HOTSEAT = 'fourfront-hotseat'
+FF_ENV_MASTERTEST = 'fourfront-mastertest'
+FF_ENV_PRODUCTION_BLUE = 'fourfront-blue'
+FF_ENV_PRODUCTION_GREEN = 'fourfront-green'
+FF_ENV_STAGING = 'fourfront-staging'
+FF_ENV_WEBDEV = 'fourfront-webdev'
+FF_ENV_WEBPROD = 'fourfront-webprod'
+FF_ENV_WEBPROD2 = 'fourfront-webprod2'
+FF_ENV_WOLF = 'fourfront-wolf'
+
+CGAP_ENV_HOTSEAT = 'fourfront-cgaphot'
+CGAP_ENV_MASTERTEST = 'fourfront-cgaptest'
+CGAP_ENV_PRODUCTION_BLUE = 'fourfront-cgapblue'
+CGAP_ENV_PRODUCTION_GREEN = 'fourfront-cgapgreen'
+CGAP_ENV_STAGING = 'fourfront-cgapstaging'
+CGAP_ENV_WEBDEV = 'fourfront-cgapdev'
+CGAP_ENV_WEBPROD = 'fourfront-cgap'
+# CGAP_ENV_WEBPROD2 doesn't have meaning in old CGAP naming. See ENV_STAGING.
+CGAP_ENV_WOLF = 'fourfront-cgapwolf'
+
+
+# These operate as pairs. Don't add extras.
+BEANSTALK_PROD_MIRRORS = {
+
+    FF_ENV_PRODUCTION_BLUE: FF_ENV_PRODUCTION_GREEN,
+    FF_ENV_PRODUCTION_GREEN: FF_ENV_PRODUCTION_BLUE,
+    FF_ENV_WEBPROD: FF_ENV_WEBPROD2,
+    FF_ENV_WEBPROD2: FF_ENV_WEBPROD,
+
+    CGAP_ENV_PRODUCTION_BLUE: CGAP_ENV_PRODUCTION_GREEN,
+    CGAP_ENV_PRODUCTION_GREEN: CGAP_ENV_PRODUCTION_BLUE,
+    CGAP_ENV_WEBPROD: None,
+
+}
+
+BEANSTALK_TEST_ENVS = [
+
+    FF_ENV_HOTSEAT,
+    FF_ENV_MASTERTEST,
+    FF_ENV_WEBDEV,
+    FF_ENV_WOLF,
+
+    CGAP_ENV_HOTSEAT,
+    CGAP_ENV_MASTERTEST,
+    CGAP_ENV_WEBDEV,
+    CGAP_ENV_WOLF,
+
+]
 
 
 def blue_green_mirror_env(envname):
@@ -47,3 +99,48 @@ def is_stg_or_prd_env(envname):
     elif any(token in envname for token in stg_or_prd_tokens):
         return True
     return False
+
+
+def is_test_env(envname):
+    return envname in BEANSTALK_TEST_ENVS
+
+
+def is_hotseat_env(envname):
+    return 'hot' in envname
+
+
+def get_env_from_context(settings, allow_environ=False):
+    if allow_environ:
+        environ_env_name = os.environ.get('ENV_NAME')
+        if environ_env_name:
+            return environ_env_name
+    return settings.get('env.name')
+
+
+def get_mirror_env_from_context(settings, allow_environ=False, allow_guess=True, ):
+    # TODO: I added allow_environ featurism here but did not yet enable it.
+    #       Want to talk to Will about whether we should consider that a compatible or breaking hcange.
+    #       -kmp 27-Mar-2020
+    """
+    Figures out who the mirror beanstalk Env is if applicable
+    This is important in our production environment because in our
+    blue-green deployment we maintain two elasticsearch intances that
+    must be up to date with each other.
+    """
+    if allow_environ:
+        environ_mirror_env_name = os.environ.get('MIRROR_ENV_NAME')
+        if environ_mirror_env_name:
+            return environ_mirror_env_name
+    declared = settings.get('mirror.env.name', '')
+    if declared:
+        return declared
+    elif allow_guess:
+        who_i_am = get_env_from_context(settings, allow_environ=allow_environ)
+        return guess_mirror_env(who_i_am)
+    else:
+        return None
+
+
+def guess_mirror_env(envname):
+    # TODO: Should this be BEANSTALK_PROD_MIRRORS.get(envname) or blue_green_mirror_env(envname)
+    return BEANSTALK_PROD_MIRRORS.get(envname)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.11.0"
+version = "0.12.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["William Ronchetti <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.12.0b1"
+version = "0.12.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["William Ronchetti <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.12.0"
+version = "0.12.0b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["William Ronchetti <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/test/test_beanstalk_utils.py
+++ b/test/test_beanstalk_utils.py
@@ -1,4 +1,6 @@
-from dcicutils import beanstalk_utils as bs
+import io
+import os
+from dcicutils import beanstalk_utils as bs, source_beanstalk_env_vars
 from unittest import mock
 
 
@@ -21,3 +23,56 @@ def test_get_beanstalk_normal_url():
         man_not_hot.return_value = {'CNAME': 'take-of-your-jacket'}
         url = bs.get_beanstalk_real_url('take-of-your-jacket')
         assert url == 'http://take-of-your-jacket'
+
+
+def _mock_not_called(name):
+    def mock_not_called(*args, **kwargs):
+        raise AssertionError("%s was called where not expected." % name)
+    return mock_not_called
+
+
+def test_source_beanstalk_env_vars_no_config_file():
+    # subprocess.Popen gets called only if config file exists and AWS_ACCESS_KEY_ID environment variable does not.
+    # This tests that if config file does not exist and AWS_ACCESS_KEY_ID does not, it doesn't get called.
+    with mock.patch("os.path.exists") as mock_exists:
+        with mock.patch.object(os, "environ", {}):
+            with mock.patch("subprocess.Popen") as mock_popen:
+                mock_exists.return_value = False
+                mock_popen = _mock_not_called("subprocess.Popen")
+                source_beanstalk_env_vars()
+
+
+def test_source_beanstalk_env_vars_aws_access_key_id():
+    # subprocess.Popen gets called only if config file exists and AWS_ACCESS_KEY_ID environment variable does not.
+    # This tests that if config file exists and AWS_ACCESS_KEY_ID does, it doesn't get called.
+    with mock.patch("os.path.exists") as mock_exists:
+        with mock.patch.object(os, "environ", {"AWS_ACCESS_KEY_ID": "something"}):
+            with mock.patch("subprocess.Popen") as mock_popen:
+                mock_exists.return_value = True
+                mock_popen.side_effect = _mock_not_called("subprocess.Popen")
+                source_beanstalk_env_vars()
+
+
+def test_source_beanstalk_env_vars_normal():
+    # subprocess.Popen gets called only if config file exists and AWS_ACCESS_KEY_ID environment variable does not.
+    # In the normal case, both of those conditions are true, and so it opens the file and parses it,
+    # setting os.environ to hold the relevant values.
+    with mock.patch("os.path.exists") as mock_exists:
+        fake_env = {}
+        with mock.patch.object(os, "environ", fake_env):
+            with mock.patch("subprocess.Popen") as mock_popen:
+                mock_exists.return_value = True
+                class FakeSubprocessPipe:
+                    def __init__(self, *args, **kwargs):
+                        self.stdout = io.StringIO(
+                            'AWS_ACCESS_KEY_ID=12345\n'
+                            'AWS_FAKE_SECRET=amazon\n'
+                        )
+                    def communicate(self):
+                        pass
+                mock_popen.side_effect = FakeSubprocessPipe
+                source_beanstalk_env_vars()
+                assert fake_env == {
+                    'AWS_ACCESS_KEY_ID': '12345',
+                    'AWS_FAKE_SECRET': 'amazon'
+                }

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -7,6 +7,8 @@ from dcicutils.env_utils import (
     FF_ENV_HOTSEAT, FF_ENV_STAGING, FF_ENV_WEBDEV, FF_ENV_WOLF,
     CGAP_ENV_PRODUCTION_BLUE, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_WEBPROD, CGAP_ENV_MASTERTEST,
     CGAP_ENV_HOTSEAT, CGAP_ENV_STAGING, CGAP_ENV_WEBDEV, CGAP_ENV_WOLF,
+    CGAP_ENV_PRODUCTION_BLUE_NEW, CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_WEBPROD_NEW, CGAP_ENV_MASTERTEST_NEW,
+    CGAP_ENV_HOTSEAT_NEW, CGAP_ENV_STAGING_NEW, CGAP_ENV_WEBDEV_NEW, CGAP_ENV_WOLF_NEW,
     get_mirror_env_from_context, is_test_env, is_hotseat_env, guess_mirror_env,
 )
 from unittest import mock
@@ -98,6 +100,11 @@ def test_is_hotseat_env():
     assert is_hotseat_env(CGAP_ENV_MASTERTEST) is False
     assert is_hotseat_env(CGAP_ENV_WOLF) is False
     assert is_hotseat_env(CGAP_ENV_WEBDEV) is False
+
+    assert is_hotseat_env(CGAP_ENV_HOTSEAT_NEW) is True
+    assert is_hotseat_env(CGAP_ENV_MASTERTEST_NEW) is False
+    assert is_hotseat_env(CGAP_ENV_WOLF_NEW) is False
+    assert is_hotseat_env(CGAP_ENV_WEBDEV_NEW) is False
 
 
 def test_get_mirror_env_from_context_without_environ():
@@ -192,17 +199,36 @@ def test_get_mirror_env_from_context_with_environ_has_env_and_mirror_env():
 
 def test_guess_mirror_env():
 
-    assert guess_mirror_env(FF_ENV_PRODUCTION_GREEN) == FF_ENV_PRODUCTION_BLUE
-    assert guess_mirror_env(FF_ENV_PRODUCTION_BLUE) == FF_ENV_PRODUCTION_GREEN
+    def assert_prod_mirrors(env, expected_mirror_env):
+        assert guess_mirror_env(env) is expected_mirror_env
+        assert BEANSTALK_PROD_MIRRORS.get(env) is expected_mirror_env
 
-    assert guess_mirror_env(FF_ENV_WEBPROD) == FF_ENV_WEBPROD2
-    assert guess_mirror_env(FF_ENV_WEBPROD2) == FF_ENV_WEBPROD
+    assert_prod_mirrors(FF_ENV_PRODUCTION_GREEN, FF_ENV_PRODUCTION_BLUE)
+    assert_prod_mirrors(FF_ENV_PRODUCTION_BLUE, FF_ENV_PRODUCTION_GREEN)
 
-    assert guess_mirror_env(FF_ENV_MASTERTEST) is None
+    assert_prod_mirrors(FF_ENV_WEBPROD, FF_ENV_WEBPROD2)
+    assert_prod_mirrors(FF_ENV_WEBPROD2, FF_ENV_WEBPROD)
 
-    assert guess_mirror_env(CGAP_ENV_PRODUCTION_GREEN) == CGAP_ENV_PRODUCTION_BLUE
-    assert guess_mirror_env(CGAP_ENV_PRODUCTION_BLUE) == CGAP_ENV_PRODUCTION_GREEN
+    assert_prod_mirrors(FF_ENV_MASTERTEST, None)
 
-    assert guess_mirror_env(CGAP_ENV_WEBPROD) is None
+    assert_prod_mirrors(CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_PRODUCTION_BLUE)
+    assert_prod_mirrors(CGAP_ENV_PRODUCTION_BLUE, CGAP_ENV_PRODUCTION_GREEN)
 
-    assert guess_mirror_env(CGAP_ENV_MASTERTEST) is None
+    assert_prod_mirrors(CGAP_ENV_STAGING, None)
+
+    assert_prod_mirrors(CGAP_ENV_WEBPROD, None)
+
+    assert_prod_mirrors(CGAP_ENV_MASTERTEST, None)
+
+    assert_prod_mirrors(CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_PRODUCTION_BLUE_NEW)
+    assert_prod_mirrors(CGAP_ENV_PRODUCTION_BLUE_NEW, CGAP_ENV_PRODUCTION_GREEN_NEW)
+
+    assert_prod_mirrors(CGAP_ENV_STAGING_NEW, None)
+
+    # A key difference between the CGAP old and new names is that
+    # the new naming assumes we have a blue/green deploy. -kmp 29-Mar-2020
+    assert CGAP_ENV_PRODUCTION_GREEN_NEW is CGAP_ENV_WEBPROD_NEW
+    assert_prod_mirrors(CGAP_ENV_WEBPROD_NEW, CGAP_ENV_PRODUCTION_BLUE_NEW)
+    assert_prod_mirrors(CGAP_ENV_PRODUCTION_BLUE_NEW, CGAP_ENV_WEBPROD_NEW)
+
+    assert_prod_mirrors(CGAP_ENV_MASTERTEST_NEW, None)

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -1,6 +1,15 @@
-import pytest
+# import pytest
+import os
 
-from dcicutils.env_utils import is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env
+from dcicutils.env_utils import (
+    is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env, BEANSTALK_PROD_MIRRORS,
+    FF_ENV_PRODUCTION_BLUE, FF_ENV_PRODUCTION_GREEN, FF_ENV_WEBPROD, FF_ENV_WEBPROD2, FF_ENV_MASTERTEST,
+    FF_ENV_HOTSEAT, FF_ENV_STAGING, FF_ENV_WEBDEV, FF_ENV_WOLF,
+    CGAP_ENV_PRODUCTION_BLUE, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_WEBPROD, CGAP_ENV_MASTERTEST,
+    CGAP_ENV_HOTSEAT, CGAP_ENV_STAGING, CGAP_ENV_WEBDEV, CGAP_ENV_WOLF,
+    get_mirror_env_from_context, is_test_env, is_hotseat_env, guess_mirror_env,
+)
+from unittest import mock
 
 
 def test_blue_green_mirror_env():
@@ -63,3 +72,137 @@ def test_is_stg_or_prd_env():
     assert is_stg_or_prd_env("fourfront-cgap-yellow") is False
     assert is_stg_or_prd_env("fourfront-cgapwolf") is False
     assert is_stg_or_prd_env("fourfront-cgaptest") is False
+
+
+def test_is_test_env():
+
+    assert is_test_env(FF_ENV_HOTSEAT) is True
+    assert is_test_env(FF_ENV_MASTERTEST) is True
+    assert is_test_env(FF_ENV_WOLF) is True
+    assert is_test_env(FF_ENV_WEBDEV) is True
+
+    assert is_test_env(CGAP_ENV_HOTSEAT) is True
+    assert is_test_env(CGAP_ENV_MASTERTEST) is True
+    assert is_test_env(CGAP_ENV_WOLF) is True
+    assert is_test_env(CGAP_ENV_WEBDEV) is True
+
+
+def test_is_hotseat_env():
+
+    assert is_hotseat_env(FF_ENV_HOTSEAT) is True
+    assert is_hotseat_env(FF_ENV_MASTERTEST) is False
+    assert is_hotseat_env(FF_ENV_WOLF) is False
+    assert is_hotseat_env(FF_ENV_WEBDEV) is False
+
+    assert is_hotseat_env(CGAP_ENV_HOTSEAT) is True
+    assert is_hotseat_env(CGAP_ENV_MASTERTEST) is False
+    assert is_hotseat_env(CGAP_ENV_WOLF) is False
+    assert is_hotseat_env(CGAP_ENV_WEBDEV) is False
+
+
+def test_get_mirror_env_from_context_without_environ():
+    """ Tests that when getting mirror env on various envs returns the correct mirror """
+
+    for allow_environ in (False, True):
+        # If the environment doesn't have either the ENV_NAME or MIRROR_ENV_NAME environment variables,
+        # it won't matter what value we pass for allow_environ.
+
+        with mock.patch.object(os, "environ", {}):
+            settings = {'env.name': FF_ENV_WEBPROD, 'mirror.env.name': 'anything'}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ)
+            assert mirror == 'anything'  # overrides any guess we might make
+
+            settings = {'env.name': FF_ENV_WEBPROD}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ)
+            assert mirror == FF_ENV_WEBPROD2  # Not found in environment, but we can guess
+
+            settings = {'env.name': FF_ENV_WEBPROD}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ, allow_guess=False)
+            assert mirror is None  # Guessing was suppressed
+
+            settings = {'env.name': FF_ENV_WEBPROD2}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ)
+            assert mirror == FF_ENV_WEBPROD
+
+            settings = {'env.name': FF_ENV_PRODUCTION_GREEN}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ)
+            assert mirror == FF_ENV_PRODUCTION_BLUE
+
+            settings = {'env.name': FF_ENV_PRODUCTION_BLUE}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ)
+            assert mirror == FF_ENV_PRODUCTION_GREEN
+
+            settings = {'env.name': FF_ENV_MASTERTEST}
+            mirror = get_mirror_env_from_context(settings, allow_environ=allow_environ)
+            assert mirror is None
+
+
+def test_get_mirror_env_from_context_with_environ_has_env():
+    """ Tests override of env name from os.environ when getting mirror env on various envs """
+
+    with mock.patch.object(os, "environ", {'ENV_NAME': 'foo'}):
+        settings = {'env.name': FF_ENV_WEBPROD}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True)
+        assert mirror is None  # "foo" has no mirror
+
+    with mock.patch.object(os, "environ", {"ENV_NAME": FF_ENV_WEBPROD2}):
+
+        settings = {}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True)
+        assert mirror == FF_ENV_WEBPROD  # env name explicitly declared, then a guess
+
+        settings = {}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True, allow_guess=False)
+        assert mirror is None  # env name explicitly declared, but guessing disallowed
+
+        settings = {'env.name': FF_ENV_WEBPROD}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True)
+        assert mirror == FF_ENV_WEBPROD  # env name in environ overrides env name in file
+
+        settings = {'env.name': FF_ENV_WEBPROD}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True, allow_guess=False)
+        assert mirror is None  # env name in environ overrides env name in file, but guessing disallowed
+
+        settings = {'env.name': FF_ENV_WEBPROD}
+        mirror = get_mirror_env_from_context(settings, allow_environ=False)
+        assert mirror == FF_ENV_WEBPROD2  # env name in environ suppressed
+
+        settings = {'env.name': FF_ENV_WEBPROD}
+        mirror = get_mirror_env_from_context(settings, allow_environ=False, allow_guess=False)
+        assert mirror == None  # env name in environ suppressed, but guessing disallowed
+
+
+def test_get_mirror_env_from_context_with_environ_has_mirror_env():
+    """ Tests override of mirror env name from os.environ when getting mirror env on various envs """
+
+    with mock.patch.object(os, "environ", {"MIRROR_ENV_NAME": 'bar'}):
+        settings = {}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True)
+        assert mirror == 'bar'  # explicitly declared, even if nothing else ise
+
+
+def test_get_mirror_env_from_context_with_environ_has_env_and_mirror_env():
+    """ Tests override of env name and mirror env name from os.environ when getting mirror env on various envs """
+
+    with mock.patch.object(os, "environ", {'ENV_NAME': FF_ENV_WEBPROD2, "MIRROR_ENV_NAME": 'bar'}):
+        settings = {'env.name': FF_ENV_WEBPROD}
+        mirror = get_mirror_env_from_context(settings, allow_environ=True)
+        assert mirror == 'bar'  # mirror explicitly declared, ignoring env name
+
+
+def test_guess_mirror_env():
+
+    assert guess_mirror_env(FF_ENV_PRODUCTION_GREEN) == FF_ENV_PRODUCTION_BLUE
+    assert guess_mirror_env(FF_ENV_PRODUCTION_BLUE) == FF_ENV_PRODUCTION_GREEN
+
+    assert guess_mirror_env(FF_ENV_WEBPROD) == FF_ENV_WEBPROD2
+    assert guess_mirror_env(FF_ENV_WEBPROD2) == FF_ENV_WEBPROD
+
+    assert guess_mirror_env(FF_ENV_MASTERTEST) is None
+
+    assert guess_mirror_env(CGAP_ENV_PRODUCTION_GREEN) == CGAP_ENV_PRODUCTION_BLUE
+    assert guess_mirror_env(CGAP_ENV_PRODUCTION_BLUE) == CGAP_ENV_PRODUCTION_GREEN
+
+    assert guess_mirror_env(CGAP_ENV_WEBPROD) is None
+
+    assert guess_mirror_env(CGAP_ENV_MASTERTEST) is None


### PR DESCRIPTION
I've implemented a number of operations that were previously managed in fourfront, so that I can have common implementations used by both cgap and fourfront.

**beanstalk_utils**

* source_beanstalk_env_vars

**env_utils**

* All of the variables `ENV_HOTSEAT`, etc. which are here `FF_ENV_HOTSEAT` or `CGAP_ENV_HOTSEAT` but which largely should not be needed in Fourfront because I added other abstractions.
* `BEANSTALK_PROD_MIRRORS` and `BEANSTALK_TEST_ENVS` contain both CGAP and FF values, but also shouldn't be needed outside of this module.
*  New functions `is_test_env`, `is_hotseat_env` that are predicates on an environment name. These operate at a better level of abstraction for Fourfront use.
* Function `get_mirror_env_from_context` (able to get an environment name and its mirror name from a config file and optionally overridden by an environment variable) was moved from Fourfront, where it was called `get_mirror_env`. Function `get_env_from_context` is new and works similarly.
* New function `guess_mirror_env` that does heuristic (but more regular) guessing about what the mirror env should look like.

**Design Issues**

 * Some question about whether `guess_mirror_env` or `get_mirror_env_from_context` is the right thing to use outside this module. But this creates some vocabulary to talk about that.

* There could be some reasonable debate over what the right default setting is four allow_environ in the `get_..._env` functions. We mentioned this on Slack earlier this evening so I implemented the option just in case. I kind of like it, but I don't want any surprises so I didn't turn it on by default.

