### PR TITLE
Support for local_attrs context manager

### DIFF
--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2,6 +2,7 @@
 qa_utils: Tools for use in quality assurance testing.
 """
 
+import contextlib
 from .misc_utils import PRINT
 
 
@@ -18,3 +19,35 @@ def mock_not_called(name):
         PRINT("kwargs=", kwargs)
         raise AssertionError("%s was called where not expected." % name)
     return mocked_function
+
+
+@contextlib.contextmanager
+def local_attrs(obj, **kwargs):
+    """
+    This binds the named attributes of the given object.
+    This is only allowed for an object that directly owns the indicated attributes.
+
+    """
+    keys = kwargs.keys()
+    for key in keys:
+        if key not in obj.__dict__:
+            # This works only for objects that directly have the indicated property.
+            # That happens for
+            #  (a) an instance where its instance variables are in keys.
+            #  (b) an uninstantiated class where its class variables (but not inherited class variables) are in keys.
+            # So the error happens for these cases:
+            #  (c) an instance where any of the keys come from its class instead of the instance itself
+            #  (d) an uninstantiated class being used for keys that are inherited rather than direct class variables
+            raise ValueError("%s inherits property %s. Treating it as dynamic could affect other objects."
+                             % (obj, key))
+    saved = {
+        key: getattr(obj, key)
+        for key in keys
+    }
+    try:
+        for key in keys:
+            setattr(obj, key, kwargs[key])
+        yield
+    finally:
+        for key in keys:
+            setattr(obj, key, saved[key])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.15.0"
+version = "0.16.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1,5 +1,6 @@
+import pytest
 import re
-from dcicutils.qa_utils import mock_not_called
+from dcicutils.qa_utils import mock_not_called, local_attrs
 
 
 def test_mock_not_called():
@@ -12,3 +13,119 @@ def test_mock_not_called():
         assert m, "Expected assertion text did not appear."
     else:
         raise AssertionError("An AssertionError was not raised.")
+
+
+def test_dynamic_properties():
+
+    NORMAL_ATTR0 = 16
+    NORMAL_ATTR1 = 17
+    NORMAL_ATTR2 = 'foo'
+    NORMAL_ATTR3 = 'bar'
+
+    OVERRIDDEN_ATTR0 = 61
+    OVERRIDDEN_ATTR1 = 71
+    OVERRIDDEN_ATTR2 = 'oof'
+    OVERRIDDEN_ATTR3 = 'rab'
+
+    def test_thing(test_obj):
+
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        attrs = ['attr0', 'attr1', 'attr2', 'attr3']
+
+        # If this were done wrong, we'd bind an inherited attribute
+        # and then when we put things back it would become an instance
+        # attribute, so we remember what things were originally
+        # instance attributes so that we can check later.
+        old_attr_dict = test_obj.__dict__.copy()
+
+        # Test of the ordinary case.
+        with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr2=OVERRIDDEN_ATTR2):
+            assert test_obj.attr0 == OVERRIDDEN_ATTR0
+            assert test_obj.attr1 == NORMAL_ATTR1
+            assert test_obj.attr2 == OVERRIDDEN_ATTR2
+            assert test_obj.attr3 == NORMAL_ATTR3
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        assert test_obj.__dict__ == old_attr_dict
+
+        # Another test of the ordinary case.
+        with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr1=OVERRIDDEN_ATTR1,
+                         attr2=OVERRIDDEN_ATTR2, attr3=OVERRIDDEN_ATTR3):
+            assert test_obj.attr0 == OVERRIDDEN_ATTR0
+            assert test_obj.attr1 == OVERRIDDEN_ATTR1
+            assert test_obj.attr2 == OVERRIDDEN_ATTR2
+            assert test_obj.attr3 == OVERRIDDEN_ATTR3
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        # Test case of raising an error and assuring things are still set to normal
+        try:
+            with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr2=OVERRIDDEN_ATTR2):
+                assert test_obj.attr0 == NORMAL_ATTR0
+                assert test_obj.attr1 == NORMAL_ATTR1
+                assert test_obj.attr2 == NORMAL_ATTR2
+                assert test_obj.attr3 == NORMAL_ATTR3
+                raise Exception("This is expected to be caught.")
+        except Exception:
+            pass
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        # Test case of no attributes set at all
+        with local_attrs(object):
+            assert test_obj.attr0 == NORMAL_ATTR0
+            assert test_obj.attr1 == NORMAL_ATTR1
+            assert test_obj.attr2 == NORMAL_ATTR2
+            assert test_obj.attr3 == NORMAL_ATTR3
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+    class Foo:
+        attr0 = NORMAL_ATTR0
+        attr1 = NORMAL_ATTR1
+        def __init__(self):
+            self.attr2 = NORMAL_ATTR2
+            self.attr3 = NORMAL_ATTR3
+
+    with pytest.raises(ValueError):
+        # Binding attr1 would affect other instances.
+        test_thing(Foo())
+
+    class Bar:
+        def __init__(self):
+            self.attr0 = NORMAL_ATTR0
+            self.attr1 = NORMAL_ATTR1
+            self.attr2 = NORMAL_ATTR2
+            self.attr3 = NORMAL_ATTR3
+
+    test_thing(Bar())
+
+    class Baz:
+        attr0 = NORMAL_ATTR0
+        attr1 = NORMAL_ATTR1
+        attr2 = NORMAL_ATTR2
+        attr3 = NORMAL_ATTR3
+
+    test_thing(Baz)
+
+    with pytest.raises(ValueError):
+        # Binding attr1 would affect other instances.
+        test_thing(Baz())
+
+    for thing in [3, "foo", None]:
+        with local_attrs(thing):
+            pass  # Just make sure no error occurs when no attributes given
+


### PR DESCRIPTION
New functionality support for
```
with local_attrs(obj, attr1=val1, attr2=val2):
    ... stuff with local values of obj.attr1 and obj.attr2 ...
```
This is intended to be used for unit testing Settings, but might have other uses.