### PR TITLE
C4-160 Add infer_foursight_from_env to env_utils

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -57,6 +57,10 @@ CGAP_STG_OR_PRD_NAMES = [CGAP_ENV_WEBPROD, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_P
 
 FF_PUBLIC_URL_STG = 'http://staging.4dnucleome.org'
 FF_PUBLIC_URL_PRD = 'https://data.4dnucleome.org'
+FF_PUBLIC_DOMAIN_STG = 'staging.4dnucleome.org'
+FF_PUBLIC_DOMAIN_PRD = 'data.4dnucleome.org'
+FF_PRODUCTION_IDENTIFIER = 'data'
+FF_STAGING_IDENTIFIER = 'staging'
 
 FF_PUBLIC_URLS = {
     'staging': FF_PUBLIC_URL_STG,
@@ -311,3 +315,22 @@ def infer_repo_from_env(envname):
         return 'fourfront'
     else:
         return None
+
+
+def infer_foursight_from_env(request, envname):
+    """  Infers the Foursight environment to view based on the given envname and request context
+
+    :param request: the current request (or an object that has member 'domain')
+    :param envname: name of the environment we are on
+    :return: Foursight env at the end of the url ie: for fourfront-green, could be either 'data' or 'staging'
+    """
+    if is_cgap_env(envname):
+        return envname[len('fourfront-'):]  # all cgap envs are prefixed and the FS envs directly match
+    else:
+        if is_stg_or_prd_env(envname):
+            if FF_PUBLIC_DOMAIN_PRD in request.domain:
+                return FF_PRODUCTION_IDENTIFIER
+            else:
+                return FF_STAGING_IDENTIFIER
+        else:
+            return envname[len('fourfront-'):]  # if not data/staging, behaves exactly like CGAP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.25.0"
+version = "0.26.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Adds the method `infer_foursight_from_env` to env_utils, to be used in `root.py` in FF/CGAP to correctly resolve the Foursight URL
- This method will need to be updated if new environments are created that do not follow the convention.