### PR TITLE
Deployment options change in service of C4-166.

### DIFF
--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -234,9 +234,7 @@ def _compute_prd_env_for_project(project):
     magic_cname = CGAP_MAGIC_CNAME if project == 'cgap' else FF_MAGIC_CNAME
     client = boto3.client('elasticbeanstalk', region_name=REGION)
     res = describe_beanstalk_environments(client, ApplicationName="4dn-web")
-    # logger.info(res)
     for env in res['Environments']:
-        # logger.info(env)
         if env.get('CNAME') == magic_cname:
             # we found data
             return env.get('EnvironmentName')

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -233,9 +233,9 @@ def _compute_prd_env_for_project(project):
     magic_cname = CGAP_MAGIC_CNAME if project == 'cgap' else FF_MAGIC_CNAME
     client = boto3.client('elasticbeanstalk', region_name=REGION)
     res = describe_beanstalk_environments(client, ApplicationName="4dn-web")
-    logger.info(res)
+    # logger.info(res)
     for env in res['Environments']:
-        logger.info(env)
+        # logger.info(env)
         if env.get('CNAME') == magic_cname:
             # we found data
             return env.get('EnvironmentName')

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -15,7 +15,8 @@ from . import ff_utils
 from botocore.exceptions import ClientError
 from .misc_utils import PRINT
 from .env_utils import (
-    is_cgap_env, is_stg_or_prd_env, public_url_mappings, blue_green_mirror_env, get_standard_mirror_env
+    is_fourfront_env, is_cgap_env, is_stg_or_prd_env, public_url_mappings,
+    blue_green_mirror_env, get_standard_mirror_env,
 )
 
 logging.basicConfig()
@@ -262,6 +263,16 @@ def compute_cgap_prd_env():
 def compute_cgap_stg_env():
     """Returns the name of the current CGAP staging environment, or None if there is none."""
     return get_standard_mirror_env(compute_cgap_prd_env())
+
+
+def compute_prd_env_for_env(envname):
+    """Given an environment, returns the name of the prod environment for its owning project."""
+    if is_cgap_env(envname):
+        return compute_cgap_prd_env()
+    elif is_fourfront_env(envname):
+        return compute_ff_prd_env()
+    else:
+        raise ValueError("Unknown environment: %s" % envname)
 
 
 def beanstalk_info(env):

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -680,6 +680,10 @@ class IniFileManager:
 Deployer = IniFileManager
 
 
+class DeploymentFailure(RuntimeError):
+    pass
+
+
 class DeployConfigManager:
 
     # Set SKIP to True to skip the create_mapping step.
@@ -700,8 +704,8 @@ class DeployConfigManager:
             apply_dict_overrides(deploy_cfg, **cls.STAGING_DEPLOYMENT_OPTION_OVERRIDES)
         elif is_stg_or_prd_env(env):
             log.info('This looks like an uncorrelated production environment. Something is definitely wrong.')
-            raise RuntimeError(
-                'Tried to run CMOD on production - error\'ing deployment')  # note that this will cause any deployments to production to fail!
+            raise DeploymentFailure(
+                'Tried to run CMOD on production - error\'ing deployment')
         elif is_test_env(env):
             if is_hotseat_env(env):
                 log.info('Looks like we are on hotseat -- do nothing to ES')

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -268,3 +268,11 @@ class Retry:
             return wrapped_function
 
         return decorator
+
+
+def apply_dict_overrides(dictionary: dict, **overrides) -> dict:
+    for k, v in overrides.items():
+        if v is not None:
+            dictionary[k] = v
+    # This function works by side effect, but getting back the changed dict may be sometimes useful.
+    return dictionary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.31.0b1"
+version = "0.31.0b2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.31.0b4"
+version = "0.31.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.30.0"
+version = "0.31.0b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.31.0b2"
+version = "0.31.0b3"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.31.0b0"
+version = "0.31.0b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.31.0b3"
+version = "0.31.0b4"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_beanstalk_utils.py
+++ b/test/test_beanstalk_utils.py
@@ -4,7 +4,8 @@ import json
 import os
 import socket
 from collections import defaultdict
-from dcicutils import beanstalk_utils as bs, env_utils, source_beanstalk_env_vars
+from dcicutils import beanstalk_utils as bs, env_utils, source_beanstalk_env_vars, compute_prd_env_for_env
+from dcicutils.env_utils import is_fourfront_env, is_cgap_env, is_stg_or_prd_env
 from dcicutils.qa_utils import mock_not_called
 from dcicutils.misc_utils import ignored
 from unittest import mock
@@ -300,6 +301,18 @@ def test_compute_cgap_stg_env_by_alternate_means():
         expected_prd_options = {env_utils.CGAP_ENV_PRODUCTION_BLUE_NEW, env_utils.CGAP_ENV_PRODUCTION_GREEN_NEW}
         assert actual_cgap_prd in expected_prd_options
         assert bs.compute_cgap_stg_env() == (expected_prd_options - {actual_cgap_prd}).pop()
+
+
+def test_compute_prd_env_for_env():
+
+    computed_ff_prd = compute_prd_env_for_env('fourfront-mastertest')
+    assert is_fourfront_env(computed_ff_prd)
+    assert is_stg_or_prd_env(computed_ff_prd)
+
+    computed_cgap_prd = compute_prd_env_for_env('fourfront-cgapwolf')
+    assert is_cgap_env(computed_cgap_prd)
+    assert is_stg_or_prd_env(computed_cgap_prd)
+
 
 
 def _mocked_describe_beanstalk_environments(*args, **kwargs):

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -8,7 +8,7 @@ import webtest
 from dcicutils.misc_utils import (
     PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp, VirtualAppError,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
-    Retry,
+    Retry, apply_dict_overrides,
 )
 from dcicutils.qa_utils import Occasionally
 from unittest import mock
@@ -513,3 +513,19 @@ def test_retry_error_handling():
         @Retry.retry_allowed(retries_allowed=4, wait_seconds=2, wait_increment=3, wait_multiplier=1.25)
         def reliably_add_three(x):
             return rarely_add3(x)
+
+
+def test_apply_dict_overrides():
+
+    x = {'a': 1, 'b': 2}
+
+    actual = apply_dict_overrides(x, a=11, c=33)
+    expected = {'a': 11, 'b': 2, 'c': 33}
+    assert isinstance(actual, dict)
+    assert actual == expected
+    assert x == expected
+
+    actual = apply_dict_overrides(x, b=22, c=None)
+    expected = {'a': 11, 'b': 22, 'c': 33}
+    assert actual == expected
+    assert x == expected


### PR DESCRIPTION
This adds a **DeployConfigManager** that can be used in Fourfront and CGAP to help resolve all the logic with **SKIP**, **STRICT**, and **WIPE_ES**. 

In service of that, I introduced `compute_prd_env_for_env` to do the obvious idiom of doing either `compute_ff_prd_env` or `compute_cgap_prd_env`.

Opportunistic other changes riding along:

* Renames `Deployer` to `IniFileManager`, though keeps the old name as an alias for compatibility for now.
* Removes some noisy logging in the internal support for `whodaman` and its more modern namings (`compute_ff_prd_env` and `compute_cgap_prd_env`, and the new `compute_prd_env_for_env`).

Some unit tests are owed.  This will remain a draft until that's fixed.