### PR TITLE
Auth env fix

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -217,6 +217,17 @@ def prod_bucket_env(envname):
 
 
 def get_prd_or_stg_env(envname):
+    """
+    Given a production-class env label, returns the env name.
+    For other envnames that aren't production envs, this returns None.
+
+    The envname is something that is either a staging or production env, in particular something
+    that is_stg_or_prd_env returns True for.
+
+    The purpose is to return the envname when shorthand env labels like 'data' or 'staging' are
+    used in place of env names like fourfront-blue or fourfront-green. Should work for fourfront
+    as well as CGAP.
+    """
     if envname == 'data':
         use_env = bs_utils.compute_ff_prd_env()
     elif envname == 'staging':

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,5 +1,6 @@
 import os
 from .misc_utils import get_setting_from_context
+from . import beanstalk_utils as bs_utils
 
 FF_ENV_DEV = 'fourfront-dev'  # Maybe not used
 FF_ENV_HOTSEAT = 'fourfront-hotseat'
@@ -213,6 +214,18 @@ def prod_bucket_env(envname):
     that ecosystem.
     """
     return BEANSTALK_PROD_BUCKET_ENVS.get(envname)
+
+
+def get_prd_or_stg_env(envname):
+    if envname == 'data':
+        use_env = bs_utils.compute_ff_prd_env()
+    elif envname == 'staging':
+        use_env = bs_utils.compute_ff_stg_env()
+    elif envname in ['fourfront-green', 'fourfront-blue']:
+        use_env = envname
+    else:
+        use_env = prod_bucket_env(envname)
+    return use_env
 
 
 def get_bucket_env(envname):

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -9,6 +9,7 @@ from . import (
     s3_utils,
     es_utils,
     env_utils,
+    beanstalk_utils
 )
 from .misc_utils import PRINT
 import requests
@@ -205,7 +206,7 @@ def authorized_request(url, auth=None, ff_env=None, verb='GET',
     OR
     authorized_request('https://data.4dnucleome.org/<some path>', ff_env='fourfront-webprod')
     """
-    use_auth = unified_authentication(auth, ff_env)
+    use_auth = _authentication(auth, ff_env)
     headers = kwargs.get('headers')
     if not headers:
         kwargs['headers'] = {'content-type': 'application/json', 'accept': 'application/json'}
@@ -1088,7 +1089,12 @@ def unified_authentication(auth=None, ff_env=None):
     # first see if key should be obtained from using ff_env
     if not auth and ff_env:
         # TODO: The ff_env argument is mis-named, something we should fix sometime. It can be a cgap env, too.
-        use_env = env_utils.prod_bucket_env(ff_env) if env_utils.is_stg_or_prd_env(ff_env) else ff_env
+        if ff_env == 'data':
+            use_env = beanstalk_utils.compute_ff_prd_env()
+        elif ff_env == 'staging':
+            use_env = beanstalk_utils.compute_ff_stg_env()
+        else:
+            use_env = env_utils.prod_bucket_env(ff_env) if env_utils.is_stg_or_prd_env(ff_env) else ff_env
         auth = s3_utils.s3Utils(env=use_env).get_access_keys()
     # see if auth is directly from get_access_keys()
     use_auth = None

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -8,8 +8,7 @@ import boto3
 from . import (
     s3_utils,
     es_utils,
-    env_utils,
-    beanstalk_utils
+    env_utils
 )
 from .misc_utils import PRINT
 import requests

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1093,6 +1093,8 @@ def unified_authentication(auth=None, ff_env=None):
             use_env = beanstalk_utils.compute_ff_prd_env()
         elif ff_env == 'staging':
             use_env = beanstalk_utils.compute_ff_stg_env()
+        elif ff_env in ['fourfront-green', 'fourfront-blue']:
+            use_env = ff_env
         else:
             use_env = env_utils.prod_bucket_env(ff_env) if env_utils.is_stg_or_prd_env(ff_env) else ff_env
         auth = s3_utils.s3Utils(env=use_env).get_access_keys()

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1089,14 +1089,7 @@ def unified_authentication(auth=None, ff_env=None):
     # first see if key should be obtained from using ff_env
     if not auth and ff_env:
         # TODO: The ff_env argument is mis-named, something we should fix sometime. It can be a cgap env, too.
-        if ff_env == 'data':
-            use_env = beanstalk_utils.compute_ff_prd_env()
-        elif ff_env == 'staging':
-            use_env = beanstalk_utils.compute_ff_stg_env()
-        elif ff_env in ['fourfront-green', 'fourfront-blue']:
-            use_env = ff_env
-        else:
-            use_env = env_utils.prod_bucket_env(ff_env) if env_utils.is_stg_or_prd_env(ff_env) else ff_env
+        use_env = env_utils.get_prd_or_stg_env(ff_env) if env_utils.is_stg_or_prd_env(ff_env) else ff_env
         auth = s3_utils.s3Utils(env=use_env).get_access_keys()
     # see if auth is directly from get_access_keys()
     use_auth = None

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -206,7 +206,7 @@ def authorized_request(url, auth=None, ff_env=None, verb='GET',
     OR
     authorized_request('https://data.4dnucleome.org/<some path>', ff_env='fourfront-webprod')
     """
-    use_auth = _authentication(auth, ff_env)
+    use_auth = unified_authentication(auth, ff_env)
     headers = kwargs.get('headers')
     if not headers:
         kwargs['headers'] = {'content-type': 'application/json', 'accept': 'application/json'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.31.1"
+version = "0.31.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Fix in unified_authentication in ff_utils so that 'data' and 'staging' (as well as 'fourfront-green' and 'fourfront-blue') return correct environment names. Previously this relied on beanstalk_utils.BEANSTALK_PROD_BUCKET_ENVS but the bucket name doesn't match the environment name in the case of fourfront prod/staging environments.