### PR TITLE
Protect against CNAME swap during testing s3Utils (C4-225)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jobs:
     - python: "3.6"
     - python: "3.7"
 before_install:
+  - date
   - pip install poetry
 install:
   - echo "Installing through poetry then running tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.33.1"
+version = "0.33.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -80,10 +80,11 @@ def test_s3Utils_creation_cgap():
     test_prd('fourfront-cgap')
 
 
-@pytest.mark.parametrize('cgap_ordinary_envname', ['fourfront-cgaptest', 'fourfront-cgapdev', 'fourfront-cgapwolf'])
-def test_s3Utils_creation(cgap_ordinary_envname):
-    util = s3Utils(env=cgap_ordinary_envname)
-    assert util.sys_bucket == 'elasticbeanstalk-%s-system' % cgap_ordinary_envname
+@pytest.mark.parametrize('ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev',
+                                              'fourfront-cgaptest', 'fourfront-cgapdev', 'fourfront-cgapwolf'])
+def test_s3Utils_creation(ordinary_envname):
+    util = s3Utils(env=ordinary_envname)
+    assert util.sys_bucket == 'elasticbeanstalk-%s-system' % ordinary_envname
 
 
 def test_s3Utils_get_keys_for_data():

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -87,7 +87,7 @@ def test_s3Utils_creation_cgap_prd():
 def test_s3Utils_creation_cgap_stg():
     print("In test_s3Utils_creation_cgap_prd. It is now", str(datetime.datetime.now()))
     # For now there is no CGAP stg...
-    assert compute_cgap_stg_env() is None
+    assert compute_cgap_stg_env() is None, "There seems to be a CGAP staging environment. Tests need updating."
 
 
 @pytest.mark.parametrize('ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev',

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -60,21 +60,24 @@ def test_s3Utils_creation_data():
     test_prd(prd_beanstalk_env)
 
 
-@pytest.mark.parametrize('cgap_production_envname', ['cgap', 'fourfront-cgap'])
-def test_s3Utils_creation_cgap(cgap_production_envname):
-    util = s3Utils(env=cgap_production_envname)
-    actual_props = {
-        'sys_bucket': util.sys_bucket,
-        'outfile_bucket': util.outfile_bucket,
-        'raw_file_bucket': util.raw_file_bucket,
-        'url': util.url,
-    }
-    assert actual_props == {
-        'sys_bucket': 'elasticbeanstalk-fourfront-cgap-system',
-        'outfile_bucket': 'elasticbeanstalk-fourfront-cgap-wfoutput',
-        'raw_file_bucket': 'elasticbeanstalk-fourfront-cgap-files',
-        'url': 'https://cgap.hms.harvard.edu',
-    }
+def test_s3Utils_creation_cgap():
+    print("In test_s3Utils_creation_staging. It is now", str(datetime.datetime.now()))
+    def test_prd(cgap_production_envname):
+        util = s3Utils(env=cgap_production_envname)
+        actual_props = {
+            'sys_bucket': util.sys_bucket,
+            'outfile_bucket': util.outfile_bucket,
+            'raw_file_bucket': util.raw_file_bucket,
+            'url': util.url,
+        }
+        assert actual_props == {
+            'sys_bucket': 'elasticbeanstalk-fourfront-cgap-system',
+            'outfile_bucket': 'elasticbeanstalk-fourfront-cgap-wfoutput',
+            'raw_file_bucket': 'elasticbeanstalk-fourfront-cgap-files',
+            'url': 'https://cgap.hms.harvard.edu',
+        }
+    test_prd('cgap')
+    test_prd('fourfront-cgap')
 
 
 @pytest.mark.parametrize('cgap_ordinary_envname', ['fourfront-cgaptest', 'fourfront-cgapdev', 'fourfront-cgapwolf'])

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -2,8 +2,8 @@ import datetime
 import pytest
 
 from dcicutils.s3_utils import s3Utils
-from dcicutils.beanstalk_utils import compute_ff_prd_env
-from dcicutils.env_utils import get_standard_mirror_env
+from dcicutils.beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env, compute_cgap_stg_env
+from dcicutils.env_utils import get_standard_mirror_env, FF_PUBLIC_URL_STG, FF_PUBLIC_URL_PRD, CGAP_PUBLIC_URL_PRD
 
 
 @pytest.mark.parametrize('ff_ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev', 'fourfront-hotseat'])
@@ -12,8 +12,8 @@ def test_s3Utils_creation(ff_ordinary_envname):
     assert util.sys_bucket == 'elasticbeanstalk-%s-system' % ff_ordinary_envname
 
 
