### PR TITLE
Make dcicutils deployer consistent with cgap/fourfront (C4-145, C4-146)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,16 @@ build:  # builds
 test:
 	pytest -vv
 
+update:  # updates dependencies
+	poetry update
+
+help:
+	@make info
+
 info:
 	@: $(info Here are some 'make' options:)
 	   $(info - Use 'make configure' to install poetry, though 'make build' will do it automatically.)
 	   $(info - Use 'make lint' to check style with flake8.)
 	   $(info - Use 'make build' to install dependencies using poetry.)
 	   $(info - Use 'make test' to run tests with the normal options we use on travis)
+	   $(info - Use 'make update' to update dependencies (and the lock file))

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -232,6 +232,13 @@ class Deployer:
                 description="Generates a product.ini file from a template appropriate for the given environment,"
                             " which defaults from the value of the ENV_NAME environment variable "
                             " and may be given with or without a 'fourfront-' prefix. ")
+            parser.add_argument("--use_any",
+                                help="whether or not to prefer the new any.ini template over a named template",
+                                action='store_true',
+                                # In order for us to change the default to True, we'd need to re-issue beanstalks
+                                # with the new environment variables. The any.ini template relies on different
+                                # variables. -kmp 29-Apr-2020
+                                default=False)
             parser.add_argument("--env",
                                 help="environment name",
                                 default=os.environ['ENV_NAME'],
@@ -263,8 +270,9 @@ class Deployer:
                                 action='store_true',
                                 default=False)
             args = parser.parse_args()
-            template_file_name = cls.environment_template_filename(args.env)
-            # template_file_name = cls.any_environment_template_filename()
+            template_file_name = (cls.any_environment_template_filename()
+                                  if args.use_any
+                                  else cls.environment_template_filename(args.env))
             ini_file_name = args.target
             # print("template_file_name=", template_file_name)
             # print("ini_file_name=", ini_file_name)

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -30,9 +30,7 @@ import sys
 import toml
 import argparse
 
-from dcicutils.env_utils import (
-    is_stg_or_prd_env, prod_bucket_env, get_standard_mirror_env, data_set_for_env, get_bucket_env, INDEXER_ENVS,
-)
+from dcicutils.env_utils import get_standard_mirror_env, data_set_for_env, get_bucket_env, INDEXER_ENVS
 from dcicutils.misc_utils import PRINT
 
 

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -100,7 +100,12 @@ class Deployer:
         except Exception:
             return 'unknown-version-at-' + datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
 
+    PARAMETERIZED_ASSIGNMENT = re.compile(r'^[ \t]*[A-Za-z][A-Za-z0-9.-_]*[ \t]*=[ \t]*[$][{]?[A-Za-z].*$')
     EMPTY_ASSIGNMENT = re.compile(r'^[ \t]*[A-Za-z][A-Za-z0-9.-_]*[ \t]*=[ \t\r\n]*$')
