### PR TITLE
Add beanstalk_utils.compute_ff_stg_env and .compute_cgap_stg_env for foursight

### DIFF
--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -243,7 +243,7 @@ def _compute_prd_env_for_project(project):
 
 def compute_ff_prd_env():
     """Returns the name of the current Fourfront production environment."""
-    return _compute_prd_env_for_project('ff')
+    return _compute_prd_env_for_project('fourfront')
 
 
 def compute_ff_stg_env():

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -14,7 +14,9 @@ from datetime import datetime
 from . import ff_utils
 from botocore.exceptions import ClientError
 from .misc_utils import PRINT
-from .env_utils import is_cgap_env, is_stg_or_prd_env, public_url_mappings, blue_green_mirror_env
+from .env_utils import (
+    is_cgap_env, is_stg_or_prd_env, public_url_mappings, blue_green_mirror_env, get_standard_mirror_env
+)
 
 logging.basicConfig()
 logger = logging.getLogger('logger')
@@ -240,14 +242,26 @@ def _compute_prd_env_for_project(project):
 
 
 def compute_ff_prd_env():
+    """Returns the name of the current Fourfront production environment."""
     return _compute_prd_env_for_project('ff')
+
+
+def compute_ff_stg_env():
+    """Returns the name of the current Fourfront staging environment."""
+    return get_standard_mirror_env(compute_ff_prd_env())
 
 
 whodaman = compute_ff_prd_env  # This naming is deprecated but retained for compatibility.
 
 
 def compute_cgap_prd_env():
+    """Returns the name of the current CGAP production environment."""
     return _compute_prd_env_for_project('cgap')
+
+
+def compute_cgap_stg_env():
+    """Returns the name of the current CGAP staging environment, or None if there is none."""
+    return get_standard_mirror_env(compute_cgap_prd_env())
 
 
 def beanstalk_info(env):

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -27,12 +27,12 @@ PRINT = print
 class VirtualAppError(Exception):
     """ Special Exception to be raised by VirtualApp that contains some additional info """
 
-    def __init__(self, msg, url, body, e):
+    def __init__(self, msg, url, body, raw_exception):
         super(VirtualAppError, self).__init__(msg)
         self.msg = msg
         self.query_url = url
         self.query_body = body