-def test_s3Utils_creation_staging():
-    print("In test_s3Utils_creation_staging. It is now", str(datetime.datetime.now()))
+def test_s3Utils_creation_ff_stg():
+    print("In test_s3Utils_creation_ff_stg. It is now", str(datetime.datetime.now()))
     def test_stg(ff_staging_envname):
         util = s3Utils(env=ff_staging_envname)
         actual_props = {
@@ -26,7 +26,7 @@ def test_s3Utils_creation_staging():
             'sys_bucket': 'elasticbeanstalk-fourfront-webprod-system',
             'outfile_bucket': 'elasticbeanstalk-fourfront-webprod-wfoutput',
             'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
-            'url': 'http://staging.4dnucleome.org',
+            'url': FF_PUBLIC_URL_STG,
         }
     test_stg('staging')
     # NOTE: These values should not be parameters because we don't know how long PyTest caches the
@@ -36,8 +36,8 @@ def test_s3Utils_creation_staging():
     test_stg(stg_beanstalk_env)
 
 
-def test_s3Utils_creation_data():
-    print("In test_s3Utils_creation_data. It is now", str(datetime.datetime.now()))
+def test_s3Utils_creation_ff_prd():
+    print("In test_s3Utils_creation_ff_prd. It is now", str(datetime.datetime.now()))
     def test_prd(ff_production_envname):
         util = s3Utils(env=ff_production_envname)
         actual_props = {
@@ -50,7 +50,7 @@ def test_s3Utils_creation_data():
             'sys_bucket': 'elasticbeanstalk-fourfront-webprod-system',
             'outfile_bucket': 'elasticbeanstalk-fourfront-webprod-wfoutput',
             'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
-            'url': 'https://data.4dnucleome.org',
+            'url': FF_PUBLIC_URL_PRD,
         }
     test_prd('data')
     # NOTE: These values should not be parameters because we don't know how long PyTest caches the
@@ -60,8 +60,8 @@ def test_s3Utils_creation_data():
     test_prd(prd_beanstalk_env)
 
 
-def test_s3Utils_creation_cgap():
-    print("In test_s3Utils_creation_staging. It is now", str(datetime.datetime.now()))
+def test_s3Utils_creation_cgap_prd():
+    print("In test_s3Utils_creation_cgap_prd. It is now", str(datetime.datetime.now()))
     def test_prd(cgap_production_envname):
         util = s3Utils(env=cgap_production_envname)
         actual_props = {
@@ -74,10 +74,20 @@ def test_s3Utils_creation_cgap():
             'sys_bucket': 'elasticbeanstalk-fourfront-cgap-system',
             'outfile_bucket': 'elasticbeanstalk-fourfront-cgap-wfoutput',
             'raw_file_bucket': 'elasticbeanstalk-fourfront-cgap-files',
-            'url': 'https://cgap.hms.harvard.edu',
+            'url': CGAP_PUBLIC_URL_PRD,
         }
     test_prd('cgap')
+    # NOTE: These values should not be parameters because we don't know how long PyTest caches the
+    #       parameter values before using them. By doing the test this way, we hold the value for as
+    #       little time as possible, making it least risk of being stale. -kmp 13-Jul-2020
     test_prd('fourfront-cgap')
+    test_prd(compute_cgap_prd_env())  # Hopefully returns 'fourfront-cgap' but just in case we're into new naming
+
+
+def test_s3Utils_creation_cgap_stg():
+    print("In test_s3Utils_creation_cgap_prd. It is now", str(datetime.datetime.now()))
+    # For now there is no CGAP stg...
+    assert compute_cgap_stg_env() is None
 
 
 @pytest.mark.parametrize('ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev',

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -1,7 +1,9 @@
+import datetime
+import pytest
+
 from dcicutils.s3_utils import s3Utils
 from dcicutils.beanstalk_utils import compute_ff_prd_env
 from dcicutils.env_utils import get_standard_mirror_env
-import pytest
 
 
 @pytest.mark.parametrize('ff_ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev', 'fourfront-hotseat'])
@@ -10,38 +12,52 @@ def test_s3Utils_creation(ff_ordinary_envname):
     assert util.sys_bucket == 'elasticbeanstalk-%s-system' % ff_ordinary_envname
 
 