+
+    @classmethod
+    def omittable(cls, line, expanded_line):
+        return cls.PARAMETERIZED_ASSIGNMENT.match(line) and cls.EMPTY_ASSIGNMENT.match(expanded_line)
 
     @classmethod
     def build_ini_stream_from_template(cls, template_file_name, init_file_stream,
@@ -181,7 +186,7 @@ class Deployer:
                     # if '$' in line:
                     #     print("line=", line)
                     #     print("expanded_line=", expanded_line)
-                    if not cls.EMPTY_ASSIGNMENT.match(expanded_line):
+                    if not cls.omittable(line, expanded_line):
                         init_file_stream.write(expanded_line)
 
         finally:

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -188,6 +188,10 @@ def prod_bucket_env(envname):
     return BEANSTALK_PROD_BUCKET_ENVS.get(envname)
 
 
+def get_bucket_env(envname):
+    return prod_bucket_env(envname) if is_stg_or_prd_env(envname) else envname
+
+
 def public_url_mappings(envname):
     """
     Returns a table of the public URLs we use for the ecosystem in which the envname resides.

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ description = "Atomic file writes."
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
+version = "1.4.0"
 
 [[package]]
 category = "dev"
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.12.47"
+version = "1.12.48"
 
 [package.dependencies]
-botocore = ">=1.15.47,<1.16.0"
+botocore = ">=1.15.48,<1.16.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.15.47"
+version = "1.15.48"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -678,8 +678,8 @@ python-versions = ">=3.4,<3.7"
 
 [metadata.files]
 atomicwrites = [
-    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
-    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
@@ -694,12 +694,12 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.0.tar.gz", hash = "sha256:594ca51a10d2b3443cbac41214e12dbb2a1cd57e1a7344659849e2e20ba6a8d8"},
 ]
 boto3 = [
-    {file = "boto3-1.12.47-py2.py3-none-any.whl", hash = "sha256:7f8b822e383c0d7656488d3b6fdc3e9c42a56fab3ed1a27c2cbc65876093cb21"},
-    {file = "boto3-1.12.47.tar.gz", hash = "sha256:84daba6d2f0c8d55477ba0b8196ffa7eb7f79d9099f768ac93eb968955877a3f"},
+    {file = "boto3-1.12.48-py2.py3-none-any.whl", hash = "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"},
+    {file = "boto3-1.12.48.tar.gz", hash = "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f"},
 ]
 botocore = [
-    {file = "botocore-1.15.47-py2.py3-none-any.whl", hash = "sha256:cceeb6d2a1bbbd062ab54552ded5065a12b14e845aa35613fc91fd68312020c0"},
-    {file = "botocore-1.15.47.tar.gz", hash = "sha256:6c6e9db7a6e420431794faee111923e4627b4920d4d9d8b16e1a578a389b2283"},
+    {file = "botocore-1.15.48-py2.py3-none-any.whl", hash = "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"},
+    {file = "botocore-1.15.48.tar.gz", hash = "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81"},
 ]
 certifi = [
     {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.19.0b0"
+version = "0.19.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.18.0"
+version = "0.19.0b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/ini_files/blue.ini
+++ b/test/ini_files/blue.ini
@@ -13,12 +13,13 @@ env.name = fourfront-blue
 mirror.env.name = fourfront-green
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-blue
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/cg_any.ini
+++ b/test/ini_files/cg_any.ini
@@ -1,23 +1,25 @@
 [app:app]
 use = config:base.ini#app
 session.secret = %(here)s/session-secret.b64
-file_upload_bucket = elasticbeanstalk-${BS_ENV}-files
-file_wfout_bucket = elasticbeanstalk-${BS_ENV}-wfoutput
-blob_bucket = elasticbeanstalk-${BS_ENV}-blobs
-system_bucket = elasticbeanstalk-${BS_ENV}-system
+file_upload_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-files
+file_wfout_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-wfoutput
+blob_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-blobs
+system_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = ${ES_SERVER}
 snovault.app_version = ask-pip
 env.name = ${BS_ENV}
-indexer.namespace = ${ES_NAMESPACE}
+mirror.env.name = ${BS_MIRROR_ENV}
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
+indexer.namespace = ${ES_NAMESPACE}
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_${DATA_SET}_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/cgap.ini
+++ b/test/ini_files/cgap.ini
@@ -10,14 +10,15 @@ accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80
 snovault.app_version = ask-pip
 env.name = fourfront-cgap
-indexer.namespace = fourfront-cgap
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
+indexer.namespace = fourfront-cgap
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/cgapdev.ini
+++ b/test/ini_files/cgapdev.ini
@@ -10,14 +10,15 @@ accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80
 snovault.app_version = ask-pip
 env.name = fourfront-cgapdev
-indexer.namespace = fourfront-cgapdev
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
+indexer.namespace = fourfront-cgapdev
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_test_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/cgaptest.ini
+++ b/test/ini_files/cgaptest.ini
@@ -10,14 +10,15 @@ accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80
 snovault.app_version = ask-pip
 env.name = fourfront-cgaptest
-indexer.namespace = fourfront-cgaptest
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
+indexer.namespace = fourfront-cgaptest
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_test_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/cgapwolf.ini
+++ b/test/ini_files/cgapwolf.ini
@@ -10,14 +10,15 @@ accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80
 snovault.app_version = ask-pip
 env.name = fourfront-cgapwolf
-indexer.namespace = fourfront-cgapwolf
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
+indexer.namespace = fourfront-cgapwolf
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_test_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/ff_any.ini
+++ b/test/ini_files/ff_any.ini
@@ -13,12 +13,13 @@ env.name = ${BS_ENV}
 mirror.env.name = ${BS_MIRROR_ENV}
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = ${ES_NAMESPACE}
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_${DATA_SET}_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/green.ini
+++ b/test/ini_files/green.ini
@@ -13,12 +13,13 @@ env.name = fourfront-green
 mirror.env.name = fourfront-blue
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-green
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/hotseat.ini
+++ b/test/ini_files/hotseat.ini
@@ -1,25 +1,25 @@
 [app:app]
 use = config:base.ini#app
 session.secret = %(here)s/session-secret.b64
-file_upload_bucket = elasticbeanstalk-fourfront-mastertest-files
-file_wfout_bucket = elasticbeanstalk-fourfront-mastertest-wfoutput
-blob_bucket = elasticbeanstalk-fourfront-mastertest-blobs
-system_bucket = elasticbeanstalk-fourfront-mastertest-system
+file_upload_bucket = elasticbeanstalk-fourfront-hotseat-files
+file_wfout_bucket = elasticbeanstalk-fourfront-hotseat-wfoutput
+blob_bucket = elasticbeanstalk-fourfront-hotseat-blobs
+system_bucket = elasticbeanstalk-fourfront-hotseat-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
-elasticsearch.server = search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com:80
+elasticsearch.server = search-fourfront-hotseat-f3oxd2wjxw3h2wsxxbcmzhhd4i.us-east-1.es.amazonaws.com:80
 snovault.app_version = ask-pip
-env.name = fourfront-mastertest
+env.name = fourfront-hotseat
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
 snovault_version = ${SNOVAULT_VERSION}
 utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
-indexer.namespace = fourfront-mastertest
+indexer.namespace = fourfront-hotseat
 elasticsearch.aws_auth = true
 production = true
-load_test_data = encoded.loadxl:load_test_data
+load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 
 [composite:indexer]

--- a/test/ini_files/webdev.ini
+++ b/test/ini_files/webdev.ini
@@ -12,12 +12,13 @@ snovault.app_version = ask-pip
 env.name = fourfront-webdev
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-webdev
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/webprod.ini
+++ b/test/ini_files/webprod.ini
@@ -13,12 +13,13 @@ env.name = fourfront-webprod
 mirror.env.name = fourfront-webprod2
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-webprod
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/ini_files/webprod2.ini
+++ b/test/ini_files/webprod2.ini
@@ -13,12 +13,13 @@ env.name = fourfront-webprod2
 mirror.env.name = fourfront-webprod
 encoded_version = ${PROJECT_VERSION}
 eb_app_version = ${APP_VERSION}
+snovault_version = ${SNOVAULT_VERSION}
+utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-webprod2
 elasticsearch.aws_auth = true
 production = true
-
 load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -26,6 +26,42 @@ class TestDeployer(Deployer):
     PYPROJECT_FILE_NAME = os.path.join(os.path.dirname(_MY_DIR), "pyproject.toml")
 
 
+def test_deployment_utils_omittable():
+
+    assert not TestDeployer.omittable("foo", "foo")
+    assert not TestDeployer.omittable(" foo", " foo")
+    assert not TestDeployer.omittable("foo=", "foo=")
+    assert not TestDeployer.omittable(" foo=", " foo=")
+    assert not TestDeployer.omittable("foo =", "foo=")
+    assert not TestDeployer.omittable(" foo =", " foo=")
+    assert not TestDeployer.omittable("foo=$X", "foo=bar")
+    assert not TestDeployer.omittable(" foo=$X", " foo=$X")
+    assert not TestDeployer.omittable("foo = $X", "foo = bar")
+    assert not TestDeployer.omittable(" foo = $X", " foo = $X")
+    assert not TestDeployer.omittable("foo=${X}", "foo=bar")
+    assert not TestDeployer.omittable(" foo=${X}", " foo=${X}")
+    assert not TestDeployer.omittable("foo = ${X}", "foo = bar")
+    assert not TestDeployer.omittable(" foo = ${X}", " foo = ${X}")
+    assert TestDeployer.omittable("foo=$X", "foo=")
+    assert TestDeployer.omittable("foo=$X", "foo= ")
+    assert TestDeployer.omittable("foo=$X", "foo= ")
+    assert TestDeployer.omittable("foo=$X", "foo= \r")
+    assert TestDeployer.omittable("foo=$X", "foo= \r\n")
+    assert TestDeployer.omittable("foo=$X", "foo=   \r\n \r\n ")
+    assert TestDeployer.omittable("foo=${X}", "foo=")
+    assert TestDeployer.omittable("foo=${X}", "foo=")
+    assert TestDeployer.omittable("foo=${X}", "foo= ")
+    assert TestDeployer.omittable("foo=${X}", "foo= \r")
+    assert TestDeployer.omittable("foo=${X}", "foo= \r\n")
+    assert TestDeployer.omittable("foo=${X}", "foo=   \r\n \r\n ")
+    assert TestDeployer.omittable(" foo = $X", " foo =")
+    assert TestDeployer.omittable(" foo = $X", " foo = ")
+    assert TestDeployer.omittable(" foo = $X", " foo = ")
+    assert TestDeployer.omittable(" foo = $X", " foo = \r")
+    assert TestDeployer.omittable(" foo = $X", " foo = \r\n")
+    assert TestDeployer.omittable(" foo = $X", " foo =   \r\n \r\n ")
+
+
 def test_deployment_utils_environment_template_filename():
 
     with pytest.raises(ValueError):
@@ -457,6 +493,11 @@ def test_deployment_utils_transitional_equivalence():
     #       can either be removed (and these transitional tests removed) or transitioned to be test data.
 
     def tester(ref_ini, bs_env, data_set, es_server, es_namespace=None):
+        """
+        This common tester program checks that the any.ini does the same thing as a given ref ini,
+        given a particular set of environment variables.  It does the output to a string in both cases
+        and then compares the result.
+        """
 
         assert ref_ini[:-4] == bs_env[10:]  # "xxx.ini" needs to match "fourfront-xxx"
 

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -18,6 +18,9 @@ from dcicutils.qa_utils import override_environ
 _MY_DIR = os.path.dirname(__file__)
 
 
+class FakeDistribution:
+    version = "simulated"
+
 class TestDeployer(Deployer):
     TEMPLATE_DIR = os.path.join(_MY_DIR, "ini_files")
     PYPROJECT_FILE_NAME = os.path.join(os.path.dirname(_MY_DIR), "pyproject.toml")
@@ -48,8 +51,8 @@ def test_deployment_utils_template_environment_names():
 
 
 MOCKED_SOURCE_BUNDLE = "/some/source/bundle"
-MOCKED_BUNDLE_VERSION = 'v-12345-bundle-version'
-MOCKED_LOCAL_GIT_VERSION = 'v-67890-git-version'
+MOCKED_BUNDLE_VERSION = 'v-12345-simulated-bundle-version'
+MOCKED_LOCAL_GIT_VERSION = 'v-67890-simulated-git-version'
 MOCKED_PROJECT_VERSION = '11.22.33'
 
 
@@ -72,219 +75,158 @@ def test_deployment_utils_build_ini_file_from_template():
     NOTE: This implicitly also tests build_ini_file_from_stream.
     """
 
+    with mock.patch("pkg_resources.get_distribution", return_value=FakeDistribution()):
 
-    some_template_file_name = "mydir/whatever"
-    some_ini_file_name = "mydir/production.ini"
+        some_template_file_name = "mydir/whatever"
+        some_ini_file_name = "mydir/production.ini"
 
-    # This is our simulation of data that is coming in from ElasticBeanstalk
-    env_vars = dict(RDS_DB_NAME='snow_white', RDS_USERNAME='user', RDS_PASSWORD='my-secret',
-                    RDS_HOSTNAME='unittest', RDS_PORT="6543")
+        # This is our simulation of data that is coming in from ElasticBeanstalk
+        env_vars = dict(RDS_DB_NAME='snow_white', RDS_USERNAME='user', RDS_PASSWORD='my-secret',
+                        RDS_HOSTNAME='unittest', RDS_PORT="6543")
 
-    # Establish our environment variables
-    with override_environ(**env_vars):
+        # Establish our environment variables
+        with override_environ(**env_vars):
 
-        # Check that our abstraction is working. There is a bit of paranoia here,
-        # but since we'll be dealing with deployment configurations, the idea is to be sure
-        # we're in the land of mocking only.
-        for env_var in env_vars:
-            assert env_var in os.environ and os.environ[env_var] == env_vars[env_var], (
-                    "os.environ[%r] did not get added correctly" % env_var
-            )
+            # Check that our abstraction is working. There is a bit of paranoia here,
+            # but since we'll be dealing with deployment configurations, the idea is to be sure
+            # we're in the land of mocking only.
+            for env_var in env_vars:
+                assert env_var in os.environ and os.environ[env_var] == env_vars[env_var], (
+                        "os.environ[%r] did not get added correctly" % env_var
+                )
 
-        # NOTE: With a small amount of extra effort, this might be possible to separate into a mock_utils for
-        #       other tests to use. But it's not quite there. -kmp 27-Apr-2020
-        class MockFileStream:
-            """
-            This represents files in the file system so that other mocks can create them and we can later
-            inquire about their contents.
-            """
-
-            FILE_SYSTEM = {}  # A dictionary of files in our fake file system.
-
-            @classmethod
-            def reset(cls):
-                """Resets the fake file system to empty."""
-                cls.FILE_SYSTEM = {}
-
-            def __init__(self, filename, mode):
-                assert 'w' in mode
-                self.filename = filename
-                self.output_string_stream = StringIO()  # A string stream to use rather than a file stream.
-
-            def __enter__(self):
+            # NOTE: With a small amount of extra effort, this might be possible to separate into a mock_utils for
+            #       other tests to use. But it's not quite there. -kmp 27-Apr-2020
+            class MockFileStream:
                 """
-                When doing a mocked call to io.open, this arranges for a StringIO() object to gather file output.
+                This represents files in the file system so that other mocks can create them and we can later
+                inquire about their contents.
                 """
-                return self.output_string_stream
 
-            def __exit__(self, type_, value, traceback):
+                FILE_SYSTEM = {}  # A dictionary of files in our fake file system.
+
+                @classmethod
+                def reset(cls):
+                    """Resets the fake file system to empty."""
+                    cls.FILE_SYSTEM = {}
+
+                def __init__(self, filename, mode):
+                    assert 'w' in mode
+                    self.filename = filename
+                    self.output_string_stream = StringIO()  # A string stream to use rather than a file stream.
+
+                def __enter__(self):
+                    """
+                    When doing a mocked call to io.open, this arranges for a StringIO() object to gather file output.
+                    """
+                    return self.output_string_stream
+
+                def __exit__(self, type_, value, traceback):
+                    """
+                    What we actually store in the file system is a list of lines, not a big string,
+                    though that design choice might not stand up to scrutiny if this mock were ever reused.
+                    In the current implementation, this takes care of getting the final data out of the string stream,
+                    breaking it into lines, and storing the lines in the mock file system.
+                    """
+                    self.FILE_SYSTEM[self.filename] = self.output_string_stream.getvalue().strip().split('\n')
+
+            # NOTE: This mock_open might be simpler and more general if we just called our mock I/O to write the files.
+            #       In effect, it is pretending as if files are there which aren't, which weird because that pretense
+            #       is inside the pretense that we have a file system at all. But it will suffice for now. -kmp 27-Apr-2020
+            def mocked_open(filename, mode='r', encoding=None):
                 """
-                What we actually store in the file system is a list of lines, not a big string,
-                though that design choice might not stand up to scrutiny if this mock were ever reused.
-                In the current implementation, this takes care of getting the final data out of the string stream,
-                breaking it into lines, and storing the lines in the mock file system.
+                On read (mode=='r'), this simulates the presence of several files in an ad hoc way, not by mock file system.
+                On write, this uses StringIO and stores the output in the mock file system as a list of lines.
                 """
-                self.FILE_SYSTEM[self.filename] = self.output_string_stream.getvalue().strip().split('\n')
+                # Our mock does nothing with the encoding, but wants to make sure no one is asking us for
+                # things we might have had to do something special with.
+                assert encoding in (None, 'utf-8')
 
-        # NOTE: This mock_open might be simpler and more general if we just called our mock I/O to write the files.
-        #       In effect, it is pretending as if files are there which aren't, which weird because that pretense
-        #       is inside the pretense that we have a file system at all. But it will suffice for now. -kmp 27-Apr-2020
-        def mocked_open(filename, mode='r', encoding=None):
-            """
-            On read (mode=='r'), this simulates the presence of several files in an ad hoc way, not by mock file system.
-            On write, this uses StringIO and stores the output in the mock file system as a list of lines.
-            """
-            # Our mock does nothing with the encoding, but wants to make sure no one is asking us for
-            # things we might have had to do something special with.
-            assert encoding in (None, 'utf-8')
+                # In this test there are two opens, one for read and one for write, so we discriminate on that basis.
+                print("Enter mock_open", filename, mode)
+                if mode == 'r':
 
-            # In this test there are two opens, one for read and one for write, so we discriminate on that basis.
-            print("Enter mock_open", filename, mode)
-            if mode == 'r':
+                    if filename == TestDeployer.EB_MANIFEST_FILENAME:
 
-                if filename == TestDeployer.EB_MANIFEST_FILENAME:
+                        print("reading mocked EB MANIFEST:", TestDeployer.EB_MANIFEST_FILENAME)
+                        return StringIO('{"Some": "Stuff", "VersionLabel": "%s", "Other": "Stuff"}\n'
+                                        % MOCKED_BUNDLE_VERSION)
 
-                    print("reading mocked EB MANIFEST:", TestDeployer.EB_MANIFEST_FILENAME)
-                    return StringIO('{"Some": "Stuff", "VersionLabel": "%s", "Other": "Stuff"}\n'
-                                    % MOCKED_BUNDLE_VERSION)
+                    elif filename == some_template_file_name:
 
-                elif filename == some_template_file_name:
+                        print("reading mocked TEMPLATE FILE", some_ini_file_name)
+                        return StringIO(
+                            '[Foo]\n'
+                            'database = "${RDS_DB_NAME}"\n'
+                            'some_url = "http://${RDS_USERNAME}@$RDS_HOSTNAME:$RDS_PORT/"\n'
+                            'oops = "$NOT_AN_ENV_VAR"\n'
+                            'hmmm = "${NOT_AN_ENV_VAR_EITHER}"\n'
+                            'shhh = "$RDS_PASSWORD"\n'
+                            'version = "${APP_VERSION}"\n'
+                            'project_version = "${PROJECT_VERSION}"\n'
+                            'indexer = ${INDEXER}'
+                        )
 
-                    print("reading mocked TEMPLATE FILE", some_ini_file_name)
-                    return StringIO(
-                        '[Foo]\n'
-                        'database = "${RDS_DB_NAME}"\n'
-                        'some_url = "http://${RDS_USERNAME}@$RDS_HOSTNAME:$RDS_PORT/"\n'
-                        'oops = "$NOT_AN_ENV_VAR"\n'
-                        'hmmm = "${NOT_AN_ENV_VAR_EITHER}"\n'
-                        'shhh = "$RDS_PASSWORD"\n'
-                        'version = "${APP_VERSION}"\n'
-                        'project_version = "${PROJECT_VERSION}"\n'
-                        'indexer = ${INDEXER}'
-                    )
+                    elif filename == TestDeployer.PYPROJECT_FILE_NAME:
 
-                elif filename == TestDeployer.PYPROJECT_FILE_NAME:
+                        print("reading mocked TOML FILE", TestDeployer.PYPROJECT_FILE_NAME)
+                        return StringIO(
+                            '[something]\n'
+                            'version = "5.6.7"\n'
+                            '[tool.poetry]\n'
+                            'author = "somebody"\n'
+                            'version = "%s"\n' % MOCKED_PROJECT_VERSION
+                        )
 
-                    print("reading mocked TOML FILE", TestDeployer.PYPROJECT_FILE_NAME)
-                    return StringIO(
-                        '[something]\n'
-                        'version = "5.6.7"\n'
-                        '[tool.poetry]\n'
-                        'author = "somebody"\n'
-                        'version = "%s"\n' % MOCKED_PROJECT_VERSION
-                    )
+                    else:
+
+                        raise AssertionError("mocked_open(%r, %r) unsupported." % (filename, mode))
 
                 else:
 
-                    raise AssertionError("mocked_open(%r, %r) unsupported." % (filename, mode))
-
-            else:
-
-                assert mode == 'w'
-                assert filename == some_ini_file_name
-                return MockFileStream(filename, mode)
+                    assert mode == 'w'
+                    assert filename == some_ini_file_name
+                    return MockFileStream(filename, mode)
 
 
-        with mock.patch("subprocess.check_output") as mock_check_output:
-            mock_check_output.side_effect = make_mocked_check_output_for_get_version()
-            with mock.patch("os.path.exists") as mock_exists:
-                def mocked_exists(filename):
-                    # This cheats on the mock file system and just knows about two specific names we care about.
-                    # If we had used the mock file system to store the files, it would be a little cleaner.
-                    # But it's close enough for now. -kmp 27-Apr-2020
-                    return filename in [TestDeployer.EB_MANIFEST_FILENAME, some_template_file_name]
-                mock_exists.side_effect = mocked_exists
-                with mock.patch("io.open", side_effect=mocked_open):
-                    # Here's where we finally call the builder. Output will be a list of lines in the mock file system.
-                    TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
-
-        # The subtle thing here is that if it were a multi-line string,
-        # all the "%" substitutions would have to be on the final line, not line-by-line where needed.
-        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
-            '[Foo]',
-            'database = "snow_white"',
-            'some_url = "http://user@unittest:6543/"',
-            'oops = "$NOT_AN_ENV_VAR"',
-            'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
-            'shhh = "my-secret"',
-            'version = "%s"' % MOCKED_BUNDLE_VERSION,
-            'project_version = "%s"' % MOCKED_PROJECT_VERSION,
-        ]
-
-        MockFileStream.reset()
-
-        with mock.patch("subprocess.check_output") as mock_check_output:
-            mock_check_output.side_effect = make_mocked_check_output_for_get_version()
-            with mock.patch("os.path.exists") as mock_exists:
-                def mocked_exists(filename):
-                    # Important to this test: This will return False for EB_MANIFEST_FILENAME,
-                    # causing the strategy of using the version there to fall through,
-                    # so we expect to try using the git version instead.
-                    return filename in [some_template_file_name]
-                mock_exists.side_effect = mocked_exists
-                with mock.patch("io.open", side_effect=mocked_open):
-                    TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
-
-        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
-            '[Foo]',
-            'database = "snow_white"',
-            'some_url = "http://user@unittest:6543/"',
-            'oops = "$NOT_AN_ENV_VAR"',
-            'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
-            'shhh = "my-secret"',
-            'version = "%s"' % MOCKED_LOCAL_GIT_VERSION,  # This is the result of no manifest file existing
-            'project_version = "%s"' % MOCKED_PROJECT_VERSION,
-        ]
-
-        MockFileStream.reset()
-
-        with mock.patch("subprocess.check_output") as mock_check_output:
-            # Note that here we simulate the absence of the 'git' command, so we also can't expect a git tag
-            # as part of the version output.
-            mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_command=False)
-            with mock.patch("os.path.exists") as mock_exists:
-
-                def mocked_exists(filename):
-                    # Important to this test: This will return False for EB_MANIFEST_FILENAME,
-                    # causing the strategy of using the version there to fall through,
-                    # so we expect to try using the git version instead, which will also fail
-                    # because we're simulating the absence of Git.
-                    return filename in [some_template_file_name]
-
-                mock_exists.side_effect = mocked_exists
-
-                class MockDateTime:
-
-                    DATETIME = datetime.datetime
-
-                    @classmethod
-                    def now(cls):
-                        return cls.DATETIME(2001, 2, 3, 4, 55, 6)
-
-                with mock.patch("io.open", side_effect=mocked_open):
-                    with mock.patch.object(datetime, "datetime", MockDateTime()):
+            with mock.patch("subprocess.check_output") as mock_check_output:
+                mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+                with mock.patch("os.path.exists") as mock_exists:
+                    def mocked_exists(filename):
+                        # This cheats on the mock file system and just knows about two specific names we care about.
+                        # If we had used the mock file system to store the files, it would be a little cleaner.
+                        # But it's close enough for now. -kmp 27-Apr-2020
+                        return filename in [TestDeployer.EB_MANIFEST_FILENAME, some_template_file_name]
+                    mock_exists.side_effect = mocked_exists
+                    with mock.patch("io.open", side_effect=mocked_open):
+                        # Here's where we finally call the builder. Output will be a list of lines in the mock file system.
                         TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
 
