### PR TITLE
Add dcicutils.deployment_utils

### DIFF
--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -1,0 +1,255 @@
+"""
+Based on environment variables, build a suitable production.ini file for deployment.
+
+For example, fourfront/deploy/generate_production_ini.py might contain:
+
+  from dcicutils.deployment_utils import Deployer
+
+  class FourfrontDeployer(Deployer):
+      _MY_DIR = os.path.dirname(__file__)
+      TEMPLATE_DIR = os.path.join(_MY_DIR, "ini_files")
+      PYPROJECT_FILE_NAME = os.path.join(os.path.dirname(_MY_DIR), "pyproject.toml")
+
+  def main():
+      FourfrontDeployer.main()
+
+  if __name__ == '__main__':
+      main()
+
+"""
+
+import datetime
+import glob
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import toml
+import argparse
+
+from dcicutils.env_utils import (
+    is_stg_or_prd_env, prod_bucket_env, get_standard_mirror_env, is_cgap_env, data_set_for_env,
+)
+from dcicutils.misc_utils import PRINT
+
+
+class Deployer:
+
+    TEMPLATE_DIR = None
+    INI_FILE_NAME = "production.ini"
+    PYPROJECT_FILE_NAME = None
+
+    @classmethod
+    def build_ini_file_from_template(cls, template_file_name, init_file_name,
+                                     bs_env=None, bs_mirror_env=None, s3_bucket_env=None,
+                                     data_set=None, es_server=None, es_namespace=None):
+        """
+        Builds a .ini file from a given template file.
+
+        Args:
+            template_file_name (str): The name of the template file to drive the construction.
+            init_file_name (str): The name of the .ini file to build.
+            bs_env (str): The ElasticBeanstalk environment name for which this .ini file should work.
+            bs_mirror_env (str): The name of the ElasticBeanstalk environment that acts as a blue/green mirror.
+            s3_bucket_env (str): Environment name that is part of the s3 bucket name. (Usually defaults properly.)
+            data_set (str): An identifier for data to load (either 'prod' for prd/stg envs, or 'test' for others)
+            es_server (str): The server name (or server:port) for the ElasticSearch server.
+            es_namespace (str): The ElasticSearch namespace to use (probably but not necessarily same as bs_env).
+        """
+        with io.open(init_file_name, 'w') as init_file_fp:
+            cls.build_ini_stream_from_template(template_file_name=template_file_name,
+                                               init_file_stream=init_file_fp,
+                                               bs_env=bs_env,
+                                               bs_mirror_env=bs_mirror_env,
+                                               s3_bucket_env=s3_bucket_env,
+                                               data_set=data_set,
+                                               es_server=es_server,
+                                               es_namespace=es_namespace)
+
+    # Ref: https://stackoverflow.com/questions/19911123/how-can-you-get-the-elastic-beanstalk-application-version-in-your-application
+    EB_MANIFEST_FILENAME = "/opt/elasticbeanstalk/deploy/manifest"
+
+    @classmethod
+    def get_eb_bundled_version(cls):
+        """
+        Returns the version of the ElasticBeanstalk source bundle, by inspecting its manifest.
+        The manifest is a JSON dictionary and the version is associated with the 'VersionLabel' key.
+        This will return None if that information cannot be obtained.
+        """
+        if os.path.exists(cls.EB_MANIFEST_FILENAME):
+            try:
+                with io.open(cls.EB_MANIFEST_FILENAME, 'r') as fp:
+                    data = json.load(fp)
+                return data.get('VersionLabel')
+            except Exception:
+                return None
+        else:
+            return None
+
+    @classmethod
+    def get_local_git_version(cls):
+        return subprocess.check_output(['git', 'describe', '--dirty']).decode('utf-8').strip('\n')
+
+    @classmethod
+    def get_app_version(cls):  # This logic (perhaps most or all of this file) should move to dcicutils
+        try:
+            return cls.get_eb_bundled_version() or cls.get_local_git_version()
+        except Exception:
+            return 'unknown-version-at-' + datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
+
+    EMPTY_ASSIGNMENT = re.compile(r'^[ \t]*[A-Za-z][A-Za-z0-9.-_]*[ \t]*=[ \t\r\n]*$')
+
+    @classmethod
+    def build_ini_stream_from_template(cls, template_file_name, init_file_stream,
+                                       bs_env=None, bs_mirror_env=None, s3_bucket_env=None, data_set=None,
+                                       es_server=None, es_namespace=None):
+        """
+        Sends output to init_file_stream corresponding to the data noe would want in an ini file
+        for the given template_file_name and available environment variables.
+
+        Args:
+            template_file_name: The template file to guide the output.
+            init_file_stream: A stream to send output to.
+            bs_env: A beanstalk environment.
+            bs_mirror_env: A beanstalk environment.
+            s3_bucket_env: Environment name that is part of the s3 bucket name. (Usually defaults properly.)
+            data_set: 'test' or 'prod'. Default is 'test' unless bs_env is a staging or production environment.
+            es_server: The name of an es server to use.
+            es_namespace: The namespace to use on the es server. If None, this uses the bs_env.
+
+        Returns: None
+
+        """
+
+        # print("data_set given = ", data_set)
+
+        es_server = es_server or os.environ.get('ENCODED_ES_SERVER', "MISSING_ENCODED_ES_SERVER")
+        bs_env = bs_env or os.environ.get("ENCODED_BS_ENV", "MISSING_ENCODED_BS_ENV")
+        bs_mirror_env = bs_mirror_env or os.environ.get("ENCODED_BS_MIRROR_ENV", get_standard_mirror_env(bs_env)) or ""
+        s3_bucket_env = s3_bucket_env or os.environ.get("ENCODED_S3_BUCKET_ENV",
+                                                        prod_bucket_env(bs_env) if is_stg_or_prd_env(bs_env) else bs_env)
+        data_set = data_set or os.environ.get("ENCODED_DATA_SET",
+                                              data_set_for_env(bs_env) or "MISSING_ENCODED_DATA_SET")
+        es_namespace = es_namespace or os.environ.get("ENCODED_ES_NAMESPACE", bs_env)
+
+        # print("data_set computed = ", data_set)
+
+        extra_vars = {
+            'APP_VERSION': cls.get_app_version(),
+            'PROJECT_VERSION': toml.load(cls.PYPROJECT_FILE_NAME)['tool']['poetry']['version'],
+            'ES_SERVER': es_server,
+            'BS_ENV': bs_env,
+            'BS_MIRROR_ENV': bs_mirror_env,
+            'S3_BUCKET_ENV': s3_bucket_env,
+            'DATA_SET': data_set,
+            'ES_NAMESPACE': es_namespace,
+        }
+
+        # We assume these variables are not set, but best to check first. Confusion might result otherwise.
+        for extra_var in extra_vars:
+            if extra_var in os.environ:
+                raise RuntimeError("The environment variable %s is already set to %s."
+                                   % (extra_var, os.environ[extra_var]))
+
+        try:
+
+            # When we've checked everything, go ahead and do the bindings.
+            for var, val in extra_vars.items():
+                os.environ[var] = val
+
+            with io.open(template_file_name, 'r') as template_fp:
+                for line in template_fp:
+                    expanded_line = os.path.expandvars(line)
+                    # Uncomment for debugging, but this must not be disabled for production code so that passwords
+                    # are not echoed into logs. -kmp 26-Feb-2020
+                    # if '$' in line:
+                    #     print("line=", line)
+                    #     print("expanded_line=", expanded_line)
+                    if not cls.EMPTY_ASSIGNMENT.match(expanded_line):
+                        init_file_stream.write(expanded_line)
+
+        finally:
+
+            for key in extra_vars.keys():
+                # Let's be tidy and put things back the way they were before.
+                # Most things probably don't care, but testing might.
+                del os.environ[key]
+
+    @classmethod
+    def environment_template_filename(cls, env_name):
+        prefixes = ["fourfront-", "cgap-"]
+        short_env_name = None
+        for prefix in prefixes:
+            if env_name.startswith(prefix):
+                short_env_name = env_name[len(prefix):]
+                break
+        if short_env_name is None:
+            short_env_name = env_name
+        file = os.path.join(cls.TEMPLATE_DIR, short_env_name + ".ini")
+        if not os.path.exists(file):
+            raise ValueError("No such environment: %s" % env_name)
+        return file
+
+    @classmethod
+    def template_environment_names(cls):
+        return sorted([
+            os.path.splitext(os.path.basename(file))[0]
+            for file in glob.glob(os.path.join(cls.TEMPLATE_DIR, "*"))
+        ])
+
+    class GenerationError(Exception):
+        pass
+
+    @classmethod
+    def main(cls):
+        try:
+            if 'ENV_NAME' not in os.environ:
+                raise cls.GenerationError("ENV_NAME is not set.")
+            parser = argparse.ArgumentParser(
+                description="Generates a product.ini file from a template appropriate for the given environment,"
+                            " which defaults from the value of the ENV_NAME environment variable "
+                            " and may be given with or without a 'fourfront-' prefix. ")
+            parser.add_argument("--env",
+                                help="environment name",
+                                default=os.environ['ENV_NAME'],
+                                choices=cls.template_environment_names())
+            parser.add_argument("--target",
+                                help="the name of a .ini file to generate",
+                                default=cls.INI_FILE_NAME)
+            parser.add_argument("--bs_env",
+                                help="an ElasticBeanstalk environment name",
+                                default=None)
+            parser.add_argument("--bs_mirror_env",
+                                help="the name of the mirror of the ElasticBeanstalk environment name",
+                                default=None)
+            parser.add_argument("--s3_bucket_env",
+                                help="name of env to use in s3 bucket name, usually defaulted without specifying",
+                                default=None)
+            parser.add_argument("--data_set",
+                                help="a data set name",
+                                choices=['test', 'prod'],
+                                default=None)
+            parser.add_argument("--es_server",
+                                help="an ElasticSearch servername or servername:port",
+                                default=None)
+            parser.add_argument("--es_namespace",
+                                help="an ElasticSearch namespace",
+                                default=None)
+            args = parser.parse_args()
+            template_file_name = cls.environment_template_filename(args.env)
+            ini_file_name = args.target
+            # print("template_file_name=", template_file_name)
+            # print("ini_file_name=", ini_file_name)
+            cls.build_ini_file_from_template(template_file_name, ini_file_name,
+                                             bs_env=args.bs_env, bs_mirror_env=args.bs_mirror_env,
+                                             s3_bucket_env=args.s3_bucket_env, data_set=args.data_set,
+                                             es_server=args.es_server, es_namespace=args.es_namespace)
+        except Exception as e:
+            PRINT("Error (%s): %s" % (e.__class__.__name__, e))
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    Deployer.main()

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -30,7 +30,7 @@ import toml
 import argparse
 
 from dcicutils.env_utils import (
-    is_stg_or_prd_env, prod_bucket_env, get_standard_mirror_env, is_cgap_env, data_set_for_env,
+    is_stg_or_prd_env, prod_bucket_env, get_standard_mirror_env, data_set_for_env,
 )
 from dcicutils.misc_utils import PRINT
 
