### PR TITLE
Misc clarifications in deployment_utils

### DIFF
--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -18,20 +18,45 @@ For example, fourfront/deploy/generate_production_ini.py might contain:
 
 """
 
+import argparse
 import datetime
 import glob
 import io
 import json
+import logging
 import os
 import pkg_resources
 import re
 import subprocess
 import sys
 import toml
-import argparse
 
-from dcicutils.env_utils import get_standard_mirror_env, data_set_for_env, get_bucket_env, INDEXER_ENVS
-from dcicutils.misc_utils import PRINT
+from .env_utils import get_standard_mirror_env, data_set_for_env, get_bucket_env, INDEXER_ENVS
+from .misc_utils import PRINT
+
+
+def boolean_setting(settings, key, default=None):
+    """
+    Given a setting from a .ini file and returns a boolean interpretation of it.
+    - Treats an actual python boolean as itself
+    - Using case-insensitive comparison, treats the string 'true' as True and both 'false' and '' as False.
+    - If an element is missing,
+    - Treats None the same as the option being missing, so returns the given default.
+    - Raises an error for any non-standard value. This is harsh, but it should not happen.
+    """
+    if key not in settings:
+        return default
+    setting = settings[key]
+    if isinstance(setting, str):
+        setting_lower = setting.lower()
+        if setting_lower in ("", "false"):
+            return False
+        elif setting_lower == "true":
+            return True
+        else:
+            return setting
+    else:  # booleans, None, and odd types (though we might want to consider making other types an error).
+        return setting
 
 
 class Deployer:
@@ -287,11 +312,12 @@ class Deployer:
                                 help="an ElasticSearch namespace",
                                 default=None)
             parser.add_argument("--indexer",
-                                help="whether this system does indexing",
-                                action='store_true',
-                                default=False)
+                                help="whether this server does indexing at all",
+                                choices=["true", "false"],
+                                default=None)
             parser.add_argument("--index_server",
-                                help="whether this is a standalone indexing server",
+                                help="whether this is a standalone indexing server, only doing indexing",
+                                choices=["true", "false"],
                                 default=None)
             args = parser.parse_args()
             template_file_name = (cls.any_environment_template_filename()

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -23,7 +23,6 @@ import datetime
 import glob
 import io
 import json
-import logging
 import os
 import pkg_resources
 import re

--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -1,5 +1,7 @@
-from .misc_utils import ignored
+import datetime
 import re
+
+from .misc_utils import ignored
 
 
 class EnglishUtils:
@@ -49,6 +51,12 @@ class EnglishUtils:
 
     @classmethod
     def string_pluralize(cls, word: str) -> str:
+        """
+        Returns the probable plural of the given word.
+        This is an ad hoc string pluralizer intended for situations where being mostly right is good enough.
+        e.g., string_pluralize('sample') => 'sample'
+              string_pluralize('community') => 'communities'
+        """
         charn = word[-1]
         char1 = word[0]
         capitalize = char1.isupper()
@@ -92,15 +100,31 @@ class EnglishUtils:
 
     @classmethod
     def select_a_or_an(cls, word):
+        """
+        Uses a heuristic to try to select the appropriate article ('a' or 'an') for a given English noun.
+        select_a_or_an("gene") => 'a'
+        select_a_or_an("accession") => 'an'
+        """
+
         return "a" if cls._PREFIX_PATTERN_FOR_A.match(word) else "an"
 
     @classmethod
     def a_or_an(cls, word):
+        """
+        Heuristically attaches either "a" or "an" to a given English noun.
+        a_or_an("gene") => "a gene"
+        a_or_an("accession") => "an accession"
+        """
         article = cls.select_a_or_an(word)
         return "%s %s" % (article, word)
 
     @classmethod
     def n_of(cls, n, thing, num_format=None):
+        """
+        Given a number and a noun, returns the name for that many of that noun.
+        e.g., n_of(7, "variant") => "7 variants"
+              n_of(1, "accession") => "1 accession"
+        """
         display_n = n
         if num_format:
             res = num_format(n, thing)
@@ -118,7 +142,13 @@ class EnglishUtils:
 
     @classmethod
     def relative_time_string(cls, seconds, detailed=True):
+        """
+        Given a number of seconds, expresses that number of seconds in English.
+        The seconds can be expressed either as a number or a datetime.timedelta.
+        """
         result = []
+        if isinstance(seconds, datetime.timedelta):
+            seconds = seconds.total_seconds()
         remaining_seconds = seconds
         units_seen = False
         for unit_info in cls._TIME_UNITS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.21.0"
+version = "0.22.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -688,12 +688,19 @@ def test_deployment_utils_transitional_equivalence():
 
 def test_deployment_utils_main():
 
-    fake_template = "something.ini"
+    # This is just a standard unit test that mocks out all the callouts and tests that the arguments are coming
+    # in and being passed along correctly to the underlying program.
+
+    fake_template = "something.ini"  # It doesn't matter what we use as a template for this test. we don't open it.
     with override_environ(ENV_NAME='fourfront-foo'):
         with mock.patch.object(Deployer, "build_ini_file_from_template") as mock_build:
+            # These next two mocks are just incidental to offering help in arg parsing.
+            # Those functions are tested elsewhere and are just plain bypassed here.
             with mock.patch.object(Deployer, "environment_template_filename", return_value=fake_template):
                 with mock.patch.object(Deployer, "template_environment_names", return_value=["something, foo"]):
 
+                    # This function is the core fo the testing, which just sets up a deployer to get called
+                    # with an input template name and a target filename, and then calls the Deployer.
                     def check_for_mocked_build(expected_kwargs=None, expected_code=0):
                         def mocked_build(*args, **kwargs):
                             assert args == (fake_template, 'production.ini')
@@ -704,6 +711,11 @@ def test_deployment_utils_main():
                         except SystemExit as e:
                             assert e.code == expected_code
 
+                    # sys.argv gets as its first element the command name, and the rest is command line args.
+                    # The '' is just an ignored command name, so [''] is no args. Command line args start with arg 1.
+
+                    # This tests that when given no command line args, all the kwargs passed through
+                    # to build_ini_file_from_template default to None.
                     with mock.patch.object(sys, "argv", ['']):
                         check_for_mocked_build({
                             'bs_env': None,
@@ -715,6 +727,9 @@ def test_deployment_utils_main():
                             'indexer': None,
                             's3_bucket_env': None
                         })
+
+                    # Next 2 tests some sample settings, in particular the settings of indexer and index_server
+                    # when given on the command line, and what gets passed through to build_ini_file_from_template.
 
                     with mock.patch.object(sys, "argv", ['', '--indexer', 'false', '--index_server', 'true']):
                         check_for_mocked_build({

--- a/test/test_lang_utils.py
+++ b/test/test_lang_utils.py
@@ -1,3 +1,5 @@
+import datetime
+
 from dcicutils.lang_utils import EnglishUtils, a_or_an, select_a_or_an, string_pluralize
 
 
@@ -91,6 +93,12 @@ def test_relative_time_string():
     test(2 * WEEK + 3 * HOUR + 2 * MINUTE + 3 * SECOND, "2 weeks, 3 hours, 2 minutes, 3 seconds", "2 weeks")
     test(4 * DAY + 1 * HOUR + 5.2 * SECOND, "4 days, 1 hour, 5.2 seconds", "4 days, 1 hour")
     test(5.2 * SECOND, "5.2 seconds", "5.2 seconds")
+
+    relative_time = datetime.timedelta(hours=1, seconds=3)
+    test(relative_time, "1 hour, 3 seconds", "1 hour")
+    t1 = datetime.datetime.now()
+    t2 = t1 + relative_time
+    test(t2 - t1, "1 hour, 3 seconds", "1 hour")
 
 
 def test_time_count_formatter():


### PR DESCRIPTION
The main purposes of this PR are these:

* Fix a bug in the defaulting of the `indexer` value in the `main` program, which was defaulting to `False` (which in turn hides the environment value of `True` that was trying to get through). I changed the default to None from False.  The logic to turn an unspecified value to False happens elsewhere already.

* Add an accessor `dcicutils.deployment_utils.boolean_setting` which can be used to recover a boolean from settings that have `"true"` and `"false"` values floating around.

* Added unit tests.

Opportunistic:

* I added some function documention some of the new `lang_utils` functions and changed `relative_time_string` to allow it to take a `datetime.timedelta` as an argument. (It's easier to see such needs when writing doc.)