-        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
-            '[Foo]',
-            'database = "snow_white"',
-            'some_url = "http://user@unittest:6543/"',
-            'oops = "$NOT_AN_ENV_VAR"',
-            'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
-            'shhh = "my-secret"',
-            'version = "unknown-version-at-20010203045506000000"',  # We mocked datetime.datetime.now() to get this
-            'project_version = "%s"' % MOCKED_PROJECT_VERSION,
-        ]
+            # The subtle thing here is that if it were a multi-line string,
+            # all the "%" substitutions would have to be on the final line, not line-by-line where needed.
+            assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+                '[Foo]',
+                'database = "snow_white"',
+                'some_url = "http://user@unittest:6543/"',
+                'oops = "$NOT_AN_ENV_VAR"',
+                'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
+                'shhh = "my-secret"',
+                'version = "%s"' % MOCKED_BUNDLE_VERSION,
+                'project_version = "%s"' % MOCKED_PROJECT_VERSION,
+            ]
 
-        MockFileStream.reset()
+            MockFileStream.reset()
 
-        for truth in ["TRUE", "True", "true"]:
-
-            # For this test, we check if the 'indexer' option being set correctly sets the ENCODED.INDEXER option
-            with mock.patch("os.path.exists") as mock_exists:
-                mock_exists.return_value = True
-                with mock.patch("io.open", side_effect=mocked_open):
-                    with override_environ(ENCODED_INDEXER=truth):
+            with mock.patch("subprocess.check_output") as mock_check_output:
+                mock_check_output.side_effect = make_mocked_check_output_for_get_version()
+                with mock.patch("os.path.exists") as mock_exists:
+                    def mocked_exists(filename):
+                        # Important to this test: This will return False for EB_MANIFEST_FILENAME,
+                        # causing the strategy of using the version there to fall through,
+                        # so we expect to try using the git version instead.
+                        return filename in [some_template_file_name]
+                    mock_exists.side_effect = mocked_exists
+                    with mock.patch("io.open", side_effect=mocked_open):
                         TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
 
             assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
