### PR TITLE
Support for declaring indexer and index_server (C4-58, C4-146)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.19.0"
+version = "0.20.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/ini_files/blue.ini
+++ b/test/ini_files/blue.ini
@@ -18,6 +18,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-blue
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data

--- a/test/ini_files/cg_any.ini
+++ b/test/ini_files/cg_any.ini
@@ -18,6 +18,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = ${ES_NAMESPACE}
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_${DATA_SET}_data

--- a/test/ini_files/cgap.ini
+++ b/test/ini_files/cgap.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-cgap
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data

--- a/test/ini_files/cgapdev.ini
+++ b/test/ini_files/cgapdev.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-cgapdev
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_test_data

--- a/test/ini_files/cgaptest.ini
+++ b/test/ini_files/cgaptest.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-cgaptest
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_test_data

--- a/test/ini_files/cgapwolf.ini
+++ b/test/ini_files/cgapwolf.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-cgapwolf
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_test_data

--- a/test/ini_files/ff_any.ini
+++ b/test/ini_files/ff_any.ini
@@ -18,6 +18,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = ${ES_NAMESPACE}
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_${DATA_SET}_data

--- a/test/ini_files/green.ini
+++ b/test/ini_files/green.ini
@@ -18,6 +18,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-green
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data

--- a/test/ini_files/hotseat.ini
+++ b/test/ini_files/hotseat.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-hotseat
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data

--- a/test/ini_files/mastertest.ini
+++ b/test/ini_files/mastertest.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-mastertest
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_test_data

--- a/test/ini_files/webdev.ini
+++ b/test/ini_files/webdev.ini
@@ -17,6 +17,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-webdev
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data

--- a/test/ini_files/webprod.ini
+++ b/test/ini_files/webprod.ini
@@ -18,6 +18,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-webprod
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data

--- a/test/ini_files/webprod2.ini
+++ b/test/ini_files/webprod2.ini
@@ -18,6 +18,7 @@ utils_version = ${UTILS_VERSION}
 mpindexer = true
 indexer = ${INDEXER}
 indexer.namespace = fourfront-webprod2
+index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
 load_test_data = encoded.loadxl:load_prod_data


### PR DESCRIPTION
This add better logic for declaring that a beanstalk is an "indexer" and/or "index server".
<table><tr><th>Indexer<br/>(default True<br />if missing)</th><th>Index Server<br />(default False<br />if missing)</th><th>Meaning</th></tr>
<tr><td>False</td><td>False</td><td>Offers real-time service to UI clients only, no indexing</td></tr>
<tr><td>True</td><td>False</td><td>Offers both indexing and UI client service (hybrid)</td></tr>
<tr><td>True</td><td>True</td><td>Acts as an indexer only, no UI client service</td></tr>
</table>

These values can be set up in various ways:
<table><tr><th>Attribute</th><th>Beanstalk Environment Variable</th><th>.ini template</th><th>generate_production_ini arg</th></tr><tr>
<td>Indexer</td><td><tt>ENCODED_INDEXER</tt></td><td><tt>INDEXER</tt></td><td><tt>--indexer</tt></tr>
<tr><td>Index Server</td><td><tt>ENCODED_INDEX_SERVER</tt></td><td><tt>INDEX_SERVER</tt></td><td><tt>--index_server</tt></tr>
</table>
Note that in the case of `generate_production_ini`, you give an argument of the string value.

Other changes in this PR:

* Minor version bump for new functionality
* Fixes to unit tests (really integration tests) that were broken by data variance on `mastertest`.