@@ -68,7 +68,7 @@ class Deployer:
                                                es_server=es_server,
                                                es_namespace=es_namespace)
 
-    # Ref: https://stackoverflow.com/questions/19911123/how-can-you-get-the-elastic-beanstalk-application-version-in-your-application
+    # Ref: https://stackoverflow.com/questions/19911123/how-can-you-get-the-elastic-beanstalk-application-version-in-your-application  # noqa: E501
     EB_MANIFEST_FILENAME = "/opt/elasticbeanstalk/deploy/manifest"
 
     @classmethod
@@ -129,7 +129,9 @@ class Deployer:
         bs_env = bs_env or os.environ.get("ENCODED_BS_ENV", "MISSING_ENCODED_BS_ENV")
         bs_mirror_env = bs_mirror_env or os.environ.get("ENCODED_BS_MIRROR_ENV", get_standard_mirror_env(bs_env)) or ""
         s3_bucket_env = s3_bucket_env or os.environ.get("ENCODED_S3_BUCKET_ENV",
-                                                        prod_bucket_env(bs_env) if is_stg_or_prd_env(bs_env) else bs_env)
+                                                        prod_bucket_env(bs_env)
+                                                        if is_stg_or_prd_env(bs_env)
+                                                        else bs_env)
         data_set = data_set or os.environ.get("ENCODED_DATA_SET",
                                               data_set_for_env(bs_env) or "MISSING_ENCODED_DATA_SET")
         es_namespace = es_namespace or os.environ.get("ENCODED_ES_NAMESPACE", bs_env)

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -122,6 +122,35 @@ BEANSTALK_TEST_ENVS = [
 
 ]
 
