### PR TITLE
Add dcicutils.misc_utils.get_setting_from_context

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,5 +1,5 @@
 import os
-
+from .misc_utils import get_setting_from_context
 
 FF_ENV_DEV = 'fourfront-dev'  # Maybe not used
 FF_ENV_HOTSEAT = 'fourfront-hotseat'
@@ -210,14 +210,10 @@ ALLOW_ENVIRON_BY_DEFAULT = True
 
 
 def get_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT):
-    if allow_environ:
-        environ_env_name = os.environ.get('ENV_NAME')
-        if environ_env_name:
-            return environ_env_name
-    return settings.get('env.name')
+    return get_setting_from_context(settings, ini_var='env.name', env_var=None if allow_environ else False)
 
 
-def get_mirror_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT, allow_guess=True, ):
+def get_mirror_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT, allow_guess=True):
     """
     Figures out who the mirror beanstalk Env is if applicable
     This is important in our production environment because in our

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -206,6 +206,8 @@ def is_hotseat_env(envname):
     return 'hot' in envname if envname else False
 
 
+# TODO: This variable and all the 'allow_environ=' arguments could go away in the next major version release.
+#       --Kent & Will 15-Apr-2020
 ALLOW_ENVIRON_BY_DEFAULT = True
 
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -2,6 +2,9 @@
 This file contains functions that might be generally useful.
 """
 
+import os
+
+
 # Using PRINT(...) for debugging, rather than its more familiar lowercase form) for intended programmatic output,
 # makes it easier to find stray print statements that were left behind in debugging. -kmp 30-Mar-2020
 
@@ -24,3 +27,28 @@ def ignored(*args, **kwargs):
         action(data, **options)
     """
     return args, kwargs
+
+
+def get_setting_from_context(settings, ini_var, env_var=None, default=None):
+    """
+    This gets a value from either an environment variable or a config file.
+
+    The environment variable overrides, since it is more dynamic in nature than a config file,
+    which might be checked into source control.
+
+    If the value of env_var is None, it will default to a name similar to ini_var,
+    but in uppercase and with '.' replaced by '_'. So a 'foo.bar' ini file setting
+    will defaultly correspond to a 'FOO_BAR' environment variable. This can be overridden
+    by using an string argument for env_var to specify the environment variable, or using False
+    to indicate that no env_var is allowed.
+    """
+    if env_var is not False:  # False specially means don't allow an environ variable, in case that's ever needed.
+        if env_var is None:
+            # foo.bar.baz in config file corresponds to FOO_BAR_BAZ as an environment variable setting.
+            env_var = ini_var.upper().replace(".", "_")
+        # NOTE WELL: An implication of this is that an environment variable of an empty string
+        #            will override a config file setting that is non-empty. This uses 'principle of least surprise',
+        #            that if environment variable settings appear to set a null string, that's what should prevail.
+        if env_var in os.environ:
+            return os.environ.get(env_var)
+    return settings.get(ini_var, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.14.0"
+version = "0.15.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -1,6 +1,7 @@
 import io
-from dcicutils.misc_utils import PRINT, ignored
-
+import os
+from dcicutils.misc_utils import PRINT, ignored, get_setting_from_context
+from unittest import mock
 
 def test_uppercase_print():
     # This is just a synonym, so the easiest thing is just to test that fact.
@@ -19,3 +20,53 @@ def test_ignored():
 
     # Check that no error occurs for having used this.
     assert foo(3, 4) is None
+
+
+def test_get_setting_from_context():
+
+    sample_settings = {'pie.flavor': 'apple'}
+
+    with mock.patch.object(os, "environ", {}):
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor') == 'apple'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color') is None
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', default='brown') == 'brown'
+
+        # Note that env_var=None means 'use default', not 'no env var'. You'd want env_var=False for 'no env var'.
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=None) == 'apple'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None) is None
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None, default='brown') == 'brown'
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=False) == 'apple'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=False) is None
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=False, default='brown') == 'brown'
+
+    with mock.patch.object(os, "environ", {'PIE_FLAVOR': 'cherry', 'PIE_COLOR': 'red'}):
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor') == 'cherry'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color') is 'red'
+
+        # Note that env_var=None means 'use default', not 'no env var'. You'd want env_var=False for 'no env var'.
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=None) == 'cherry'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None) is 'red'
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=False) is 'apple'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=False) is None
+
+    with mock.patch.object(os, "environ", {'PIE_FLAVOR': '', 'PIE_COLOR': ''}):
+
+        # Note that because there is an explicit value in the environment, even null, that gets used.
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor') == ''
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=None) == ''
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=False) == 'apple'
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=None, default='lime') == ''
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=False, default='lime') == 'apple'
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.color') == ''
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None) == ''
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=False) is None
+
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None, default='green') == ''
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=False, default='green') == 'green'


### PR DESCRIPTION
This adds support for a customization pattern we expect we'll reuse. See the doc string for `get_setting_from_context` for information on what it does.