@@ -294,21 +236,38 @@ def test_deployment_utils_build_ini_file_from_template():
                 'oops = "$NOT_AN_ENV_VAR"',
                 'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
                 'shhh = "my-secret"',
-                'version = "v-12345-bundle-version"',
-                'project_version = "11.22.33"',
-                'indexer = true',  # the value will have been canonicalized
+                'version = "%s"' % MOCKED_LOCAL_GIT_VERSION,  # This is the result of no manifest file existing
+                'project_version = "%s"' % MOCKED_PROJECT_VERSION,
             ]
 
             MockFileStream.reset()
 
-        for falsity in ["FALSE", "False", "false", "", None, "misspelling"]:
+            with mock.patch("subprocess.check_output") as mock_check_output:
+                # Note that here we simulate the absence of the 'git' command, so we also can't expect a git tag
+                # as part of the version output.
+                mock_check_output.side_effect = make_mocked_check_output_for_get_version(simulate_git_command=False)
+                with mock.patch("os.path.exists") as mock_exists:
 
-            # For this test, we check if the 'indexer' option being set correctly sets the ENCODED.INDEXER option
-            with mock.patch("os.path.exists") as mock_exists:
-                mock_exists.return_value = True
-                with mock.patch("io.open", side_effect=mocked_open):
-                    with override_environ(ENCODED_INDEXER=falsity):
-                        TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
+                    def mocked_exists(filename):
+                        # Important to this test: This will return False for EB_MANIFEST_FILENAME,
+                        # causing the strategy of using the version there to fall through,
+                        # so we expect to try using the git version instead, which will also fail
+                        # because we're simulating the absence of Git.
+                        return filename in [some_template_file_name]
+
+                    mock_exists.side_effect = mocked_exists
+
+                    class MockDateTime:
+
+                        DATETIME = datetime.datetime
+
+                        @classmethod
+                        def now(cls):
+                            return cls.DATETIME(2001, 2, 3, 4, 55, 6)
+
+                    with mock.patch("io.open", side_effect=mocked_open):
+                        with mock.patch.object(datetime, "datetime", MockDateTime()):
+                            TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
 
             assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
                 '[Foo]',
