### PR TITLE
Add qa_utils.ControlledTime

### DIFF
--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -177,10 +177,14 @@ class EnglishUtils:
         return result
 
 
-select_a_or_an = EnglishUtils.select_a_or_an
+# Export specific useful functions
 
 a_or_an = EnglishUtils.a_or_an
 
-string_pluralize = EnglishUtils.string_pluralize
+n_of = EnglishUtils.n_of
 
 relative_time_string = EnglishUtils.relative_time_string
+
+select_a_or_an = EnglishUtils.select_a_or_an
+
+string_pluralize = EnglishUtils.string_pluralize

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -111,6 +111,8 @@ class ControlledTime:  # This will move to dcicutils -kmp 7-May-2020
                  local_timezone: pytz.timezone = HMS_TIMEZONE):
         if not isinstance(initial_time, datetime.datetime):
             raise ValueError("Expected initial_time to be a datetime: %r" % initial_time)
+        if initial_time.tzinfo is not None:
+            raise ValueError("Expected initial_time to be a naive datetime (no timezone): %r" % initial_time)
         if not isinstance(tick_seconds, (int, float)):
             raise ValueError("Expected tick_seconds to be an int or a float: %r" % tick_seconds)
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -80,6 +80,27 @@ def override_environ(**overrides):
 
 
 class ControlledTime:  # This will move to dcicutils -kmp 7-May-2020
+    """
+    This class can be used in mocking datetime.datetime for things that do certain time-related actions.
+    Everytime datetime.now() is called, time increments by a known amount (default 1 second). So:
+
+        start_time = datetime.datetime.now()
+
+        def sleepy_function():
+            time.sleep(10)
+
+        dt = ControlledTime()
+        with unittest.mock.patch("datetime.datetime", dt):
+            with unittest.mock.patch("time.sleep", dt.sleep):
+                t0 = datetime.datetime.now()
+                sleepy_function()  # sleeps 10 seconds
+                t1 = datetime.datetime.now()  # 1 more second increments
+                assert (t1 - t0).total_seconds() == 11  # 11 virtual seconds have passed
+
+        end_time = datetime.datetime.now()
+        # In reality, whole test takes much less than one second...
+        assert (end_time - start_time).total_seconds() < 0.5
+    """
 
     # A randomly chosen but reproducible date 2010-07-01 12:00:00
     INITIAL_TIME = datetime.datetime(2010, 1, 1, 12, 0, 0)
@@ -99,6 +120,9 @@ class ControlledTime:  # This will move to dcicutils -kmp 7-May-2020
         self._local_timezone = local_timezone
 
     def set_datetime(self, dt):
+        """
+        Sets the virtual clock time to the given value, which must be a regular datetime object.
+        """
         if not isinstance(dt, datetime.datetime):
             raise ValueError("Expected a datetime: %r" % dt)
         if dt.tzinfo:
@@ -106,18 +130,50 @@ class ControlledTime:  # This will move to dcicutils -kmp 7-May-2020
         self._just_now = dt
 
     def reset_datetime(self):
+        """
+        Resets the virtual clock time to the original datetime that it had on creation.
+        """
         self.set_datetime(self._initial_time)
 
     def just_now(self) -> datetime.datetime:
+        """
+        This is like .now() but it doesn't increment the virtual clock,
+        it just tells you the previously known virtual clock time.
+        """
         return self._just_now
 
     def now(self) -> datetime.datetime:
+        """
+        This advances time by one tick and returns the new time.
+
+        To re-read the same time without advancing the clock, use .just_now() instead of .now().
+
+        The tick duration is controlled by the tick_seconds initialization argument to ControlledTime.
+
+        Note that neither .now() nor .utcnow() yields a time with a timezone,
+        though the normal conversion operations are available on the times it does yield.
+        It is assumed that .now() returns time in the Harvard Medical School timezone, US/Eastern
+        unless a different local_timezone was specified when creating the ControlledTime.
+        """
         self._just_now += self._tick_timedelta
         return self._just_now
 
     def utcnow(self) -> datetime.datetime:
+        """
+        This tells you what the virtual clock time would be in UTC.
+        This works by adjusting for the difference in hours between the local timezone and UTC.
+
+        Note that neither .now() nor .utcnow() yields a time with a timezone,
+        though the normal conversion operations are available on the times it does yield.
+        It is assumed that .now() returns time in the Harvard Medical School timezone, US/Eastern
+        unless a different local_timezone was specified when creating the ControlledTime.
+        """
         now = self.now()
         return self._local_timezone.localize(now).astimezone(pytz.UTC).replace(tzinfo=None)
 
     def sleep(self, secs: float):