+BEANSTALK_DEV_DATA_SETS = {
+
+    'fourfront-hotseat': 'prod',
+    'fourfront-mastertest': 'test',
+    'fourfront-webdev': 'prod',
+
+    'fourfront-cgapdev': 'test',
+    'fourfront-cgaptest': 'test',
+    'fourfront-cgapwolf': 'test',
+
+    'cgap-dev': 'test',
+    'cgap-test': 'test',
+    'cgap-wolf': 'test',
+
+}
+
+def data_set_for_env(envname, default=None):
+    """
+    This relates to which data set to load.
+    For production environments, really the null set is loaded because the data is already there and trusted.
+    This must always work for all production environments and there is deliberately no provision to override that.
+    In all other environments, the question is whether to load ADDITIONAL data, and that's a kind of custom choice,
+    so we consult a table for now, pending a better theory of organization.
+    """
+    if is_stg_or_prd_env(envname):
+        return 'prod'
+    else:
+        return BEANSTALK_DEV_DATA_SETS.get(envname, default)
+
 
 def blue_green_mirror_env(envname):
     """

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -138,6 +138,7 @@ BEANSTALK_DEV_DATA_SETS = {
 
 }
 
+
 def data_set_for_env(envname, default=None):
     """
     This relates to which data set to load.

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -3,6 +3,7 @@ qa_utils: Tools for use in quality assurance testing.
 """
 
 import contextlib
+import os
 from .misc_utils import PRINT
 
 
@@ -51,3 +52,26 @@ def local_attrs(obj, **kwargs):
     finally:
         for key in keys:
             setattr(obj, key, saved[key])
+
+
+@contextlib.contextmanager
+def override_environ(**overrides):
+    to_delete = []
+    to_restore = {}
+    env = os.environ
+    try:
+        for k, v in overrides.items():
+            if k in env:
+                to_restore[k] = env[k]
+            else:
+                to_delete.append(k)
+            if v is None:
+                env.pop(k, None)  # Delete key k, tolerating it being already gone
+            else:
+                env[k] = v
+        yield
+    finally:
+        for k in to_delete:
+            env.pop(k, None)  # Delete key k, tolerating it being already gone
+        for k, v in to_restore.items():
+            os.environ[k] = v

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,10 +37,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.12.34"
+version = "1.12.42"
 
 [package.dependencies]
-botocore = ">=1.15.34,<1.16.0"
+botocore = ">=1.15.42,<1.16.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -50,7 +50,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.15.34"
+version = "1.15.42"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -71,7 +71,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.11.28"
+version = "2020.4.5.1"
 
 [[package]]
 category = "main"
@@ -113,7 +113,7 @@ description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.0.4"
+version = "5.1"
 
 [package.extras]
 toml = ["toml"]
@@ -329,7 +329,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.6"
+version = "2.4.7"
 
 [[package]]
 category = "dev"
@@ -432,7 +432,7 @@ description = "Thin-wrapper around the mock package for easier use with pytest"
 name = "pytest-mock"
 optional = false
 python-versions = ">=3.5"
-version = "3.0.0"
+version = "3.1.0"
 
 [package.dependencies]
 pytest = ">=2.7"
@@ -545,6 +545,14 @@ docs = ["sphinx", "twisted"]
 tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "python-rapidjson"]
 
 [[package]]
+category = "main"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.0"
+
+[[package]]
 category = "dev"
 description = "Type Hints for Python"
 marker = "python_version < \"3.5\""
@@ -571,11 +579,11 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.8"
+version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -600,7 +608,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "bbacb8c7db1eb67eeac44a83f2431b07641718b134405d28be908d56480dbc82"
+content-hash = "8de09338da2ff26e20e9dd4834286cbb00ac20ac6c1dd5d20c27bff1cf5d99da"
 python-versions = ">=3.4,<3.7"
 
 [metadata.files]
@@ -616,16 +624,16 @@ aws-requests-auth = [
     {file = "aws-requests-auth-0.4.2.tar.gz", hash = "sha256:112c85fe938a01e28f7e1a87168615b6977b28596362b1dcbafbf4f2cc69f720"},
 ]
 boto3 = [
-    {file = "boto3-1.12.34-py2.py3-none-any.whl", hash = "sha256:52b8de35f6647e3b8ce81f6a745a67812623b5c4acc2d6bd5e814fddfa488321"},
-    {file = "boto3-1.12.34.tar.gz", hash = "sha256:5246caf509baa4716065e6bb78bdc516fdd6b0dfbd9098cc2a0f779fad789c6c"},
+    {file = "boto3-1.12.42-py2.py3-none-any.whl", hash = "sha256:c205c9d69beb43f1dee6f8c30029a418afe1f82fc52a254d9f3b5ab24ee5dd00"},
+    {file = "boto3-1.12.42.tar.gz", hash = "sha256:bd005143eadea91dcba536caffcdd19d9a4dbefa7f59ddd503ef0ef2e5079c36"},
 ]
 botocore = [
-    {file = "botocore-1.15.34-py2.py3-none-any.whl", hash = "sha256:db0fba3f4adfb9bf3976aae10efa9acb59e3efe52ce8feac71ecac0b7be2fc2e"},
-    {file = "botocore-1.15.34.tar.gz", hash = "sha256:c799623598d04c66b0be4cb990c01a24bd3c06023f0c7221adead38a7431c994"},
+    {file = "botocore-1.15.42-py2.py3-none-any.whl", hash = "sha256:1b7730de543a751c2491f1510688f3c34a8b9669998d8b88f8facf6c3be3c790"},
+    {file = "botocore-1.15.42.tar.gz", hash = "sha256:2ce77c2b11253b64a3d7ec0aa696c064d6ed83c32e6288fc2d59f485f8119828"},
 ]
 certifi = [
-    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
-    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
+    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
+    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -670,37 +678,37 @@ coverage = [
     {file = "coverage-4.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351"},
     {file = "coverage-4.5.4-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5"},
     {file = "coverage-4.5.4.tar.gz", hash = "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c"},
-    {file = "coverage-5.0.4-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:8a620767b8209f3446197c0e29ba895d75a1e272a36af0786ec70fe7834e4307"},
-    {file = "coverage-5.0.4-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:73aa6e86034dad9f00f4bbf5a666a889d17d79db73bc5af04abd6c20a014d9c8"},
-    {file = "coverage-5.0.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:408ce64078398b2ee2ec08199ea3fcf382828d2f8a19c5a5ba2946fe5ddc6c31"},
-    {file = "coverage-5.0.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:cda33311cb9fb9323958a69499a667bd728a39a7aa4718d7622597a44c4f1441"},
-    {file = "coverage-5.0.4-cp27-cp27m-win32.whl", hash = "sha256:5f587dfd83cb669933186661a351ad6fc7166273bc3e3a1531ec5c783d997aac"},
-    {file = "coverage-5.0.4-cp27-cp27m-win_amd64.whl", hash = "sha256:9fad78c13e71546a76c2f8789623eec8e499f8d2d799f4b4547162ce0a4df435"},
-    {file = "coverage-5.0.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:2e08c32cbede4a29e2a701822291ae2bc9b5220a971bba9d1e7615312efd3037"},
-    {file = "coverage-5.0.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:922fb9ef2c67c3ab20e22948dcfd783397e4c043a5c5fa5ff5e9df5529074b0a"},
-    {file = "coverage-5.0.4-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:c3fc325ce4cbf902d05a80daa47b645d07e796a80682c1c5800d6ac5045193e5"},
-    {file = "coverage-5.0.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30"},
-    {file = "coverage-5.0.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6ad6ca45e9e92c05295f638e78cd42bfaaf8ee07878c9ed73e93190b26c125f7"},
-    {file = "coverage-5.0.4-cp35-cp35m-win32.whl", hash = "sha256:eda55e6e9ea258f5e4add23bcf33dc53b2c319e70806e180aecbff8d90ea24de"},
-    {file = "coverage-5.0.4-cp35-cp35m-win_amd64.whl", hash = "sha256:4a8a259bf990044351baf69d3b23e575699dd60b18460c71e81dc565f5819ac1"},
-    {file = "coverage-5.0.4-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:f372cdbb240e09ee855735b9d85e7f50730dcfb6296b74b95a3e5dea0615c4c1"},
-    {file = "coverage-5.0.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a37c6233b28e5bc340054cf6170e7090a4e85069513320275a4dc929144dccf0"},
-    {file = "coverage-5.0.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:443be7602c790960b9514567917af538cac7807a7c0c0727c4d2bbd4014920fd"},
-    {file = "coverage-5.0.4-cp36-cp36m-win32.whl", hash = "sha256:165a48268bfb5a77e2d9dbb80de7ea917332a79c7adb747bd005b3a07ff8caf0"},
-    {file = "coverage-5.0.4-cp36-cp36m-win_amd64.whl", hash = "sha256:0a907199566269e1cfa304325cc3b45c72ae341fbb3253ddde19fa820ded7a8b"},
-    {file = "coverage-5.0.4-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:513e6526e0082c59a984448f4104c9bf346c2da9961779ede1fc458e8e8a1f78"},
-    {file = "coverage-5.0.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3844c3dab800ca8536f75ae89f3cf566848a3eb2af4d9f7b1103b4f4f7a5dad6"},
-    {file = "coverage-5.0.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:641e329e7f2c01531c45c687efcec8aeca2a78a4ff26d49184dce3d53fc35014"},
-    {file = "coverage-5.0.4-cp37-cp37m-win32.whl", hash = "sha256:db1d4e38c9b15be1521722e946ee24f6db95b189d1447fa9ff18dd16ba89f732"},
-    {file = "coverage-5.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:62061e87071497951155cbccee487980524d7abea647a1b2a6eb6b9647df9006"},
-    {file = "coverage-5.0.4-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:65a7e00c00472cd0f59ae09d2fb8a8aaae7f4a0cf54b2b74f3138d9f9ceb9cb2"},
-    {file = "coverage-5.0.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1f66cf263ec77af5b8fe14ef14c5e46e2eb4a795ac495ad7c03adc72ae43fafe"},
-    {file = "coverage-5.0.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:85596aa5d9aac1bf39fe39d9fa1051b0f00823982a1de5766e35d495b4a36ca9"},
-    {file = "coverage-5.0.4-cp38-cp38-win32.whl", hash = "sha256:86a0ea78fd851b313b2e712266f663e13b6bc78c2fb260b079e8b67d970474b1"},
-    {file = "coverage-5.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0"},
-    {file = "coverage-5.0.4-cp39-cp39-win32.whl", hash = "sha256:7c9762f80a25d8d0e4ab3cb1af5d9dffbddb3ee5d21c43e3474c84bf5ff941f7"},
-    {file = "coverage-5.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:4482f69e0701139d0f2c44f3c395d1d1d37abd81bfafbf9b6efbe2542679d892"},
-    {file = "coverage-5.0.4.tar.gz", hash = "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
@@ -774,8 +782,8 @@ pyflakes = [
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.6-py2.py3-none-any.whl", hash = "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"},
-    {file = "pyparsing-2.4.6.tar.gz", hash = "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f"},
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
     {file = "pytest-4.6.9-py2.py3-none-any.whl", hash = "sha256:c77a5f30a90e0ce24db9eaa14ddfd38d4afb5ea159309bdd2dae55b931bc9324"},
@@ -790,8 +798,8 @@ pytest-cov = [
 pytest-mock = [
     {file = "pytest-mock-2.0.0.tar.gz", hash = "sha256:b35eb281e93aafed138db25c8772b95d3756108b601947f89af503f8c629413f"},
     {file = "pytest_mock-2.0.0-py2.py3-none-any.whl", hash = "sha256:cb67402d87d5f53c579263d37971a164743dc33c159dfb4fb4a86f37c5552307"},
-    {file = "pytest-mock-3.0.0.tar.gz", hash = "sha256:a4494016753a30231f8519bfd160242a0f3c8fb82ca36e7b6f82a7fb602ac6b8"},
-    {file = "pytest_mock-3.0.0-py2.py3-none-any.whl", hash = "sha256:98e02534f170e4f37d7e1abdfc5973fd4207aa609582291717f643764e71c925"},
+    {file = "pytest-mock-3.1.0.tar.gz", hash = "sha256:ce610831cedeff5331f4e2fc453a5dd65384303f680ab34bee2c6533855b431c"},
+    {file = "pytest_mock-3.1.0-py2.py3-none-any.whl", hash = "sha256:997729451dfc36b851a9accf675488c7020beccda15e11c75632ee3d1b1ccd71"},
 ]
 pytest-runner = [
     {file = "pytest-runner-5.2.tar.gz", hash = "sha256:96c7e73ead7b93e388c5d614770d2bae6526efd997757d3543fe17b557a0942b"},
@@ -832,6 +840,11 @@ structlog = [
     {file = "structlog-19.2.0-py2.py3-none-any.whl", hash = "sha256:6640e6690fc31d5949bc614c1a630464d3aaa625284aeb7c6e486c3010d73e12"},
     {file = "structlog-19.2.0.tar.gz", hash = "sha256:4287058cf4ce1a59bc5dea290d6386d37f29a37529c9a51cdf7387e51710152b"},
 ]
+toml = [
+    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
+    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
+    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+]
 typing = [
     {file = "typing-3.7.4.1-py2-none-any.whl", hash = "sha256:c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36"},
     {file = "typing-3.7.4.1-py3-none-any.whl", hash = "sha256:f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"},
@@ -840,8 +853,8 @@ typing = [
 urllib3 = [
     {file = "urllib3-1.24.3-py2.py3-none-any.whl", hash = "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"},
     {file = "urllib3-1.24.3.tar.gz", hash = "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4"},
-    {file = "urllib3-1.25.8-py2.py3-none-any.whl", hash = "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"},
-    {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.16.0"
+version = "0.17.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -9,9 +9,6 @@ homepage = "https://github.com/4dn-dcic/utils"
 repository = "https://github.com/4dn-dcic/utils"
 packages = [
   { include="dcicutils", from="." }
-]
-include = [
-  "nosuchfile"
 ]
 
 [tool.poetry.dependencies]
@@ -24,6 +21,7 @@ aws-requests-auth = ">=0.4.2,<1"
 urllib3 = "^1.24.3"
 structlog = "^19.2.0"
 requests = "^2.21.0"
+toml = ">=0.10.0,<1"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=4.5.0"

--- a/test/ini_files/blue.ini
+++ b/test/ini_files/blue.ini
@@ -1,0 +1,80 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-webprod-files
+file_wfout_bucket = elasticbeanstalk-fourfront-webprod-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-webprod-blobs
+system_bucket = elasticbeanstalk-fourfront-webprod-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-blue
+mirror.env.name = fourfront-green
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = fourfront-blue
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_prod_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/cg_any.ini
+++ b/test/ini_files/cg_any.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-${BS_ENV}-files
+file_wfout_bucket = elasticbeanstalk-${BS_ENV}-wfoutput
+blob_bucket = elasticbeanstalk-${BS_ENV}-blobs
+system_bucket = elasticbeanstalk-${BS_ENV}-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = ${ES_SERVER}
+snovault.app_version = ask-pip
+env.name = ${BS_ENV}
+indexer.namespace = ${ES_NAMESPACE}
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_${DATA_SET}_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/cgap.ini
+++ b/test/ini_files/cgap.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-cgap-files
+file_wfout_bucket = elasticbeanstalk-fourfront-cgap-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-cgap-blobs
+system_bucket = elasticbeanstalk-fourfront-cgap-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-cgap
+indexer.namespace = fourfront-cgap
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_prod_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/cgapdev.ini
+++ b/test/ini_files/cgapdev.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-cgapdev-files
+file_wfout_bucket = elasticbeanstalk-fourfront-cgapdev-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-cgapdev-blobs
+system_bucket = elasticbeanstalk-fourfront-cgapdev-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-cgapdev
+indexer.namespace = fourfront-cgapdev
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_test_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/cgaptest.ini
+++ b/test/ini_files/cgaptest.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-cgaptest-files
+file_wfout_bucket = elasticbeanstalk-fourfront-cgaptest-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-cgaptest-blobs
+system_bucket = elasticbeanstalk-fourfront-cgaptest-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-cgaptest
+indexer.namespace = fourfront-cgaptest
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_test_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/cgapwolf.ini
+++ b/test/ini_files/cgapwolf.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-cgapwolf-files
+file_wfout_bucket = elasticbeanstalk-fourfront-cgapwolf-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-cgapwolf-blobs
+system_bucket = elasticbeanstalk-fourfront-cgapwolf-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-cgapwolf
+indexer.namespace = fourfront-cgapwolf
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_test_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/ff_any.ini
+++ b/test/ini_files/ff_any.ini
@@ -1,0 +1,80 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-files
+file_wfout_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-wfoutput
+blob_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-blobs
+system_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = ${ES_SERVER}
+snovault.app_version = ask-pip
+env.name = ${BS_ENV}
+mirror.env.name = ${BS_MIRROR_ENV}
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = ${ES_NAMESPACE}
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_${DATA_SET}_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/green.ini
+++ b/test/ini_files/green.ini
@@ -1,0 +1,80 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-webprod-files
+file_wfout_bucket = elasticbeanstalk-fourfront-webprod-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-webprod-blobs
+system_bucket = elasticbeanstalk-fourfront-webprod-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-green-cghpezl64x4uma3etijfknh7ja.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-green
+mirror.env.name = fourfront-blue
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = fourfront-green
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_prod_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/mastertest.ini
+++ b/test/ini_files/mastertest.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-mastertest-files
+file_wfout_bucket = elasticbeanstalk-fourfront-mastertest-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-mastertest-blobs
+system_bucket = elasticbeanstalk-fourfront-mastertest-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-mastertest
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = fourfront-mastertest
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_test_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/webdev.ini
+++ b/test/ini_files/webdev.ini
@@ -1,0 +1,79 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-webdev-files
+file_wfout_bucket = elasticbeanstalk-fourfront-webdev-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-webdev-blobs
+system_bucket = elasticbeanstalk-fourfront-webdev-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-webdev
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = fourfront-webdev
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_prod_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/webprod.ini
+++ b/test/ini_files/webprod.ini
@@ -1,0 +1,80 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-webprod-files
+file_wfout_bucket = elasticbeanstalk-fourfront-webprod-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-webprod-blobs
+system_bucket = elasticbeanstalk-fourfront-webprod-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-webprod
+mirror.env.name = fourfront-webprod2
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = fourfront-webprod
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_prod_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/ini_files/webprod2.ini
+++ b/test/ini_files/webprod2.ini
@@ -1,0 +1,80 @@
+[app:app]
+use = config:base.ini#app
+session.secret = %(here)s/session-secret.b64
+file_upload_bucket = elasticbeanstalk-fourfront-webprod-files
+file_wfout_bucket = elasticbeanstalk-fourfront-webprod-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-webprod-blobs
+system_bucket = elasticbeanstalk-fourfront-webprod-system
+# blob_store_profile_name = encoded-4dn-files
+accession_factory = encoded.server_defaults.enc_accession
+indexer.processes = $(python3 -c 'import multiprocessing; print(max(1, multiprocessing.cpu_count() - 2));')
+elasticsearch.server = search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.us-east-1.es.amazonaws.com:80
+snovault.app_version = ask-pip
+env.name = fourfront-webprod2
+mirror.env.name = fourfront-webprod
+encoded_version = ${PROJECT_VERSION}
+eb_app_version = ${APP_VERSION}
+mpindexer = true
+indexer = true
+indexer.namespace = fourfront-webprod2
+elasticsearch.aws_auth = true
+production = true
+
+load_test_data = encoded.loadxl:load_prod_data
+sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+
+[composite:indexer]
+use = config:base.ini#indexer
+
+[pipeline:main]
+pipeline =
+    config:base.ini#memlimit
+    egg:PasteDeploy#prefix
+    app
+
+[pipeline:debug]
+pipeline =
+    egg:repoze.debug#pdbpm
+    app
+set pyramid.includes =
+    pyramid_translogger
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+threads = 1
+
+[loggers]
+keys = root, encoded, encoded_listener
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_encoded]
+level = WARN
+handlers = console
+qualname = encoded
+propagate = 0
+
+[logger_encoded_listener]
+level = INFO
+handlers = console
+qualname = snovault.elasticsearch.es_index_listener
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(message)s

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -1,0 +1,395 @@
+import datetime
+import os
+
+import pytest
+import re
+import subprocess
+
+from contextlib import contextmanager
+from io import StringIO
+from unittest import mock
+
+from dcicutils.deployment_utils import Deployer
+from dcicutils.misc_utils import ignored
+from dcicutils.env_utils import is_cgap_env
+
+
+_MY_DIR = os.path.dirname(__file__)
+
+
+class TestDeployer(Deployer):
+    TEMPLATE_DIR = os.path.join(_MY_DIR, "ini_files")
+    PYPROJECT_FILE_NAME = os.path.join(os.path.dirname(_MY_DIR), "pyproject.toml")
+
+
+@contextmanager
+def override_environ(**overrides):
+    to_delete = []
+    to_restore = {}
+    env = os.environ
+    try:
+        for k, v in overrides.items():
+            if k in env:
+                to_restore[k] = env[k]
+            else:
+                to_delete.append(k)
+            env[k] = v
+        yield
+    finally:
+        for k in to_delete:
+            del os.environ[k]
+        for k, v in to_restore.items():
+            os.environ[k] = v
+
+
+def test_deployment_utils_environment_template_filename():
+
+    with pytest.raises(ValueError):
+        TestDeployer.environment_template_filename('foo')
+
+    actual = os.path.abspath(TestDeployer.environment_template_filename('cgapdev'))
+
+    assert actual.endswith("/ini_files/cgapdev.ini")
+    assert os.path.exists(actual)
+
+    assert (TestDeployer.environment_template_filename('cgapdev') ==
+            TestDeployer.environment_template_filename('fourfront-cgapdev'))
+
+
+def test_deployment_utils_template_environment_names():
+
+    names = TestDeployer.template_environment_names()
+
+    required_names = ['blue', 'green', 'cgap', 'cgapdev', 'cgaptest', 'webdev', 'webprod', 'webprod2']
+
+    for required_name in required_names:
+        assert required_name in names
+
+
+MOCKED_SOURCE_BUNDLE = "/some/source/bundle"
+MOCKED_BUNDLE_VERSION = 'v-12345-bundle-version'
+MOCKED_LOCAL_GIT_VERSION = 'v-67890-git-version'
+MOCKED_PROJECT_VERSION = '11.22.33'
+
+
+def make_mocked_check_output_for_get_version(simulate_git_command=True, simulate_git_repo=True):
+    def mocked_check_output(command):
+        if simulate_git_command and command[0] == 'git':
+            assert command == ['git', 'describe', '--dirty']  # This is the only case we handle
+            if simulate_git_repo:
+                return bytes(MOCKED_LOCAL_GIT_VERSION, 'utf-8')
+            else:
+                raise subprocess.CalledProcessError(returncode=1, cmd=command)
+        else:
+            raise FileNotFoundError("Simulated absence of 'git'.")
+    return mocked_check_output
+
+
+def test_deployment_utils_build_ini_file_from_template():
+    # NOTE: This implicitly also tests build_ini_file_from_stream.
+
+    some_template_file_name = "mydir/whatever"
+    some_ini_file_name = "mydir/production.ini"
+    env_vars = dict(RDS_DB_NAME='snow_white', RDS_USERNAME='user', RDS_PASSWORD='my-secret',
+                    RDS_HOSTNAME='unittest', RDS_PORT="6543")
+
+    with override_environ(**env_vars):
+
+        for env_var in env_vars:
+            assert env_var in os.environ and os.environ[env_var] == env_vars[env_var], (
+                    "os.environ[%r] did not get added correctly" % env_var
+            )
+
+        class MockFileStream:
+
+            FILE_SYSTEM = {}
+
+            @classmethod
+            def reset(cls):
+                cls.FILE_SYSTEM = {}
+
+            def __init__(self, filename, mode):
+                assert 'w' in mode
+                self.filename = filename
+                self.output_string_stream = StringIO()
+
+            def __enter__(self):
+                return self.output_string_stream
+
+            def __exit__(self, type_, value, traceback):
+                self.FILE_SYSTEM[self.filename] = self.output_string_stream.getvalue().strip().split('\n')
+
+        def mocked_open(filename, mode='r', encoding=None):
+            assert encoding in (None, 'utf-8')
+            # In this test there are two opens, one for read and one for write, so we discriminate on that basis.
+            print("Enter mock_open", filename, mode)
+            if mode == 'r':
+                if filename == TestDeployer.EB_MANIFEST_FILENAME:
+                    print("reading mocked EB MANIFEST:", TestDeployer.EB_MANIFEST_FILENAME)
+                    return StringIO('{"Some": "Stuff", "VersionLabel": "%s", "Other": "Stuff"}\n'
+                                    % MOCKED_BUNDLE_VERSION)
+                elif filename == some_template_file_name:
+                    print("reading mocked TEMPLATE FILE", some_ini_file_name)
+                    return StringIO(
+                        '[Foo]\n'
+                        'DATABASE = "${RDS_DB_NAME}"\n'
+                        'SOME_URL = "http://${RDS_USERNAME}@$RDS_HOSTNAME:$RDS_PORT/"\n'
+                        'OOPS = "$NOT_AN_ENV_VAR"\n'
+                        'HMMM = "${NOT_AN_ENV_VAR_EITHER}"\n'
+                        'SHHH = "$RDS_PASSWORD"\n'
+                        'VERSION = "${APP_VERSION}"\n'
+                        'PROJECT_VERSION = "${PROJECT_VERSION}"\n'
+                    )
+                elif filename == TestDeployer.PYPROJECT_FILE_NAME:
+                    print("reading mocked TOML FILE", TestDeployer.PYPROJECT_FILE_NAME)
+                    return StringIO(
+                        '[something]\n'
+                        'version = "5.6.7"\n'
+                        '[tool.poetry]\n'
+                        'author = "somebody"\n'
+                        'version = "%s"\n' % MOCKED_PROJECT_VERSION
+                    )
+                else:
+                    raise AssertionError("mocked_open(%r, %r) unsupported." % (filename, mode))
+            else:
+                assert mode == 'w'
+                assert filename == some_ini_file_name
+                return MockFileStream(filename, mode)
+
+        with mock.patch("subprocess.check_output") as mock_check_output:
+            mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+            with mock.patch("os.path.exists") as mock_exists:
+                def mocked_exists(filename):
+                    return filename in [TestDeployer.EB_MANIFEST_FILENAME, some_template_file_name]
+                mock_exists.side_effect = mocked_exists
+                with mock.patch("io.open", side_effect=mocked_open):
+                    TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
+
+        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+            '[Foo]',
+            'DATABASE = "snow_white"',
+            'SOME_URL = "http://user@unittest:6543/"',
+            'OOPS = "$NOT_AN_ENV_VAR"',
+            'HMMM = "${NOT_AN_ENV_VAR_EITHER}"',
+            'SHHH = "my-secret"',
+            'VERSION = "%s"' % MOCKED_BUNDLE_VERSION,
+            'PROJECT_VERSION = "%s"' % MOCKED_PROJECT_VERSION,
+        ]
+
+        MockFileStream.reset()
+
+        with mock.patch("subprocess.check_output") as mock_check_output:
+            mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+            with mock.patch("os.path.exists") as mock_exists:
+                def mocked_exists(filename):
+                    # Important to this test: This will return False for EB_MANIFEST_FILENAME,
+                    # causing the strategy of using the version there to fall through,
+                    # so we expect to try using the git version instead.
+                    return filename in [some_template_file_name]
+                mock_exists.side_effect = mocked_exists
+                with mock.patch("io.open", side_effect=mocked_open):
+                    TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
+
+        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+            '[Foo]',
+            'DATABASE = "snow_white"',
+            'SOME_URL = "http://user@unittest:6543/"',
+            'OOPS = "$NOT_AN_ENV_VAR"',
+            'HMMM = "${NOT_AN_ENV_VAR_EITHER}"',
+            'SHHH = "my-secret"',
+            'VERSION = "%s"' % MOCKED_LOCAL_GIT_VERSION,
+            'PROJECT_VERSION = "%s"' % MOCKED_PROJECT_VERSION,
+        ]
+
+        MockFileStream.reset()
+
+        with mock.patch("subprocess.check_output") as mock_check_output:
+            mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_command=False)
+            with mock.patch("os.path.exists") as mock_exists:
+
+                def mocked_exists(filename):
+                    # Important to this test: This will return False for EB_MANIFEST_FILENAME,
+                    # causing the strategy of using the version there to fall through,
+                    # so we expect to try using the git version instead, which will also fail
+                    # because we're simulating the absence of Git.
+                    return filename in [some_template_file_name]
+
+                mock_exists.side_effect = mocked_exists
+
+                class MockDateTime:
+
+                    DATETIME = datetime.datetime
+
+                    @classmethod
+                    def now(cls):
+                        return cls.DATETIME(2001, 2, 3, 4, 55, 6)
+
+                with mock.patch("io.open", side_effect=mocked_open):
+                    with mock.patch.object(datetime, "datetime", MockDateTime()):
+                        TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
+
+        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+            '[Foo]',
+            'DATABASE = "snow_white"',
+            'SOME_URL = "http://user@unittest:6543/"',
+            'OOPS = "$NOT_AN_ENV_VAR"',
+            'HMMM = "${NOT_AN_ENV_VAR_EITHER}"',
+            'SHHH = "my-secret"',
+            'VERSION = "unknown-version-at-20010203045506000000"',  # We mocked datetime.datetime.now() to get this
+            'PROJECT_VERSION = "%s"' % MOCKED_PROJECT_VERSION,
+        ]
+
+        MockFileStream.reset()
+
+        # Uncomment this for debugging...
+        # assert False, "PASSED"
+
+
+def test_deployment_utils_get_app_version():
+
+    with mock.patch('subprocess.check_output') as mock_check_output:
+
+        with mock.patch("os.path.exists") as mock_exists:
+            mock_exists.return_value = True
+            with mock.patch("io.open") as mock_open:
+                mock_open.return_value = StringIO('{"VersionLabel": "%s"}' % MOCKED_BUNDLE_VERSION)
+                mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+                assert TestDeployer.get_app_version() == MOCKED_BUNDLE_VERSION
+
+        mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+        assert TestDeployer.get_app_version() == MOCKED_LOCAL_GIT_VERSION
+
+        # Simulate 'git' command not found.
+        mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_command=False)
+        v = TestDeployer.get_app_version()
+        assert re.match("^unknown-version-at-[0-9]+$", v)
+
+        assert not os.environ.get('EB_CONFIG_SOURCE_BUNDLE')
+        # Simulate 'git' repo not found.
+        mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_repo=False)
+        v = TestDeployer.get_app_version()
+        assert re.match("^unknown-version-at-[0-9]+$", v)
+
+
+def test_deployment_utils_get_local_git_version():
+
+    with mock.patch('subprocess.check_output') as mock_check_output:
+
+        mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+        assert TestDeployer.get_local_git_version() == MOCKED_LOCAL_GIT_VERSION
+
+        mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_command=False)
+        with pytest.raises(FileNotFoundError):
+            TestDeployer.get_local_git_version()
+
+        mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_repo=False)
+        with pytest.raises(subprocess.CalledProcessError):
+            TestDeployer.get_local_git_version()
+
+
+def test_deployment_utils_get_eb_bundled_version():
+
+    with mock.patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        with mock.patch("io.open") as mock_open:
+            mock_open.return_value = StringIO('{"VersionLabel": "%s"}' % MOCKED_BUNDLE_VERSION)
+            assert TestDeployer.get_eb_bundled_version() == MOCKED_BUNDLE_VERSION
+
+    with mock.patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = False
+        with mock.patch("io.open") as mock_open:
+            def mocked_open_error(filename, mode='r'):
+                ignored(filename, mode)
+                raise Exception("Simulated file error (file not found or permissions problem).")
+            mock_open.side_effect = mocked_open_error
+            assert TestDeployer.get_eb_bundled_version() is None
+
+
+def test_deployment_utils_transitional_equivalence():
+    """
+    We used to use separate files for each environment. This tests that the new any.ini technology,
+    with a few new environment variables, will produce the same thing.
+
+    This proves that if we set at least "ENCODED_ES_SERVER" and "ENCODED_BS_ENV" environment variables,
+    or invoke generate_ini_file adding the "--es_server" nad "--bs_env" arguments, we should get a proper
+    production.ini.
+    """
+
+    # TODO: Once this mechanism is in place, the files cgap.ini, cgapdev.ini, cgaptest.ini, and cgapwolf.ini
+    #       can either be removed (and these transitional tests removed) or transitioned to be test data.
+
+    def tester(ref_ini, bs_env, data_set, es_server, es_namespace=None):
+
+        assert ref_ini[:-4] == bs_env[10:]  # "xxx.ini" needs to match "fourfront-xxx"
+
+        es_namespace = es_namespace or bs_env
+
+        # Test of build_ini_from_template with just 2 keyword arguments explicitly supplied (bs_env, es_server),
+        # and others defaulted.
+
+        old_output = StringIO()
+        new_output = StringIO()
+
+        any_ini = os.path.join(TestDeployer.TEMPLATE_DIR, "cg_any.ini" if is_cgap_env(bs_env) else "ff_any.ini")
+
+        TestDeployer.build_ini_stream_from_template(os.path.join(TestDeployer.TEMPLATE_DIR, ref_ini), old_output)
+        TestDeployer.build_ini_stream_from_template(any_ini, new_output,
+                                                    # data_env & es_namespace are something we should be able to default
+                                                    bs_env=bs_env, es_server=es_server)
+
+        old_content = old_output.getvalue()
+        new_content = new_output.getvalue()
+        assert old_content == new_content
+
+        # Test of build_ini_from_template with all 4 keyword arguments explicitly supplied (bs_env, data_set,
+        # es_server, es_namespace), none defaulted.
+
+        old_output = StringIO()
+        new_output = StringIO()
+
+        TestDeployer.build_ini_stream_from_template(os.path.join(TestDeployer.TEMPLATE_DIR, ref_ini), old_output)
+        TestDeployer.build_ini_stream_from_template(any_ini, new_output,
+                                                    bs_env=bs_env, data_set=data_set,
+                                                    es_server=es_server, es_namespace=es_namespace)
+
+        old_content = old_output.getvalue()
+        new_content = new_output.getvalue()
+        assert old_content == new_content
+
+    with mock.patch.object(TestDeployer, "get_app_version", return_value=MOCKED_PROJECT_VERSION):
+        with mock.patch("toml.load", return_value={"tool": {"poetry": {"version": MOCKED_LOCAL_GIT_VERSION}}}):
+
+            # CGAP uses data_set='prod' for 'fourfront-cgap' and data_set='test' for all others.
+
+            tester(ref_ini="cgap.ini", bs_env="fourfront-cgap", data_set="prod",
+                   es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="cgapdev.ini", bs_env="fourfront-cgapdev", data_set="test",
+                   es_server="search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="cgaptest.ini", bs_env="fourfront-cgaptest", data_set="test",
+                   es_server="search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="cgapwolf.ini", bs_env="fourfront-cgapwolf", data_set="test",
+                   es_server="search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80")
+
+            # Fourfront uses data_set='prod' for everything but 'fourfront-mastertest', which uses data_set='test'
+
+            tester(ref_ini="webprod.ini", bs_env="fourfront-webprod", data_set="prod",
+                   es_server="search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="webprod2.ini", bs_env="fourfront-webprod2", data_set="prod",
+                   es_server="search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="blue.ini", bs_env="fourfront-blue", data_set="prod",
+                   es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="green.ini", bs_env="fourfront-green", data_set="prod",
+                   es_server="search-fourfront-green-cghpezl64x4uma3etijfknh7ja.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="webdev.ini", bs_env="fourfront-webdev", data_set="prod",
+                   es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.us-east-1.es.amazonaws.com:80")
+
+            tester(ref_ini="mastertest.ini", bs_env="fourfront-mastertest", data_set="test",
+                   es_server="search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com:80")
+

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -11,7 +11,7 @@ from dcicutils.env_utils import (
     CGAP_ENV_HOTSEAT_NEW, CGAP_ENV_STAGING_NEW, CGAP_ENV_WEBDEV_NEW, CGAP_ENV_WOLF_NEW,
     get_mirror_env_from_context, is_test_env, is_hotseat_env, guess_mirror_env, get_standard_mirror_env,
     prod_bucket_env, public_url_mappings, CGAP_PUBLIC_URLS, FF_PUBLIC_URLS, FF_PROD_BUCKET_ENV, CGAP_PROD_BUCKET_ENV,
-    infer_repo_from_env
+    infer_repo_from_env, data_set_for_env,
 )
 from unittest import mock
 
@@ -38,6 +38,28 @@ def test_prod_bucket_env():
 
     assert prod_bucket_env('fourfront-cgapdev') is None
     assert prod_bucket_env('fourfront-cgapwolf') is None
+
+
+def test_data_set_for_env():
+
+    assert data_set_for_env('fourfront-blue') == 'prod'
+    assert data_set_for_env('fourfront-green') == 'prod'
+    assert data_set_for_env('fourfront-hotseat') == 'prod'
+    assert data_set_for_env('fourfront-mastertest') == 'test'
+    assert data_set_for_env('fourfront-webdev') == 'prod'
+    assert data_set_for_env('fourfront-webprod') == 'prod'
+    assert data_set_for_env('fourfront-webprod2') == 'prod'
+
+    assert data_set_for_env('fourfront-cgap') == 'prod'
+    assert data_set_for_env('fourfront-cgapdev') == 'test'
+    assert data_set_for_env('fourfront-cgaptest') == 'test'
+    assert data_set_for_env('fourfront-cgapwolf') == 'test'
+
+    assert data_set_for_env('cgap-blue') == 'prod'
+    assert data_set_for_env('cgap-green') == 'prod'
+    assert data_set_for_env('cgap-dev') == 'test'
+    assert data_set_for_env('cgap-test') == 'test'
+    assert data_set_for_env('cgap-wolf') == 'test'
 
 
 def test_public_url_mappings():


### PR DESCRIPTION
This adds `dcicutils.deployment_utils` so that the deployment code for FF and CGAP can be shared.

In the process of moving it here, I had to make it object-oriented so that it was straightforward to override the parameters like `TEMPLATE_DIR` and `PYPROJECT_FILE_NAME`, which are now class variables and have a normal way to override by making a subclass.

As the notes at the top of `dcicutils/deployment_utils.py` mention, this is intended to be used in the following way in `fourfront/deploy/generate_production_ini.py`:
```
from dcicutils.deployment_utils import Deployer

class FourfrontDeployer(Deployer):
    _MY_DIR = os.path.dirname(__file__)
    TEMPLATE_DIR = os.path.join(_MY_DIR, "ini_files")
    PYPROJECT_FILE_NAME = os.path.join(os.path.dirname(_MY_DIR), "pyproject.toml")

def main():
    FourfrontDeployer.main()

if __name__ == '__main__':
    main()
```
`cgap_portal` would work similarly.