-        self.raw_exception = e
+        self.raw_exception = raw_exception
 
     def __repr__(self):
         return ("Exception encountered on VirtualApp\n"
@@ -86,7 +86,7 @@ class VirtualApp:
         try:
             return self.wrapped_app.get(url, **kwargs)
         except webtest.AppError as e:
-            raise VirtualAppError(msg='HTTP GET failed.', url=url, body='<empty>', e=str(e))
+            raise VirtualAppError(msg='HTTP GET failed.', url=url, body='<empty>', raw_exception=str(e))
 
     def post_json(self, url, obj, **kwargs):
         """ Wrapper for TestApp.post_json that logs the outgoing POST
@@ -100,7 +100,7 @@ class VirtualApp:
         try:
             return self.wrapped_app.post_json(url, obj, **kwargs)
         except webtest.AppError as e:
-            raise VirtualAppError(msg='HTTP POST failed.', url=url, body=obj, e=str(e))
+            raise VirtualAppError(msg='HTTP POST failed.', url=url, body=obj, raw_exception=str(e))
 
     def patch_json(self, url, fields, **kwargs):
         """ Wrapper for TestApp.patch_json that logs the outgoing PATCH
@@ -114,7 +114,7 @@ class VirtualApp:
         try:
             return self.wrapped_app.patch_json(url, fields, **kwargs)
         except webtest.AppError as e:
-            raise VirtualAppError(msg='HTTP PATCH failed.', url=url, body=fields, e=str(e))
+            raise VirtualAppError(msg='HTTP PATCH failed.', url=url, body=fields, raw_exception=str(e))
 
 
 def ignored(*args, **kwargs):

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -35,11 +35,11 @@ class VirtualAppError(Exception):
         self.raw_exception = e
 
     def __repr__(self):
-        return "Exception encountered on VirtualApp\n" \
-               "URL: %s\n" \
-               "BODY: %s\n" \
-               "MSG: %s\n" \
-               "Raw Exception: %s\n" % (self.query_url, self.query_body, self.msg, self.raw_exception)
+        return ("Exception encountered on VirtualApp\n"
+                "URL: %s\n"
+                "BODY: %s\n"
+                "MSG: %s\n"
+                "Raw Exception: %s\n" % (self.query_url, self.query_body, self.msg, self.raw_exception))
 
     def __str__(self):
         return self.__repr__()

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -86,7 +86,7 @@ class VirtualApp:
         try:
             return self.wrapped_app.get(url, **kwargs)
         except webtest.AppError as e:
-            raise VirtualAppError(msg='HTTP GET failed.', url=url, body='<empty>', raw_exception=str(e))
+            raise VirtualAppError(msg='HTTP GET failed.', url=url, body='<empty>', raw_exception=e)
 
     def post_json(self, url, obj, **kwargs):
         """ Wrapper for TestApp.post_json that logs the outgoing POST
@@ -100,7 +100,7 @@ class VirtualApp:
         try:
             return self.wrapped_app.post_json(url, obj, **kwargs)
         except webtest.AppError as e:
-            raise VirtualAppError(msg='HTTP POST failed.', url=url, body=obj, raw_exception=str(e))
+            raise VirtualAppError(msg='HTTP POST failed.', url=url, body=obj, raw_exception=e)
 
     def patch_json(self, url, fields, **kwargs):
         """ Wrapper for TestApp.patch_json that logs the outgoing PATCH
@@ -114,7 +114,7 @@ class VirtualApp:
         try:
             return self.wrapped_app.patch_json(url, fields, **kwargs)
         except webtest.AppError as e:
-            raise VirtualAppError(msg='HTTP PATCH failed.', url=url, body=fields, raw_exception=str(e))
+            raise VirtualAppError(msg='HTTP PATCH failed.', url=url, body=fields, raw_exception=e)
 
 
 def ignored(*args, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.29.1"
+version = "0.30.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.29.0"
+version = "0.29.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -404,6 +404,10 @@ def test_infer_repo_from_env():
     assert infer_repo_from_env('cgap-foo') == 'cgap-portal'
     assert infer_repo_from_env('fourfront-cgapfoo') == 'cgap-portal'
 
+    # Edge cases that the code specifically looks for:
+    assert infer_repo_from_env(None) is None
+    assert infer_repo_from_env('who-knows') is None
+
 
 def test_infer_foursight_env():
 

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -12,8 +12,8 @@ from dcicutils.env_utils import (
     get_mirror_env_from_context, is_test_env, is_hotseat_env, guess_mirror_env, get_standard_mirror_env,
     prod_bucket_env, public_url_mappings, CGAP_PUBLIC_URLS, FF_PUBLIC_URLS, FF_PROD_BUCKET_ENV, CGAP_PROD_BUCKET_ENV,
     infer_repo_from_env, data_set_for_env, get_bucket_env, infer_foursight_from_env, FF_PRODUCTION_IDENTIFIER,
-    FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV, indexer_env_for_env,
-    FF_ENV_INDEXER, CGAP_ENV_INDEXER,
+    FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV,
+    FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env,
 )
 from unittest import mock
 
@@ -436,6 +436,7 @@ def test_infer_foursight_env():
 
 
 def test_indexer_env_for_env():
+
     assert indexer_env_for_env('fourfront-mastertest') == FF_ENV_INDEXER
     assert indexer_env_for_env('fourfront-blue') == FF_ENV_INDEXER
     assert indexer_env_for_env('fourfront-green') == FF_ENV_INDEXER
@@ -450,3 +451,19 @@ def test_indexer_env_for_env():
     assert indexer_env_for_env('fourfront-indexer') is None
     assert indexer_env_for_env('cgap-indexer') is None
     assert indexer_env_for_env('blah-env') is None
+
+
+def test_is_indexer_env():
+
+    assert is_indexer_env('fourfront-indexer')
+    assert is_indexer_env(FF_ENV_INDEXER)
+
+    assert is_indexer_env('cgap-indexer')
+    assert is_indexer_env(CGAP_ENV_INDEXER)
+
+    # Try a few non-indexers ...
+    assert not is_indexer_env('fourfront-cgap')
+    assert not is_indexer_env('fourfront-blue')
+    assert not is_indexer_env('fourfront-green')
+    assert not is_indexer_env('fourfront-mastertest')
+    assert not is_indexer_env('fourfront-cgapwolf')

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -334,7 +334,7 @@ def test_virtual_app_crud_failure():
 
     simulated_error_message = "simulated error"
 
-    class FakeTestApp(VirtualAppError):
+    class FakeTestApp:
 
         def __init__(self, app, environ):
             ignored(app, environ)
@@ -371,28 +371,6 @@ def test_virtual_app_crud_failure():
                 assert str(e.raw_exception) == simulated_error_message
                 # assert isinstance(e.raw_exception, webtest.AppError)
                 assert isinstance(e.raw_exception, str)  # <-- TODO: This seems like a bug to me. -kmp 22-May-2020
-
-
-def test_virtual_app_post_failure():
-
-    class FakeTestApp(VirtualAppError):
-
-        def __init__(self, app, environ):
-            ignored(app, environ)
-
-        def get(self, url, **kwargs):
-            raise webtest.AppError("simulated error")
-
-    with mock.patch.object(VirtualApp, "HELPER_CLASS", FakeTestApp):
-
-        app = FakeApp()
-        environ = {'some': 'stuff'}
-
-        vapp = VirtualApp(app, environ)
-
-        with pytest.raises(VirtualAppError):
-            vapp.get("http://fixture.4dnucleome.org/some/url")
-
 
 
 def test_filtered_warnings():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -369,8 +369,7 @@ def test_virtual_app_crud_failure():
             except Exception as e:
                 assert isinstance(e, VirtualAppError)  # NOTE: not webtest.AppError, which is what was raised
                 assert str(e.raw_exception) == simulated_error_message
-                # assert isinstance(e.raw_exception, webtest.AppError)
-                assert isinstance(e.raw_exception, str)  # <-- TODO: This seems like a bug to me. -kmp 22-May-2020
+                assert isinstance(e.raw_exception, webtest.AppError)
 
 
 def test_filtered_warnings():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -2,10 +2,11 @@ import io
 import json
 import os
 import pytest
+import re
 import warnings
 import webtest
 from dcicutils.misc_utils import (
-    PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp,
+    PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp, VirtualAppError,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
     Retry,
 )
@@ -293,6 +294,107 @@ def test_virtual_app_patch_json():
         ]
 
 
+def test_virtual_app_error():
+
+    error_message = "You did a bad thing."
+    offending_url = "http://fixture.4dnucleome.org/offending/url"
+    body_text = '{"alpha": "omega"}'
+    body_json = {"alpha": "omega"}
+    wrapped_error = Exception("Some other exception")
+
+    e = VirtualAppError(error_message, offending_url, body_text, wrapped_error)
+    m = str(e)
+
+    assert error_message in m
+    assert offending_url in m
+    assert body_text in m
+    assert str(wrapped_error) in m
+
+    # And the repr is the same.
+    assert repr(e) == str(e)
+
+    # NOTE: Weirdly, I think we'd have had complete code coverage even without this next test, but that illustrates
+    #  why code coverage counts aren't always the right metric. With different data, the same code paths sometimes
+    #  does different things in ways that code coverage tools don't register. -kmp 21-May-2020
+
+    e2 = VirtualAppError(error_message, offending_url, body_json, wrapped_error)
+    m2 = str(e2)
+
+    assert error_message in m2
+    assert offending_url in m2
+    assert str(body_json) in m2             # body_json will be rendered as a Python dict (e.g., with single quotes)
+    assert not json.dumps(body_json) in m2  # So body_json will NOT be rendered as JSON via json.dumps
+    assert str(wrapped_error) in m2
+
+    # And the repr is the same.
+    assert repr(e2) == str(e2)
+
+
+def test_virtual_app_crud_failure():
+
+    simulated_error_message = "simulated error"
+
+    class FakeTestApp(VirtualAppError):
+
+        def __init__(self, app, environ):
+            ignored(app, environ)
+
+        def get(self, url, **kwargs):
+            raise webtest.AppError(simulated_error_message)
+
+        def post_json(self, url, object, **kwargs):
+            raise webtest.AppError(simulated_error_message)
+
+        def patch_json(self, url, fields, **kwargs):
+            raise webtest.AppError(simulated_error_message)
+
+    with mock.patch.object(VirtualApp, "HELPER_CLASS", FakeTestApp):
+
+        app = FakeApp()
+        environ = {'some': 'stuff'}
+
+        vapp = VirtualApp(app, environ)
+
+        some_url = "http://fixture.4dnucleome.org/some/url"
+
+        operations = [
+            lambda: vapp.get(some_url),
+            lambda: vapp.post_json(some_url, {'a': 1, 'b': 2, 'c': 3}),
+            lambda: vapp.patch_json(some_url, {'b': 5})
+        ]
+
+        for operation in operations:
+            try:
+                operation()
+            except Exception as e:
+                assert isinstance(e, VirtualAppError)  # NOTE: not webtest.AppError, which is what was raised
+                assert str(e.raw_exception) == simulated_error_message
+                # assert isinstance(e.raw_exception, webtest.AppError)
+                assert isinstance(e.raw_exception, str)  # <-- TODO: This seems like a bug to me. -kmp 22-May-2020
+
+
+def test_virtual_app_post_failure():
+
+    class FakeTestApp(VirtualAppError):
+
+        def __init__(self, app, environ):
+            ignored(app, environ)
+
+        def get(self, url, **kwargs):
+            raise webtest.AppError("simulated error")
+
+    with mock.patch.object(VirtualApp, "HELPER_CLASS", FakeTestApp):
+
+        app = FakeApp()
+        environ = {'some': 'stuff'}
+
+        vapp = VirtualApp(app, environ)
+
+        with pytest.raises(VirtualAppError):
+            vapp.get("http://fixture.4dnucleome.org/some/url")
+
+
+
 def test_filtered_warnings():
 
     def expect_warnings(pairs):
@@ -323,14 +425,15 @@ def test_filtered_warnings():
         expect_warnings([(1, Warning), (1, DeprecationWarning), (0, SyntaxWarning)])
 
 
+def _adder(n):
+    def addn(x):
+        return x + n
+    return addn
+
+
 def test_retry():
 
-    def adder(n):
-        def addn(x):
-            return x + n
-        return addn
-
-    sometimes_add2 = Occasionally(adder(2), success_frequency=2)
+    sometimes_add2 = Occasionally(_adder(2), success_frequency=2)
 
     try:
         assert sometimes_add2(1) == 3
@@ -352,7 +455,7 @@ def test_retry():
     assert reliably_add2(2) == 4
     assert reliably_add2(3) == 5
 
-    rarely_add3 = Occasionally(adder(3), success_frequency=5)
+    rarely_add3 = Occasionally(_adder(3), success_frequency=5)
 
     with pytest.raises(Exception):
         assert rarely_add3(1) == 4
@@ -364,7 +467,10 @@ def test_retry():
         assert rarely_add3(1) == 4
     assert rarely_add3(1) == 4  # 5th time's a charm
 
-    rarely_add3.reset()
+
+def test_retry_timeouts():
+
+    rarely_add3 = Occasionally(_adder(3), success_frequency=5)
 
     ARGS = 1  # We have to access a random place out of a tuple structure for mock data on time.sleep's arg
 
@@ -420,7 +526,10 @@ def test_retry():
         assert mock_sleep.mock_calls[6][ARGS][0] == 8   # 2 + 3 * 2
         assert mock_sleep.mock_calls[7][ARGS][0] == 11  # 2 + 3 * 3
 
-    rarely_add3.reset()
+
+def test_retry_error_handling():
+
+    rarely_add3 = Occasionally(_adder(3), success_frequency=5)
 
     with pytest.raises(SyntaxError):
 


### PR DESCRIPTION
This adds two functions to `dcicutils.beanstalk_utils` that are needed by a PR of Will's.

* `compute_ff_stg_env` (similar to existing `compute_ff_prd_env`, but returns the staging env)
* `compute_cgap_stg_env` (just returns `None` for now, but if `compute_cgap_prd_env` starts returning the value of CGAP_ENV_PRODUCTION_BLUE_NEW or CGAP_ENV_PRODUCTION_GREEN_NEW, this will start returning the other of those).

I used what I think is a more intuitive way to compute these, but took the implementation that was in the pending Foursight PR and used that as an additional test of correctness of my other technique.

Also, I had a branch open to improve unit tests in utils, so I repurposed that branch to contain these additions, hence the odd branch name and a number of opportunistic other tests that are riding along with this. This brings code coverage for `misc_utils` and `env_utils` to 100%.