-@pytest.mark.parametrize('ff_staging_envname', ['staging', get_standard_mirror_env(compute_ff_prd_env())])
-def test_s3Utils_creation_staging(ff_staging_envname):
-    util = s3Utils(env=ff_staging_envname)
-    actual_props = {
-        'sys_bucket': util.sys_bucket,
-        'outfile_bucket': util.outfile_bucket,
-        'raw_file_bucket': util.raw_file_bucket,
-        'url': util.url,
-    }
-    assert actual_props == {
-        'sys_bucket': 'elasticbeanstalk-fourfront-webprod-system',
-        'outfile_bucket': 'elasticbeanstalk-fourfront-webprod-wfoutput',
-        'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
-        'url': 'http://staging.4dnucleome.org',
-    }
+def test_s3Utils_creation_staging():
+    print("In test_s3Utils_creation_staging. It is now", str(datetime.datetime.now()))
+    def test_stg(ff_staging_envname):
+        util = s3Utils(env=ff_staging_envname)
+        actual_props = {
+            'sys_bucket': util.sys_bucket,
+            'outfile_bucket': util.outfile_bucket,
+            'raw_file_bucket': util.raw_file_bucket,
+            'url': util.url,
+        }
+        assert actual_props == {
+            'sys_bucket': 'elasticbeanstalk-fourfront-webprod-system',
+            'outfile_bucket': 'elasticbeanstalk-fourfront-webprod-wfoutput',
+            'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
+            'url': 'http://staging.4dnucleome.org',
+        }
+    test_stg('staging')
+    # NOTE: These values should not be parameters because we don't know how long PyTest caches the
+    #       parameter values before using them. By doing the test this way, we hold the value for as
+    #       little time as possible, making it least risk of being stale. -kmp 10-Jul-2020
+    stg_beanstalk_env = get_standard_mirror_env(compute_ff_prd_env())
+    test_stg(stg_beanstalk_env)
 
 
-@pytest.mark.parametrize('ff_production_envname', ['data', compute_ff_prd_env()])
-def test_s3Utils_creation_data(ff_production_envname):
-    util = s3Utils(env=ff_production_envname)
-    actual_props = {
-        'sys_bucket': util.sys_bucket,
-        'outfile_bucket': util.outfile_bucket,
-        'raw_file_bucket': util.raw_file_bucket,
-        'url': util.url,
-    }
-    assert actual_props == {
-        'sys_bucket': 'elasticbeanstalk-fourfront-webprod-system',
-        'outfile_bucket': 'elasticbeanstalk-fourfront-webprod-wfoutput',
-        'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
-        'url': 'https://data.4dnucleome.org',
-    }
+def test_s3Utils_creation_data():
+    print("In test_s3Utils_creation_data. It is now", str(datetime.datetime.now()))
+    def test_prd(ff_production_envname):
+        util = s3Utils(env=ff_production_envname)
+        actual_props = {
+            'sys_bucket': util.sys_bucket,
+            'outfile_bucket': util.outfile_bucket,
+            'raw_file_bucket': util.raw_file_bucket,
+            'url': util.url,
+        }
+        assert actual_props == {
+            'sys_bucket': 'elasticbeanstalk-fourfront-webprod-system',
+            'outfile_bucket': 'elasticbeanstalk-fourfront-webprod-wfoutput',
+            'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
+            'url': 'https://data.4dnucleome.org',
+        }
+    test_prd('data')
+    # NOTE: These values should not be parameters because we don't know how long PyTest caches the
+    #       parameter values before using them. By doing the test this way, we hold the value for as
+    #       little time as possible, making it least risk of being stale. -kmp 10-Jul-2020
+    prd_beanstalk_env = compute_ff_prd_env()
+    test_prd(prd_beanstalk_env)
 
 
 @pytest.mark.parametrize('cgap_production_envname', ['cgap', 'fourfront-cgap'])


### PR DESCRIPTION
In order to address the problem described in [C4-225](https://hms-dbmi.atlassian.net/browse/C4-225), this fix moves the computation of the interesting value (the current production beanstalk) to right before it gets used, so that it won't go stale waiting to be used.  I got rid of the loop so that it wouldn't sit for the execution of the first pass through the loop before needing the second value. Instead, I just turned the loop body into a function, and each of the two calls it was going to iterate over into visibly distinct calls to that function so that the second value is computed as late as can be.

**Testing**

Probably the conditions of the failure are hard to make happen, although we _could_ arrange to run tests in a coordinated way with the CNAME swap sometime to be sure. Still, it's hard to see how doing it this way can make anything worse so it seems worth making this change regardless.

Also, this adds a call to `date` to the `.travis.yml` so it's easier to quickly tell what time the test ran in case of future problems.