### PR TITLE
Support for 'make publish' (C4-150)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ test:
 update:  # updates dependencies
 	poetry update
 
+publish:
+	scripts/publish
+
 help:
 	@make info
 
@@ -24,5 +27,6 @@ info:
 	   $(info - Use 'make configure' to install poetry, though 'make build' will do it automatically.)
 	   $(info - Use 'make lint' to check style with flake8.)
 	   $(info - Use 'make build' to install dependencies using poetry.)
+	   $(info - Use 'make publish' to publish this library, but only if auto-publishing has failed.)
 	   $(info - Use 'make test' to run tests with the normal options we use on travis)
 	   $(info - Use 'make update' to update dependencies (and the lock file))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.20.0"
+version = "0.20.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if [ -z "$PYPI_USER" ]; then
+    echo '$PYPI_USER is not set.'
+    exit 1
+fi    
+
+if [ -z "$PYPI_PASSWORD" ]; then
+    echo '$PYPI_PASSWORD is not set.'
+    exit 1    
+fi
+
+changes=`git diff`
+
+if [ -n "${changes}" ]; then
+  echo "You have made changes to this branch that you have not committed."
+  exit 1
+fi
+
+staged_changes=`git diff --staged`
+
+if [ -n "${staged_changes}" ]; then
+  echo "You have staged changes to this branch that you have not committed."
+  exit 1
+fi
+
+tagged=`git log -1 --decorate | head -1 | grep 'tag:'`
+
+if [ -z "$tagged" ]; then
+  # We don't encourage people to tag it unless they have no changes pending.
+  echo "You can only publish a tagged commit."
+  exit 1
+fi
+
+read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+then
+  echo "Publishing aborted."
+  exit 1
+fi
+
+poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD


### PR DESCRIPTION
Following up on the auto-publishing problem described in [C4-150](https://hms-dbmi.atlassian.net/browse/C4-150), this adds a manual workaround to the publication problem.

* `scripts/publish` is the same script as `[python_lambda]bin/publish`, which was written in a way that can be run from any directory containing poetry information in `pyproject.toml`.
* `Makefile` adds a `make` target that will call the script.
* Bumping the patch version only because this is visible only to maintainers of this library, not to users, and is really a kind of bug fix.