@@ -317,66 +276,111 @@ def test_deployment_utils_build_ini_file_from_template():
                 'oops = "$NOT_AN_ENV_VAR"',
                 'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
                 'shhh = "my-secret"',
-                'version = "v-12345-bundle-version"',
-                'project_version = "11.22.33"',
-                # (The 'indexer =' line will be suppressed.)
+                'version = "unknown-version-at-20010203045506000000"',  # We mocked datetime.datetime.now() to get this
+                'project_version = "%s"' % MOCKED_PROJECT_VERSION,
             ]
 
             MockFileStream.reset()
 
-        # For this test, we check if the 'indexer' option being set correctly sets the ENCODED.INDEXER option
-        with mock.patch("os.path.exists") as mock_exists:
-            mock_exists.return_value = True
-            with mock.patch("io.open", side_effect=mocked_open):
-                TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name, indexer=True)
+            for truth in ["TRUE", "True", "true"]:
 
-        assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
-            '[Foo]',
-            'database = "snow_white"',
-            'some_url = "http://user@unittest:6543/"',
-            'oops = "$NOT_AN_ENV_VAR"',
-            'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
-            'shhh = "my-secret"',
-            'version = "v-12345-bundle-version"',
-            'project_version = "11.22.33"',
-            'indexer = true',
-        ]
+                # For this test, we check if the 'indexer' option being set correctly sets the ENCODED.INDEXER option
+                with mock.patch("os.path.exists") as mock_exists:
+                    mock_exists.return_value = True
+                    with mock.patch("io.open", side_effect=mocked_open):
+                        with override_environ(ENCODED_INDEXER=truth):
+                            TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
 
