### PR TITLE
Helping avoid unforced errors

### DIFF
--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -344,4 +344,4 @@ class Deployer:
 
 
 if __name__ == "__main__":
-    Deployer.main()
+    Deployer.main()  # noqa - this is just for debugging

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -6,7 +6,7 @@ import datetime
 import contextlib
 import os
 import pytz
-from .misc_utils import PRINT
+from .misc_utils import PRINT, ignored
 
 
 def mock_not_called(name):
@@ -179,3 +179,39 @@ class ControlledTime:  # This will move to dcicutils -kmp 7-May-2020
         """
 
         self._just_now += datetime.timedelta(seconds=secs)
+
+
+def notice_pytest_fixtures(*fixtures):
+    """
+    This declares its arguments to be pytest fixtures in use by surrounding code.
+
+    This useful for assuring tools like flake8 and PyCharm that the arguments it is given are not being
+    ignored but instead may just have usage patterns that don't make uses apparent.
+
+    For example, in a file test_file.py, we might see uses of my_fixture and my_autoused_fixture
+    that wrongly appear both globally unused AND also locally unused in the test_something function.
+
+      from module_a import foo, bar
+      from module_b import mock_application  # <-- sample fixture, to be used explicitly
+      from module_c import mock_database     # <-- sample fixture to be used implicitly
+
+      def test_something(mock_application):  # <-- sample of fixture used explicitly
+          assert foo() = bar()
+
+    In both cases, the apparently unused variables may cause flake8, PyCharm, and other
+    'lint' programs to complain that some repair action is needed, such as removing the unused
+    variables, even though such an action might break code. Using this declaration will
+    guard against that, while providing useful documentation for the code:
+
+      from module_a import foo, bar
+      from module_b import mock_application
+      from module_c import mock_database
+      from dcicutils.qa_utils import notice_pytest_fixtures
+
+      notice_pytest_fixtures(application, database_session)
+
+      def test_something(mock_application):
+          notice_pytest_fixtures(mock_application)  # <-- protects bound variable from seeming unused
+          assert foo() = bar()
+    """
+    ignored(fixtures)  # we don't use the given fixtures, but now the tools will think we do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.24.0"
+version = "0.25.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/fixtures/sample_fixtures.py
+++ b/test/fixtures/sample_fixtures.py
@@ -1,0 +1,25 @@
+import pytest
+
+from unittest import mock
+
+
+class MockMathError(Exception):
+    pass
+
+
+class MockMath:
+
+    MATH_ENABLED = False
+
+    @classmethod
+    def add(cls, x, y):
+        if cls.MATH_ENABLED:
+            return x + y
+        else:
+            raise MockMathError("Math is not enabled.")
+
+
+@pytest.yield_fixture()
+def math_enabled():
+    with mock.patch.object(MockMath, "MATH_ENABLED", True):
+        yield

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -2,7 +2,10 @@ import io
 import json
 import os
 import webtest
-from dcicutils.misc_utils import PRINT, ignored, get_setting_from_context, VirtualApp, _VirtualAppHelper
+from dcicutils.misc_utils import (
+    PRINT, ignored, get_setting_from_context, VirtualApp,
+    _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
+)
 from unittest import mock
 
 
@@ -17,10 +20,8 @@ def test_uppercase_print():
 
 
 def test_ignored():
-
     def foo(x, y):
         ignored(x, y)
-
     # Check that no error occurs for having used this.
     assert foo(3, 4) is None
 
@@ -47,13 +48,13 @@ def test_get_setting_from_context():
     with mock.patch.object(os, "environ", {'PIE_FLAVOR': 'cherry', 'PIE_COLOR': 'red'}):
 
         assert get_setting_from_context(sample_settings, ini_var='pie.flavor') == 'cherry'
-        assert get_setting_from_context(sample_settings, ini_var='pie.color') is 'red'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color') == 'red'
 
         # Note that env_var=None means 'use default', not 'no env var'. You'd want env_var=False for 'no env var'.
         assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=None) == 'cherry'
-        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None) is 'red'
+        assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=None) == 'red'
 
-        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=False) is 'apple'
+        assert get_setting_from_context(sample_settings, ini_var='pie.flavor', env_var=False) == 'apple'
         assert get_setting_from_context(sample_settings, ini_var='pie.color', env_var=False) is None
 
     with mock.patch.object(os, "environ", {'PIE_FLAVOR': '', 'PIE_COLOR': ''}):
@@ -176,8 +177,7 @@ def test_virtual_app_get():
                 'op': 'get',
                 'url': 'http://no.such.place/',
                 'kwargs': {'params': {'foo': 'bar'}},
-            }
-            ,
+            },
         ]
 
 
@@ -231,8 +231,7 @@ def test_virtual_app_post_json():
                 'url': 'http://no.such.place/',
                 'obj': {'alpha': 'omega'},
                 'kwargs': {'params': {'foo': 'bar'}},
-            }
-            ,
+            },
         ]
 
 
@@ -286,6 +285,5 @@ def test_virtual_app_patch_json():
                 'url': 'http://no.such.place/',
                 'obj': {'alpha': 'omega'},
                 'kwargs': {'params': {'foo': 'bar'}},
-            }
-            ,
+            },
         ]


### PR DESCRIPTION
It often happens that flake8 fusses over weird things. That turns out to make one do an impulse decision to just believe it. But that's an accident waiting to happen because it complains about unused variables and pytest requires that fixtures look like unused variables. So I made a way to declare them. See the doc string for `dcicutils.qa_utils.notice_pytest_fixtures`, which has a detailed example in the doc string. The function itself is utterly trivial, but the thing it implements is actually quite important to avoiding errors, and the test case really does properly test that this will both placate flake8 and not interfere with fixtures.

