### PR TITLE
Fix search_metadata with 'from' parameter

### DIFF
--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -325,7 +325,9 @@ def get_search_generator(search_url, auth=None, ff_env=None, page_limit=50):
     url_params = get_url_params(search_url)
     # indexing below is needed because url params are returned in lists
     curr_from = int(url_params.get('from', ['0'])[0])  # use query 'from' or 0 if not provided
+    initial_from = curr_from
     search_limit = url_params.get('limit', ['all'])[0]  # use limit=all by default
+
     if search_limit != 'all':
         search_limit = int(search_limit)
     url_params['limit'] = [str(page_limit)]
@@ -334,7 +336,7 @@ def get_search_generator(search_url, auth=None, ff_env=None, page_limit=50):
     # stop when fewer results than the limit are returned
     last_total = None
     while last_total is None or last_total == page_limit:
-        if search_limit != 'all' and curr_from >= search_limit:
+        if search_limit != 'all' and curr_from - initial_from >= search_limit:
             break
         url_params['from'] = [str(curr_from)]  # use from to drive search pagination
         search_url = update_url_params_and_unparse(search_url, url_params)
@@ -348,8 +350,8 @@ def get_search_generator(search_url, auth=None, ff_env=None, page_limit=50):
                   'status code is %s.' % (search_url, response.status_code))
         last_total = len(search_res)
         curr_from += last_total
-        if search_limit != 'all' and curr_from > search_limit:
-            limit_diff = curr_from - search_limit
+        if search_limit != 'all' and curr_from - initial_from > search_limit:
+            limit_diff = curr_from - initial_from - search_limit
             yield search_res[:-limit_diff]
         else:
             yield search_res

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.17.0"
+version = "0.17.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -390,7 +390,7 @@ def test_search_metadata(integrated_ff, url):
     search_res_limit = ff_utils.search_metadata(url + '/search/?limit=3&type=File', key=integrated_ff['ff_key'])
     assert len(search_res_limit) == 3
     # search with a limit from a certain entry
-    search_res_from_limit = ff_utils.search_metadata(url + '/search/?type=HiglassViewConfig&from=5&limit=53', key=integrated_ff['ff_key'])
+    search_res_from_limit = ff_utils.search_metadata(url + '/search/?type=File&from=5&limit=53', key=integrated_ff['ff_key'])
     assert len(search_res_from_limit) == 53
     # search with a filter
     search_res_filt = ff_utils.search_metadata(url + '/search/?limit=3&type=File&file_type=reads',

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -389,6 +389,9 @@ def test_search_metadata(integrated_ff, url):
     # search with a limit
     search_res_limit = ff_utils.search_metadata(url + '/search/?limit=3&type=File', key=integrated_ff['ff_key'])
     assert len(search_res_limit) == 3
+    # search with a limit from a certain entry
+    search_res_from_limit = ff_utils.search_metadata(url + '/search/?type=HiglassViewConfig&from=5&limit=53', key=integrated_ff['ff_key'])
+    assert len(search_res_from_limit) == 53
     # search with a filter
     search_res_filt = ff_utils.search_metadata(url + '/search/?limit=3&type=File&file_type=reads',
                                                key=integrated_ff['ff_key'])


### PR DESCRIPTION
`ff_utils.search_metadata` did not work correctly when the url contained a `from` parameter, e.g., `ff_utils.search_metadata('/search/?type=HiglassViewConfig&from=5&limit=8', my_key).` This PR fixes that.