-        MockFileStream.reset()
+                assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+                    '[Foo]',
+                    'database = "snow_white"',
+                    'some_url = "http://user@unittest:6543/"',
+                    'oops = "$NOT_AN_ENV_VAR"',
+                    'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
+                    'shhh = "my-secret"',
+                    'version = "%s"' % MOCKED_BUNDLE_VERSION,
+                    'project_version = "11.22.33"',
+                    'indexer = true',  # the value will have been canonicalized
+                ]
 
-        # For these next three tests, we're going to pretend we deployed with
-        # bs_name == 'fourfront-indexer' in various ways. We expect an exception to be raised.
+                MockFileStream.reset()
 
-        with pytest.raises(RuntimeError):
+            for falsity in ["FALSE", "False", "false", "", None, "misspelling"]:
+
+                # For this test, we check if the 'indexer' option being set correctly sets the ENCODED.INDEXER option
+                with mock.patch("os.path.exists") as mock_exists:
+                    mock_exists.return_value = True
+                    with mock.patch("io.open", side_effect=mocked_open):
+                        with override_environ(ENCODED_INDEXER=falsity):
+                            TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name)
+
+                assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+                    '[Foo]',
+                    'database = "snow_white"',
+                    'some_url = "http://user@unittest:6543/"',
+                    'oops = "$NOT_AN_ENV_VAR"',
+                    'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
+                    'shhh = "my-secret"',
+                    'version = "%s"' % MOCKED_BUNDLE_VERSION,
+                    'project_version = "11.22.33"',
+                    # (The 'indexer =' line will be suppressed.)
+                ]
+
+                MockFileStream.reset()
+
+            # For this test, we check if the 'indexer' option being set correctly sets the ENCODED.INDEXER option
             with mock.patch("os.path.exists") as mock_exists:
                 mock_exists.return_value = True
                 with mock.patch("io.open", side_effect=mocked_open):