+        """
+        This simulates sleep by advancing the virtual clock time by the indicated number of seconds.
+        """
+
         self._just_now += datetime.timedelta(seconds=secs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.12.48"
+version = "1.13.4"
 
 [package.dependencies]
-botocore = ">=1.15.48,<1.16.0"
+botocore = ">=1.16.4,<1.17.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.15.48"
+version = "1.16.4"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -480,6 +480,14 @@ six = ">=1.5"
 
 [[package]]
 category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2020.1"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -673,7 +681,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "54f0dfe07783f74fdccacd1ff65649cdfea9eb5f6aa8a1c1bd2aed262cf0db04"
+content-hash = "cfbfa8a4e0ed192f0b47cdb5e8623c1a2b07cc75e5d6c4267cc3318fb885eec7"
 python-versions = ">=3.4,<3.7"
 
 [metadata.files]
@@ -694,12 +702,12 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.0.tar.gz", hash = "sha256:594ca51a10d2b3443cbac41214e12dbb2a1cd57e1a7344659849e2e20ba6a8d8"},
 ]
 boto3 = [
-    {file = "boto3-1.12.48-py2.py3-none-any.whl", hash = "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"},
-    {file = "boto3-1.12.48.tar.gz", hash = "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f"},
+    {file = "boto3-1.13.4-py2.py3-none-any.whl", hash = "sha256:69d2f78d3f9915fc789001d634d14fd05be5125f8f454a9e891ddfb98f3e2d11"},
+    {file = "boto3-1.13.4.tar.gz", hash = "sha256:33b6a07f9ca3d979543eeb70ad08eb1949a9767901569c10309da46b8520c952"},
 ]
 botocore = [
-    {file = "botocore-1.15.48-py2.py3-none-any.whl", hash = "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"},
-    {file = "botocore-1.15.48.tar.gz", hash = "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81"},
+    {file = "botocore-1.16.4-py2.py3-none-any.whl", hash = "sha256:62e5ad459ffb3fbc32e1d871b91790ba403cef3ed17307a43be2d79ac993b960"},
+    {file = "botocore-1.16.4.tar.gz", hash = "sha256:c97721df7aa738538569ef27b41c68a254582bfde67b199b4909d9d42a269422"},
 ]
 certifi = [
     {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
@@ -878,6 +886,10 @@ pytest-runner = [
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+pytz = [
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 requests = [
     {file = "requests-2.21.0-py2.py3-none-any.whl", hash = "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.13.4"
+version = "1.12.48"
 
 [package.dependencies]
-botocore = ">=1.16.4,<1.17.0"
+botocore = ">=1.15.48,<1.16.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.16.4"
+version = "1.15.48"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -702,12 +702,12 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.0.tar.gz", hash = "sha256:594ca51a10d2b3443cbac41214e12dbb2a1cd57e1a7344659849e2e20ba6a8d8"},
 ]
 boto3 = [
-    {file = "boto3-1.13.4-py2.py3-none-any.whl", hash = "sha256:69d2f78d3f9915fc789001d634d14fd05be5125f8f454a9e891ddfb98f3e2d11"},
-    {file = "boto3-1.13.4.tar.gz", hash = "sha256:33b6a07f9ca3d979543eeb70ad08eb1949a9767901569c10309da46b8520c952"},
+    {file = "boto3-1.12.48-py2.py3-none-any.whl", hash = "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"},
+    {file = "boto3-1.12.48.tar.gz", hash = "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f"},
 ]
 botocore = [
-    {file = "botocore-1.16.4-py2.py3-none-any.whl", hash = "sha256:62e5ad459ffb3fbc32e1d871b91790ba403cef3ed17307a43be2d79ac993b960"},
-    {file = "botocore-1.16.4.tar.gz", hash = "sha256:c97721df7aa738538569ef27b41c68a254582bfde67b199b4909d9d42a269422"},
+    {file = "botocore-1.15.48-py2.py3-none-any.whl", hash = "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"},
+    {file = "botocore-1.15.48.tar.gz", hash = "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81"},
 ]
 certifi = [
     {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.23.0"
+version = "0.24.0b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -12,16 +12,17 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.4,<3.7"
+aws-requests-auth = ">=0.4.2,<1"
 boto3 = "^1.10.46"
 botocore = "^1.13.46"
 # TODO: elasticsearch is on version 7. -kmp 15-Feb-2020
 elasticsearch = "^5.5.3"
-aws-requests-auth = ">=0.4.2,<1"
-urllib3 = "^1.24.3"
-structlog = "^19.2.0"
+python = ">=3.4,<3.7"
+pytz = ">=2016.4"
 requests = "^2.21.0"
+structlog = "^19.2.0"
 toml = ">=0.10.0,<1"
+urllib3 = "^1.24.3"
 webtest = "^2.0.34"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.24.0b0"
+version = "0.24.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -12,18 +12,18 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-aws-requests-auth = ">=0.4.2,<1"
+python = ">=3.4,<3.7"
 boto3 = "^1.10.46"
 botocore = "^1.13.46"
 # TODO: elasticsearch is on version 7. -kmp 15-Feb-2020
 elasticsearch = "^5.5.3"
-python = ">=3.4,<3.7"
-pytz = ">=2016.4"
-requests = "^2.21.0"
-structlog = "^19.2.0"
-toml = ">=0.10.0,<1"
+aws-requests-auth = ">=0.4.2,<1"
 urllib3 = "^1.24.3"
+structlog = "^19.2.0"
+requests = "^2.21.0"
+toml = ">=0.10.0,<1"
 webtest = "^2.0.34"
+pytz = ">=2016.4"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=4.5.0"

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -197,6 +197,22 @@ def test_override_environ():
     assert unique_prop3 not in os.environ
 
 
+def test_controlled_time_creation():
+
+    t = ControlledTime()
+
+    assert t.just_now() == t.INITIAL_TIME
+
+    with pytest.raises(ValueError):  # expecting a datetime
+        ControlledTime(initial_time=1)  # noqa
+
+    with pytest.raises(ValueError):  # expecting the datetime has no timezone
+        ControlledTime(initial_time=datetime.datetime(2019, 1, 1, tzinfo=pytz.UTC))
+
+    with pytest.raises(ValueError):  # expecting an int or float
+        ControlledTime(tick_seconds="whatever")  # noqa
+
+
 def test_controlled_time_just_now():
 
     t = ControlledTime()


### PR DESCRIPTION
This is functionality useful for testing. A worked example will show up in snovault shortly, but the unit tests should give some hint of how this works. Basically these are useful for mocking `datetime.datetime.now()`, `datetime.datetime.utcnow()`, and `time.sleep()`.