### PR TITLE
Rectify a small omission to an earlier C4-102 fix

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -46,7 +46,7 @@ FOURFRONT_STG_OR_PRD_NAMES = ['staging', 'stagging', 'data']
 # Done this way because it's safer going forward.
 CGAP_STG_OR_PRD_TOKENS = []
 CGAP_STG_OR_PRD_NAMES = [CGAP_ENV_WEBPROD, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_PRODUCTION_BLUE,
-                         # CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_PRODUCTION_BLUE_NEW,
+                         CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_PRODUCTION_BLUE_NEW,
                          'cgap']
 
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -45,7 +45,9 @@ FOURFRONT_STG_OR_PRD_NAMES = ['staging', 'stagging', 'data']
 
 # Done this way because it's safer going forward.
 CGAP_STG_OR_PRD_TOKENS = []
-CGAP_STG_OR_PRD_NAMES = [CGAP_ENV_WEBPROD, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_PRODUCTION_BLUE, 'cgap']
+CGAP_STG_OR_PRD_NAMES = [CGAP_ENV_WEBPROD, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_PRODUCTION_BLUE,
+                         # CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_PRODUCTION_BLUE_NEW,
+                         'cgap']
 
 
 FF_PUBLIC_URL_STG = 'http://staging.4dnucleome.org'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.13.0"
+version = "0.13.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["William Ronchetti <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -114,6 +114,13 @@ def test_is_stg_or_prd_env():
     assert is_stg_or_prd_env("fourfront-cgapwolf") is False
     assert is_stg_or_prd_env("fourfront-cgaptest") is False
 
+    assert is_stg_or_prd_env("cgap-green") is True
+    assert is_stg_or_prd_env("cgap-blue") is True
+    assert is_stg_or_prd_env("cgap-dev") is False
+    assert is_stg_or_prd_env("cgap-wolf") is False
+    assert is_stg_or_prd_env("cgap-test") is False
+    assert is_stg_or_prd_env("cgap-yellow") is False
+
 
 def test_is_test_env():
 


### PR DESCRIPTION
In `dcicutils 0.13.0`, I left out the names `cgap-blue` and `cgap-green` as possible `is_stg_or_prd_env` names. The omission got turned up when writing `fourfront` unit tests. This trivial PR adds the missing names.