-                    with override_environ(ENCODED_BS_ENV='fourfront-indexer'):
+                    TestDeployer.build_ini_file_from_template(some_template_file_name, some_ini_file_name, indexer=True)
+
+            assert MockFileStream.FILE_SYSTEM[some_ini_file_name] == [
+                '[Foo]',
+                'database = "snow_white"',
+                'some_url = "http://user@unittest:6543/"',
+                'oops = "$NOT_AN_ENV_VAR"',
+                'hmmm = "${NOT_AN_ENV_VAR_EITHER}"',
+                'shhh = "my-secret"',
+                'version = "%s"' % MOCKED_BUNDLE_VERSION,
+                'project_version = "11.22.33"',
+                'indexer = true',
+            ]
+
+            MockFileStream.reset()
+
+            # For these next three tests, we're going to pretend we deployed with
+            # bs_name == 'fourfront-indexer' in various ways. We expect an exception to be raised.
+
+            with pytest.raises(RuntimeError):
+                with mock.patch("os.path.exists") as mock_exists:
+                    mock_exists.return_value = True
+                    with mock.patch("io.open", side_effect=mocked_open):
+                        with override_environ(ENCODED_BS_ENV='fourfront-indexer'):
+                            TestDeployer.build_ini_file_from_template(some_template_file_name,
+                                                                      some_ini_file_name, indexer=True)
+
+            MockFileStream.reset()
+
+            with pytest.raises(RuntimeError):
+                with mock.patch("os.path.exists") as mock_exists:
+                    mock_exists.return_value = True
+                    with mock.patch("io.open", side_effect=mocked_open):
                         TestDeployer.build_ini_file_from_template(some_template_file_name,
-                                                                  some_ini_file_name, indexer=True)
+                                                                  some_ini_file_name,
+                                                                  bs_env='fourfront-indexer', indexer=True)
 
-        MockFileStream.reset()
+            MockFileStream.reset()
 
-        with pytest.raises(RuntimeError):
-            with mock.patch("os.path.exists") as mock_exists:
-                mock_exists.return_value = True
-                with mock.patch("io.open", side_effect=mocked_open):
-                    TestDeployer.build_ini_file_from_template(some_template_file_name,
-                                                              some_ini_file_name,
-                                                              bs_env='fourfront-indexer', indexer=True)
+            with pytest.raises(RuntimeError):
+                with mock.patch("os.path.exists") as mock_exists:
+                    mock_exists.return_value = True
+                    with mock.patch("io.open", side_effect=mocked_open):
+                        TestDeployer.build_ini_file_from_template(some_template_file_name,
+                                                                  some_ini_file_name,
+                                                                  bs_env='fourfront-indexer')
 
-        MockFileStream.reset()
-
-        with pytest.raises(RuntimeError):
-            with mock.patch("os.path.exists") as mock_exists:
-                mock_exists.return_value = True
-                with mock.patch("io.open", side_effect=mocked_open):
-                    TestDeployer.build_ini_file_from_template(some_template_file_name,
-                                                              some_ini_file_name,
-                                                              bs_env='fourfront-indexer')
-
-        # Uncomment this for debugging...
-        # assert False, "PASSED"
+            # Uncomment this for debugging...
+            # assert False, "PASSED"
 
 
 def test_deployment_utils_get_app_version():
@@ -490,40 +494,40 @@ def test_deployment_utils_transitional_equivalence():
         new_content = new_output.getvalue()
         assert old_content == new_content
 
-    with mock.patch.object(TestDeployer, "get_app_version", return_value=MOCKED_PROJECT_VERSION):
-        with mock.patch("toml.load", return_value={"tool": {"poetry": {"version": MOCKED_LOCAL_GIT_VERSION}}}):
+    with mock.patch("pkg_resources.get_distribution", return_value=FakeDistribution()):
+        with mock.patch.object(TestDeployer, "get_app_version", return_value=MOCKED_PROJECT_VERSION):
+            with mock.patch("toml.load", return_value={"tool": {"poetry": {"version": MOCKED_LOCAL_GIT_VERSION}}}):
 
