### PR TITLE
misc_utils.Retry and associated tools

### DIFF
--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -37,7 +37,7 @@ from dcicutils.env_utils import (
     get_standard_mirror_env, data_set_for_env, get_bucket_env, INDEXER_ENVS, is_fourfront_env, is_cgap_env,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env
 )
-from dcicutils.misc_utils import PRINT, RetryManager
+from dcicutils.misc_utils import PRINT, Retry
 
 # constants associated with EB-related APIs
 EB_CONFIGURATION_SETTINGS = 'ConfigurationSettings'
@@ -228,7 +228,7 @@ class EBDeployer:
         return configurable_options
 
     @classmethod
-    @RetryManager.retry_allowed(retries_allowed=1, wait_seconds=10)
+    @Retry.retry_allowed(retries_allowed=1, wait_seconds=10)
     def verify_template_creation(cls, client, template_name):
         """ Does a get for the given template_name to verify EB has recognized that it is
             available.

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -6,7 +6,7 @@ import datetime
 import contextlib
 import os
 import pytz
-from .misc_utils import PRINT, ignored, RetryManager
+from .misc_utils import PRINT, ignored, Retry
 
 
 def mock_not_called(name):
@@ -251,26 +251,37 @@ class Occasionally:
 
     def __call__(self, *args, **kwargs):
         self.count = (self.count + 1) % self.frequency
-        if ((self.count == 0 and not self.frequently_fails) or (self.count != 0 and self.frequently_fails)):
+        if (self.count == 0 and not self.frequently_fails) or (self.count != 0 and self.frequently_fails):
             raise self.error_class(self.error_message)
         else:
             return self.function(*args, **kwargs)
 
 
-class RetryManagerForTesting(RetryManager):
+class RetryManager(Retry):
+    """
+    This class provides a method that is not thread-safe but is usable in unit testing to locally bind retry options
+    for a function declared elsewhere using the Retry.allow_retries(...) decorator.
+
+    NOTE: this does NOT use module names of functions to avoid collisions (though you can override that
+    with a name_key). For example:
+
+        with RetryManager.retry_options("foo", wait_seconds=4):
+            ...code where foo will wait 4 seconds before retrying...
+
+    """
 
     @classmethod
     @contextlib.contextmanager
-    def retry_options(cls, key, retries_allowed=None, wait_seconds=None,
+    def retry_options(cls, name_key, retries_allowed=None, wait_seconds=None,
                       wait_increment=None, wait_multiplier=None):
-        if not isinstance(key, str):
-            raise ValueError("The required 'key' argument to the RetryManager.retry_options context manager"
-                             " must be a string: %r" % key)
-        function_profile = cls.RETRY_PROFILES.get(key)
+        if not isinstance(name_key, str):
+            raise ValueError("The required 'name_key' argument to the RetryManager.retry_options context manager"
+                             " must be a string: %r" % name_key)
+        function_profile = cls._RETRY_OPTIONS_CATALOG.get(name_key)
         if not function_profile:
-            raise ValueError("The 'key' argument to RetryManager.retry_options"
-                             " did not name a registered function: %r" % key)
-        assert isinstance(function_profile, cls.RetryProfile)
+            raise ValueError("The 'name_key' argument to RetryManager.retry_options"
+                             " did not name a registered function: %r" % name_key)
+        assert isinstance(function_profile, cls.RetryOptions)
         options = {}
         if retries_allowed is not None:
             options['retries_allowed'] = retries_allowed

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,7 +37,7 @@ description = "Screen-scraping library"
 name = "beautifulsoup4"
 optional = false
 python-versions = "*"
-version = "4.9.0"
+version = "4.9.1"
 
 [package.dependencies]
 soupsieve = [">1.2", "<2.0"]
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.13.9"
+version = "1.13.13"
 
 [package.dependencies]
-botocore = ">=1.16.9,<1.17.0"
+botocore = ">=1.16.13,<1.17.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.16.9"
+version = "1.16.13"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -285,7 +285,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.2.0"
+version = "8.3.0"
 
 [[package]]
 category = "dev"
@@ -293,7 +293,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3"
+version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -581,7 +581,7 @@ description = "A modern CSS selector implementation for Beautiful Soup."
 name = "soupsieve"
 optional = false
 python-versions = "*"
-version = "1.9.5"
+version = "1.9.6"
 
 [[package]]
 category = "main"
@@ -706,8 +706,8 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "3ac9b07c52a1c3b0b16310d4d45571095f42b0d7601ba51766faeefdbe7eacd6"
-python-versions = ">=3.4,<3.7"
+content-hash = "f0e20ad02ef51f1c641238e715aa2582c66e4a335b7dd84358adca86baec2c9c"
+python-versions = ">=3.4,<3.8"
 
 [metadata.files]
 atomicwrites = [
@@ -722,16 +722,17 @@ aws-requests-auth = [
     {file = "aws-requests-auth-0.4.2.tar.gz", hash = "sha256:112c85fe938a01e28f7e1a87168615b6977b28596362b1dcbafbf4f2cc69f720"},
 ]
 beautifulsoup4 = [
-    {file = "beautifulsoup4-4.9.0-py2-none-any.whl", hash = "sha256:a4bbe77fd30670455c5296242967a123ec28c37e9702a8a81bd2f20a4baf0368"},
-    {file = "beautifulsoup4-4.9.0-py3-none-any.whl", hash = "sha256:d4e96ac9b0c3a6d3f0caae2e4124e6055c5dcafde8e2f831ff194c104f0775a0"},
-    {file = "beautifulsoup4-4.9.0.tar.gz", hash = "sha256:594ca51a10d2b3443cbac41214e12dbb2a1cd57e1a7344659849e2e20ba6a8d8"},
+    {file = "beautifulsoup4-4.9.1-py2-none-any.whl", hash = "sha256:e718f2342e2e099b640a34ab782407b7b676f47ee272d6739e60b8ea23829f2c"},
+    {file = "beautifulsoup4-4.9.1-py3-none-any.whl", hash = "sha256:a6237df3c32ccfaee4fd201c8f5f9d9df619b93121d01353a64a73ce8c6ef9a8"},
+    {file = "beautifulsoup4-4.9.1.tar.gz", hash = "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7"},
 ]
 boto3 = [
-    {file = "boto3-1.13.9.tar.gz", hash = "sha256:06dd5d0f2ed3570f60eab04b9f04d229ff980b55102447481992756efe268639"},
+    {file = "boto3-1.13.13-py2.py3-none-any.whl", hash = "sha256:a396e514eb6ee57994718a7c85d3810bfda23faba01dd80c65e0aba6a5dedb1f"},
+    {file = "boto3-1.13.13.tar.gz", hash = "sha256:3c740de27ca113bcdbf5449d6d221428e5bc529e8e7d8e7dd87790602078c333"},
 ]
 botocore = [
-    {file = "botocore-1.16.9-py2.py3-none-any.whl", hash = "sha256:d82f34844f9fc64d51b46046eed1f98fc367897832e5c4734ce58c0e17e7188f"},
-    {file = "botocore-1.16.9.tar.gz", hash = "sha256:8743cd10500b6c4c4d9423d3aa2905ed886fea2bd4bb7c8eff6e6c08283c9ab9"},
+    {file = "botocore-1.16.13-py2.py3-none-any.whl", hash = "sha256:5227e7a6d9d88560bae22149dc0d87b71679cf9c63ad79bf37bb2b7cd8e07db0"},
+    {file = "botocore-1.16.13.tar.gz", hash = "sha256:babc267e4ff043f3e722f9b0103fd808934519f9148ef7360c255d1aefcb96d7"},
 ]
 certifi = [
     {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
@@ -860,12 +861,12 @@ mccabe = [
 more-itertools = [
     {file = "more-itertools-7.2.0.tar.gz", hash = "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832"},
     {file = "more_itertools-7.2.0-py3-none-any.whl", hash = "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"},
-    {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
-    {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
+    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
+    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
 ]
 packaging = [
-    {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
-    {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pathlib2 = [
     {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
@@ -951,8 +952,8 @@ smmap = [
     {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
 ]
 soupsieve = [
-    {file = "soupsieve-1.9.5-py2.py3-none-any.whl", hash = "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5"},
-    {file = "soupsieve-1.9.5.tar.gz", hash = "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"},
+    {file = "soupsieve-1.9.6-py2.py3-none-any.whl", hash = "sha256:feb1e937fa26a69e08436aad4a9037cd7e1d4c7212909502ba30701247ff8abd"},
+    {file = "soupsieve-1.9.6.tar.gz", hash = "sha256:7985bacc98c34923a439967c1a602dc4f1e15f923b6fcf02344184f86cc7efaa"},
 ]
 structlog = [
     {file = "structlog-19.2.0-py2.py3-none-any.whl", hash = "sha256:6640e6690fc31d5949bc614c1a630464d3aaa625284aeb7c6e486c3010d73e12"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.28.2"
+version = "0.29.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -7,7 +7,7 @@ import webtest
 from dcicutils.misc_utils import (
     PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
-    RetryManager,
+    Retry,
 )
 from dcicutils.qa_utils import Occasionally
 from unittest import mock
@@ -344,7 +344,7 @@ def test_retry_manager():
 
     sometimes_add2.reset()
 
-    @RetryManager.retry_allowed(retries_allowed=1)
+    @Retry.retry_allowed(retries_allowed=1)
     def reliably_add2(x):
         return sometimes_add2(x)
 
@@ -368,7 +368,7 @@ def test_retry_manager():
 
     # NOTE WELL: For testing, we chose 1.25 to use factors of 2 so floating point can exactly compare
 
-    @RetryManager.retry_allowed(retries_allowed=4, wait_seconds=2, wait_multiplier=1.25)
+    @Retry.retry_allowed(retries_allowed=4, wait_seconds=2, wait_multiplier=1.25)
     def reliably_add3(x):
         return rarely_add3(x)
 

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -559,7 +559,9 @@ def test_retry_manager():
         assert mock_sleep.mock_calls[6][ARGS][0] == 3.125    # 2 * 1.25 ** 2
         assert mock_sleep.mock_calls[7][ARGS][0] == 3.90625  # 2 * 1.25 ** 3
 
-        with RetryManager.retry_options('reliably_add3', retries_allowed=3, wait_seconds=5):
+        # Note that this does not change the wait multiplier, but does exercise the code that processes it,
+        # showing that it is doing the same thing as before.
+        with RetryManager.retry_options('reliably_add3', retries_allowed=3, wait_seconds=5, wait_multiplier=1.25):
 
             mock_sleep.reset_mock()
             assert mock_sleep.call_count == 0
@@ -594,3 +596,21 @@ def test_retry_manager():
                     assert mock_sleep.mock_calls[i][ARGS][0] == 7
                     assert mock_sleep.mock_calls[i + 1][ARGS][0] == 8.75
                     assert mock_sleep.mock_calls[i + 2][ARGS][0] == 10.9375
+
+        with pytest.raises(ValueError):
+
+            # The name-key must not be a number.
+            with RetryManager.retry_options(name_key=17, retries_allowed=3, wait_seconds=5):
+                pass
+
+        with pytest.raises(ValueError):
+
+            # The name-key must not be a number.
+            with RetryManager.retry_options(17, retries_allowed=3, wait_seconds=5):
+                pass
+
+        with pytest.raises(ValueError):
+
+            # The name-key must be registered
+            with RetryManager.retry_options(name_key="not-a-registered-name", retries_allowed=3, wait_seconds=5):
+                pass


### PR DESCRIPTION
This introduces:

* `misc_utils.Retry`, which implements the decorator `@Retry.retry_allowed()`
* `qa_utils.Occasionally`, which is a class usable to help mock flaky behavior.
* `qa_utils.RetryManager`, which subclasses `misc_utils.Retry`, providing a not-thread-safe binding facility (using `local_attrs`, which has that same restriction) attributes of a function declared with `misc_utils.RetryManager.retry_allowed`.