### PR TITLE
Add a filtered_warnings context manager

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -2,9 +2,13 @@
 This file contains functions that might be generally useful.
 """
 
+import contextlib
 import os
 import logging
+import warnings
 import webtest  # importing the library makes it easier to mock testing
+
+from typing import Type
 
 
 # Is this the right place for this? I feel like this should be done in an application, not a library.
@@ -152,3 +156,20 @@ def get_setting_from_context(settings, ini_var, env_var=None, default=None):
         if env_var in os.environ:
             return os.environ.get(env_var)
     return settings.get(ini_var, default)
+
+
+# This should move to dcicutils.misc_utils for better sharing
+@contextlib.contextmanager
+def filtered_warnings(action, message: str = "", category: Type[Warning] = Warning,
+                      module: str = "", lineno: int = 0, append: bool = False):
+    """
+    Context manager temporarily filters deprecation messages for the duration of the body.
+    Used otherwise the same as warnings.filterwarnings would be used.
+
+    Note: This is not threadsafe. It's OK while loading system and during testing,
+          but not in worker threads.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action, message=message, category=category, module=module,
+                                lineno=lineno, append=append)
+        yield

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -158,13 +158,17 @@ def get_setting_from_context(settings, ini_var, env_var=None, default=None):
     return settings.get(ini_var, default)
 
 
-# This should move to dcicutils.misc_utils for better sharing
 @contextlib.contextmanager
 def filtered_warnings(action, message: str = "", category: Type[Warning] = Warning,
                       module: str = "", lineno: int = 0, append: bool = False):
     """
     Context manager temporarily filters deprecation messages for the duration of the body.
     Used otherwise the same as warnings.filterwarnings would be used.
+
+    For example:
+    
+           with filtered_warnings('ignore', category=DeprecationWarning):
+               ... use something that's deprecated without a lot of fuss ...
 
     Note: This is not threadsafe. It's OK while loading system and during testing,
           but not in worker threads.

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -166,7 +166,7 @@ def filtered_warnings(action, message: str = "", category: Type[Warning] = Warni
     Used otherwise the same as warnings.filterwarnings would be used.
 
     For example:
-    
+
            with filtered_warnings('ignore', category=DeprecationWarning):
                ... use something that's deprecated without a lot of fuss ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.26.0"
+version = "0.27.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.27.0"
+version = "0.28.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -1,9 +1,10 @@
 import io
 import json
 import os
+import warnings
 import webtest
 from dcicutils.misc_utils import (
-    PRINT, ignored, get_setting_from_context, VirtualApp,
+    PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
 )
 from unittest import mock
@@ -287,3 +288,33 @@ def test_virtual_app_patch_json():
                 'kwargs': {'params': {'foo': 'bar'}},
             },
         ]
+
+
+def test_filtered_warnings():
+
+    def expect_warnings(pairs):
+        with warnings.catch_warnings(record=True) as w:
+            # Trigger a warning.
+            warnings.warn("oh, this is deprecated for sure", DeprecationWarning)  # noqa
+            warnings.warn("tsk, tsk, tsk, what ugly code", SyntaxWarning)  # noqa
+            # Verify some things
+            for expected_count, expected_type in pairs:
+                count = 0
+                for warning in w:
+                    if issubclass(warning.category, expected_type):
+                        count += 1
+                assert count == expected_count
+
+    expect_warnings([(2, Warning), (1, DeprecationWarning), (1, SyntaxWarning)])
+
+    with filtered_warnings("ignore"):
+        expect_warnings([(0, Warning), (0, DeprecationWarning), (0, SyntaxWarning)])
+
+    with filtered_warnings("ignore", category=Warning):
+        expect_warnings([(0, Warning), (0, DeprecationWarning), (0, SyntaxWarning)])
+
+    with filtered_warnings("ignore", category=DeprecationWarning):
+        expect_warnings([(1, Warning), (0, DeprecationWarning), (1, SyntaxWarning)])
+
+    with filtered_warnings("ignore", category=SyntaxWarning):
+        expect_warnings([(1, Warning), (1, DeprecationWarning), (0, SyntaxWarning)])


### PR DESCRIPTION
Adds a 'filtered_warnings' context manager for disabling warnings in a small region of code when we already know about during system setup or testing.