-            # CGAP uses data_set='prod' for 'fourfront-cgap' and data_set='test' for all others.
+                # CGAP uses data_set='prod' for 'fourfront-cgap' and data_set='test' for all others.
 
-            tester(ref_ini="cgap.ini", bs_env="fourfront-cgap", data_set="prod",
-                   es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="cgap.ini", bs_env="fourfront-cgap", data_set="prod",
+                       es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="cgapdev.ini", bs_env="fourfront-cgapdev", data_set="test",
-                   es_server="search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="cgapdev.ini", bs_env="fourfront-cgapdev", data_set="test",
+                       es_server="search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="cgaptest.ini", bs_env="fourfront-cgaptest", data_set="test",
-                   es_server="search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="cgaptest.ini", bs_env="fourfront-cgaptest", data_set="test",
+                       es_server="search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="cgapwolf.ini", bs_env="fourfront-cgapwolf", data_set="test",
-                   es_server="search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="cgapwolf.ini", bs_env="fourfront-cgapwolf", data_set="test",
+                       es_server="search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80")
 
-            # Fourfront uses data_set='prod' for everything but 'fourfront-mastertest', which uses data_set='test'
+                # Fourfront uses data_set='prod' for everything but 'fourfront-mastertest', which uses data_set='test'
 
-            tester(ref_ini="webprod.ini", bs_env="fourfront-webprod", data_set="prod",
-                   es_server="search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="webprod.ini", bs_env="fourfront-webprod", data_set="prod",
+                       es_server="search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="webprod2.ini", bs_env="fourfront-webprod2", data_set="prod",
-                   es_server="search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="webprod2.ini", bs_env="fourfront-webprod2", data_set="prod",
+                       es_server="search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="blue.ini", bs_env="fourfront-blue", data_set="prod",
-                   es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="blue.ini", bs_env="fourfront-blue", data_set="prod",
+                       es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="green.ini", bs_env="fourfront-green", data_set="prod",
-                   es_server="search-fourfront-green-cghpezl64x4uma3etijfknh7ja.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="green.ini", bs_env="fourfront-green", data_set="prod",
+                       es_server="search-fourfront-green-cghpezl64x4uma3etijfknh7ja.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="webdev.ini", bs_env="fourfront-webdev", data_set="prod",
-                   es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.us-east-1.es.amazonaws.com:80")
+                tester(ref_ini="webdev.ini", bs_env="fourfront-webdev", data_set="prod",
+                       es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.us-east-1.es.amazonaws.com:80")
 
-            tester(ref_ini="mastertest.ini", bs_env="fourfront-mastertest", data_set="test",
-                   es_server="search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com:80")
-
+                tester(ref_ini="mastertest.ini", bs_env="fourfront-mastertest", data_set="test",
+                       es_server="search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com:80")

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -11,9 +11,33 @@ from dcicutils.env_utils import (
     CGAP_ENV_HOTSEAT_NEW, CGAP_ENV_STAGING_NEW, CGAP_ENV_WEBDEV_NEW, CGAP_ENV_WOLF_NEW,
     get_mirror_env_from_context, is_test_env, is_hotseat_env, guess_mirror_env, get_standard_mirror_env,
     prod_bucket_env, public_url_mappings, CGAP_PUBLIC_URLS, FF_PUBLIC_URLS, FF_PROD_BUCKET_ENV, CGAP_PROD_BUCKET_ENV,
-    infer_repo_from_env, data_set_for_env,
+    infer_repo_from_env, data_set_for_env, get_bucket_env
 )
 from unittest import mock
+
+
+def test_get_bucket_env():
+
+    # Fourfront tests
+
+    assert get_bucket_env('fourfront-webprod') == FF_PROD_BUCKET_ENV
+    assert get_bucket_env('fourfront-webprod2') == FF_PROD_BUCKET_ENV
+
+    assert get_bucket_env('fourfront-blue') == FF_PROD_BUCKET_ENV
+    assert get_bucket_env('fourfront-green') == FF_PROD_BUCKET_ENV
+
+    assert get_bucket_env('fourfront-mastertest') == 'fourfront-mastertest'
+    assert get_bucket_env('fourfront-webdev') == 'fourfront-webdev'
+
+    # CGAP tests
+
+    assert get_bucket_env('fourfront-cgap') == CGAP_PROD_BUCKET_ENV
+
+    assert get_bucket_env('fourfront-cgap-blue') == CGAP_PROD_BUCKET_ENV
+    assert get_bucket_env('fourfront-cgap-green') == CGAP_PROD_BUCKET_ENV
+
+    assert get_bucket_env('fourfront-cgapdev') == 'fourfront-cgapdev'
+    assert get_bucket_env('fourfront-cgapwolf') == 'fourfront-cgapwolf'
 
 
 def test_prod_bucket_env():


### PR DESCRIPTION
This is an implementation of code to solve two problems:
* Consolidate deployer code of cgap-portal and fourfront. (That work had begun but there was more that needed to happen.)
* Propagate logic related to deploying an indexer.

There are a number of small changes here that are the result of leveling code between the three codebases. (The cgap-portal and fourfront versions of that code will go away soon, but for now it's a three-way thing until we're ready to remove it.)

There's a biggish change to the testing, which is mostly to mock pkg_resources, which required reindenting a large swath.

This adds support for keeping track of `SNOVAULT_VERSION` and `UTILS_VERSION`. (Those things look funny here (which doesn't use snovault or utils) but it's because the `ini_files` that are used here are copies of what is used in those other repos, where the version is actually loaded. The versions here are only for testing, and I had to mock the `pkg_resources` for them.)

I added a function called `dcicutils.env_utils.get_bucket_env`, and tests for it.