### PR TITLE
Add LockoutManager and RateManager

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -359,108 +359,112 @@ def utc_today_str():
     return datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y-%m-%d")
 
 
-class LockoutManager:
-    """
-    This class is used as a guard of a critical operation that can only be called within a certain frequency.
-    e.g.,
-
-        class Foo:
-            def __init__(self):
-                # 60 seconds required between calls, with a 1 second margin of error (overhead, clocks varying, etc)
-                self.lockout_manager = LockoutManager(action="foo", lockout_seconds=1, safety_seconds=1)
-            def foo():
-                self.lockout_manager.wait_if_needed()
-                do_guarded_action()
-
-        f = Foo()     # make a Foo
-        v1 = f.foo()  # will immediately get a value
-        time.sleep(58)
-        v2 = f.foo()  # will wait about 2 seconds, then get a value
-        v3 = f.foo()  # will wait about 60 seconds, then get a value
-
-    Conceptually this is a special case of RateManager for n=1, though in practice it arose differently and
-    the supplementary methods (which we happen to use mostly for testing) differ because the n=1 case is simpler
-    and admits more questions. So, for now at least, this is not a subclass of RateManager but a separate
-    implementation.
-    """
-
-    EARLIEST_TIMESTAMP = datetime.datetime(datetime.MINYEAR, 1, 1)  # maybe useful for testing
-
-    def __init__(self, *, lockout_seconds, safety_seconds=0, action="metered action", enabled=True, log=None):
-        """
-        Creates a LockoutManager that cooperates in assuring a guarded operation is only happens at a certain rate.
-
-        The rate is once person lockout_seconds. This is a special case of RateManager and might get phased out
-        as redundant, but has slightly different operations available for testing.
-
-        Args:
-
-        lockout_seconds int: A theoretical number of seconds allowed between calls to the guarded operation.
-        safety_seconds int: An amount added to interval_seconds to accommodate real world coordination fuzziness.
-        action str: A noun or noun phrase describing the action being guarded.
-        enabled bool: A boolean controlling whether this facility is enabled. If False, waiting is disabled.
-        log object: A logger object (supporting operations like .debug, .info, .warning, and .error).
-        """
-
-        # This makes it easy to turn off the feature
-        self.lockout_enabled = enabled
-        self.lockout_seconds = lockout_seconds
-        self.safety_seconds = safety_seconds
-        self.action = action
-        self._timestamp = self.EARLIEST_TIMESTAMP
-        self.log = log or logging
-
-    @property
-    def timestamp(self):
-        """The timestamp is read-only. Use update_timestamp() to set it."""
-        return self._timestamp
-
-    @property
-    def effective_lockout_seconds(self):
-        """
-        The effective time between calls
-
-        Returns: the sum of the lockout and the safety seconds
-        """
-        return self.lockout_seconds + self.safety_seconds
-
-    def wait_if_needed(self):
-        """
-        This function is intended to be called immediately prior to each guarded operation.
-
-        This function will wait (using time.sleep) only if necessary, and for the amount necessary,
-        to comply with rate-limiting declared in the creation of this LockoutManager.
-
-        NOTE WELL: It is presumed that all calls are coming from this source. This doesn't have ESP that would
-        detect or otherwise accommodate externally generated calls, so violations of rate-limiting can still
-        happen that way. This should be sufficient for sequential testing, and better than nothing for
-        production operation.  This is not a substitute for responding to server-initiated throttling protocols.
-        """
-        now = datetime.datetime.now()
-        # Note that this quantity is always positive because now is always bigger than the timestamp.
-        seconds_since_last_purge = (now - self._timestamp).total_seconds()
-        # Note again that because seconds_since_last_attempt is positive, the wait seconds will
-        # never exceed self.effective_lockout_seconds, so
-        #   0 <= wait_seconds <= self.effective_lockout_seconds
-        wait_seconds = max(0.0, self.effective_lockout_seconds - seconds_since_last_purge)
-        if wait_seconds > 0.0:
-            shared_message = ("Last %s attempt was at %s (%s seconds ago)."
-                              % (self.action, self._timestamp, seconds_since_last_purge))
-            if self.lockout_enabled:
-                action_message = "Waiting %s seconds before attempting another." % wait_seconds
-                self.log.warning("%s %s" % (shared_message, action_message))
-                time.sleep(wait_seconds)
-            else:
-                action_message = "Continuing anyway because lockout is disabled."
-                self.log.warning("%s %s" % (shared_message, action_message))
-        self.update_timestamp()
-
-    def update_timestamp(self):
-        """
-        Explicitly sets the reference time point for computation of our lockout.
-        This is called implicitly by .wait_if_needed(), and for some situations that may be sufficient.
-        """
-        self._timestamp = datetime.datetime.now()
+# I think we will not need LockoutManager. It's really just a special case of RateManager,
+# though its operations are a little different. This commented-out code should be removed
+# once we have successfully installed a system based on RateManager. -kmp 20-Jul-2020
+#
+# class LockoutManager:
+#     """
+#     This class is used as a guard of a critical operation that can only be called within a certain frequency.
+#     e.g.,
+#
+#         class Foo:
+#             def __init__(self):
+#                 # 60 seconds required between calls, with a 1 second margin of error (overhead, clocks varying, etc)
+#                 self.lockout_manager = LockoutManager(action="foo", lockout_seconds=1, safety_seconds=1)
+#             def foo():
+#                 self.lockout_manager.wait_if_needed()
+#                 do_guarded_action()
+#
+#         f = Foo()     # make a Foo
+#         v1 = f.foo()  # will immediately get a value
+#         time.sleep(58)
+#         v2 = f.foo()  # will wait about 2 seconds, then get a value
+#         v3 = f.foo()  # will wait about 60 seconds, then get a value
+#
+#     Conceptually this is a special case of RateManager for n=1, though in practice it arose differently and
+#     the supplementary methods (which we happen to use mostly for testing) differ because the n=1 case is simpler
+#     and admits more questions. So, for now at least, this is not a subclass of RateManager but a separate
+#     implementation.
+#     """
+#
+#     EARLIEST_TIMESTAMP = datetime.datetime(datetime.MINYEAR, 1, 1)  # maybe useful for testing
+#
+#     def __init__(self, *, lockout_seconds, safety_seconds=0, action="metered action", enabled=True, log=None):
+#         """
+#         Creates a LockoutManager that cooperates in assuring a guarded operation is only happens at a certain rate.
+#
+#         The rate is once person lockout_seconds. This is a special case of RateManager and might get phased out
+#         as redundant, but has slightly different operations available for testing.
+#
+#         Args:
+#
+#         lockout_seconds int: A theoretical number of seconds allowed between calls to the guarded operation.
+#         safety_seconds int: An amount added to interval_seconds to accommodate real world coordination fuzziness.
+#         action str: A noun or noun phrase describing the action being guarded.
+#         enabled bool: A boolean controlling whether this facility is enabled. If False, waiting is disabled.
+#         log object: A logger object (supporting operations like .debug, .info, .warning, and .error).
+#         """
+#
+#         # This makes it easy to turn off the feature
+#         self.lockout_enabled = enabled
+#         self.lockout_seconds = lockout_seconds
+#         self.safety_seconds = safety_seconds
+#         self.action = action
+#         self._timestamp = self.EARLIEST_TIMESTAMP
+#         self.log = log or logging
+#
+#     @property
+#     def timestamp(self):
+#         """The timestamp is read-only. Use update_timestamp() to set it."""
+#         return self._timestamp
+#
+#     @property
+#     def effective_lockout_seconds(self):
+#         """
+#         The effective time between calls
+#
+#         Returns: the sum of the lockout and the safety seconds
+#         """
+#         return self.lockout_seconds + self.safety_seconds
+#
+#     def wait_if_needed(self):
+#         """
+#         This function is intended to be called immediately prior to each guarded operation.
+#
+#         This function will wait (using time.sleep) only if necessary, and for the amount necessary,
+#         to comply with rate-limiting declared in the creation of this LockoutManager.
+#
+#         NOTE WELL: It is presumed that all calls are coming from this source. This doesn't have ESP that would
+#         detect or otherwise accommodate externally generated calls, so violations of rate-limiting can still
+#         happen that way. This should be sufficient for sequential testing, and better than nothing for
+#         production operation.  This is not a substitute for responding to server-initiated throttling protocols.
+#         """
+#         now = datetime.datetime.now()
+#         # Note that this quantity is always positive because now is always bigger than the timestamp.
+#         seconds_since_last_purge = (now - self._timestamp).total_seconds()
+#         # Note again that because seconds_since_last_attempt is positive, the wait seconds will
+#         # never exceed self.effective_lockout_seconds, so
+#         #   0 <= wait_seconds <= self.effective_lockout_seconds
+#         wait_seconds = max(0.0, self.effective_lockout_seconds - seconds_since_last_purge)
+#         if wait_seconds > 0.0:
+#             shared_message = ("Last %s attempt was at %s (%s seconds ago)."
+#                               % (self.action, self._timestamp, seconds_since_last_purge))
+#             if self.lockout_enabled:
+#                 action_message = "Waiting %s seconds before attempting another." % wait_seconds
+#                 self.log.warning("%s %s" % (shared_message, action_message))
+#                 time.sleep(wait_seconds)
+#             else:
+#                 action_message = "Continuing anyway because lockout is disabled."
+#                 self.log.warning("%s %s" % (shared_message, action_message))
+#         self.update_timestamp()
+#
+#     def update_timestamp(self):
+#         """
+#         Explicitly sets the reference time point for computation of our lockout.
+#         This is called implicitly by .wait_if_needed(), and for some situations that may be sufficient.
+#         """
+#         self._timestamp = datetime.datetime.now()
 
 
 class RateManager:

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -193,6 +193,12 @@ class Retry:
     """
 
     class RetryOptions:
+        """
+        A helper class used internally by the Retry class.
+
+        One of these objects is created and registered for each decorated function unless the name_key is 'anonymous'.
+        See Retry._RETRY_OPTIONS_CATALOG.
+        """
 
         def __init__(self, retries_allowed=None, wait_seconds=None, wait_increment=None, wait_multiplier=None):
             self.retries_allowed = retries_allowed
@@ -246,6 +252,15 @@ class Retry:
         will cause the something_that_fails_a_lot(...) code to retry several times before giving up,
         either using the same wait each time or, if given a wait_multiplier or wait_increment, using
         that advice to adjust the wait time upward on each time.
+
+        Args:
+
+            name_key: An optional key that can be used by qa_utils.RetryManager to adjust these parameters in testing.
+                      If the argument is 'anonymous', no record will be created.
+            retries_allowed: The number of retries allowed. Default is cls.DEFAULT_RETRIES_ALLOWED.
+            wait_seconds: The number of wait_seconds between retries. Default is cls.DEFAULT_WAIT_SECONDS.
+            wait_increment: A fixed increment by which the number of wait_seconds is adjusted on each retry.
+            wait_multiplier: A multiplier by which the number of wait_seconds is adjusted on each retry.
         """
 
         def decorator(function):
@@ -304,6 +319,15 @@ class Retry:
             res2 = retrying(testapp.get)(url)
             ...etc.
 
+        Args:
+
+            fn: A function that will be retried on failure.
+            retries_allowed: The number of retries allowed. Default is cls.DEFAULT_RETRIES_ALLOWED.
+            wait_seconds: The number of wait_seconds between retries. Default is cls.DEFAULT_WAIT_SECONDS.
+            wait_increment: A fixed increment by which the number of wait_seconds is adjusted on each retry.
+            wait_multiplier: A multiplier by which the number of wait_seconds is adjusted on each retry.
+
+        Returns: whatever the fn returns, assuming it returns normally/successfully.
         """
         # A special name_key of 'anonymous' is the default, which causes there not to be a name key.
         # This cannot work in conjunction with RetryManager because different calls may result in different
@@ -316,6 +340,13 @@ class Retry:
 
 
 def apply_dict_overrides(dictionary: dict, **overrides) -> dict:
+    """
+    Assigns a given set of overrides to a dictionary, ignoring any entries with None values, which it leaves alone.
+    """
+    # I'm not entirely sure the treatment of None is the right thing. Need to look into that.
+    # Then again, if None were stored, then apply_dict_overrides(d, var1=1, var2=2, var3=None)
+    # would be no different than (dict(d, var1=1, var2=2, var3=None). It might be more useful
+    # and/or interesting if it would actually remove the key instead. -kmp 18-Jul-2020
     for k, v in overrides.items():
         if v is not None:
             dictionary[k] = v
@@ -324,21 +355,60 @@ def apply_dict_overrides(dictionary: dict, **overrides) -> dict:
 
 
 def utc_today_str():
+    """Returns a YYYY-mm-dd date string, relative to the UTC timezone."""
     return datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y-%m-%d")
 
 
 class LockoutManager:
+    """
+    This class is used as a guard of a critical operation that can only be called within a certain frequency.
+    e.g.,
+
+        class Foo:
+            def __init__(self):
+                # 60 seconds required between calls, with a 1 second margin of error (overhead, clocks varying, etc)
+                self.lockout_manager = LockoutManager(action="foo", lockout_seconds=1, safety_seconds=1)
+            def foo():
+                self.lockout_manager.wait_if_needed()
+                do_guarded_action()
+
+        f = Foo()     # make a Foo
+        v1 = f.foo()  # will immediately get a value
+        time.sleep(58)
+        v2 = f.foo()  # will wait about 2 seconds, then get a value
+        v3 = f.foo()  # will wait about 60 seconds, then get a value
+
+    Conceptually this is a special case of RateManager for n=1, though in practice it arose differently and
+    the supplementary methods (which we happen to use mostly for testing) differ because the n=1 case is simpler
+    and admits more questions. So, for now at least, this is not a subclass of RateManager but a separate
+    implementation.
+    """
 
     EARLIEST_TIMESTAMP = datetime.datetime(datetime.MINYEAR, 1, 1)  # maybe useful for testing
 
     def __init__(self, *, lockout_seconds, safety_seconds=0, action="metered action", enabled=True, log=None):
+        """
+        Creates a LockoutManager that cooperates in assuring a guarded operation is only happens at a certain rate.
+
+        The rate is once person lockout_seconds. This is a special case of RateManager and might get phased out
+        as redundant, but has slightly different operations available for testing.
+
+        Args:
+
+        lockout_seconds int: A theoretical number of seconds allowed between calls to the guarded operation.
+        safety_seconds int: An amount added to interval_seconds to accommodate real world coordination fuzziness.
+        action str: A noun or noun phrase describing the action being guarded.
+        enabled bool: A boolean controlling whether this facility is enabled. If False, waiting is disabled.
+        log object: A logger object (supporting operations like .debug, .info, .warning, and .error).
+        """
+
         # This makes it easy to turn off the feature
         self.lockout_enabled = enabled
         self.lockout_seconds = lockout_seconds
         self.safety_seconds = safety_seconds
         self.action = action
         self._timestamp = self.EARLIEST_TIMESTAMP
-        self.log = log
+        self.log = log or logging
 
     @property
     def timestamp(self):
@@ -347,9 +417,25 @@ class LockoutManager:
 
     @property
     def effective_lockout_seconds(self):
+        """
+        The effective time between calls
+
+        Returns: the sum of the lockout and the safety seconds
+        """
         return self.lockout_seconds + self.safety_seconds
 
     def wait_if_needed(self):
+        """
+        This function is intended to be called immediately prior to each guarded operation.
+
+        This function will wait (using time.sleep) only if necessary, and for the amount necessary,
+        to comply with rate-limiting declared in the creation of this LockoutManager.
+
+        NOTE WELL: It is presumed that all calls are coming from this source. This doesn't have ESP that would
+        detect or otherwise accommodate externally generated calls, so violations of rate-limiting can still
+        happen that way. This should be sufficient for sequential testing, and better than nothing for
+        production operation.  This is not a substitute for responding to server-initiated throttling protocols.
+        """
         now = datetime.datetime.now()
         # Note that this quantity is always positive because now is always bigger than the timestamp.
         seconds_since_last_purge = (now - self._timestamp).total_seconds()
@@ -362,13 +448,11 @@ class LockoutManager:
                               % (self.action, self._timestamp, seconds_since_last_purge))
             if self.lockout_enabled:
                 action_message = "Waiting %s seconds before attempting another." % wait_seconds
-                if self.log:
-                    self.log.warning("%s %s" % (shared_message, action_message))
+                self.log.warning("%s %s" % (shared_message, action_message))
                 time.sleep(wait_seconds)
             else:
                 action_message = "Continuing anyway because lockout is disabled."
-                if self.log:
-                    self.log.warning("%s %s" % (shared_message, action_message))
+                self.log.warning("%s %s" % (shared_message, action_message))
         self.update_timestamp()
 
     def update_timestamp(self):
@@ -380,11 +464,50 @@ class LockoutManager:
 
 
 class RateManager:
+    """
+    This class is used for functions that can only be called at a certain rate, described by calls per unit time.
+    e.g.,
+
+        class Foo:
+            def __init__(self):
+                # 60 seconds required between calls, with a 1 second margin of error (overhead, clocks varying, etc)
+                self.rate_manager = RateManager(action="foo", interval_seconds=1, safety_seconds=1)
+            def foo():
+                self.lockout_manager.wait_if_needed()
+                do_guarded_action()
+
+        f = Foo()     # make a Foo
+        v1 = f.foo()  # will immediately get a value
+        time.sleep(58)
+        v2 = f.foo()  # will wait about 2 seconds, then get a value
+        v3 = f.foo()  # will wait about 60 seconds, then get a value
+
+    Conceptually this is a special case of RateManager for n=1, though in practice it arose differently and
+    the supplementary methods (which we happen to use mostly for testing) differ because the n=1 case is simpler
+    and admits more questions. So, for now at least, this is not a subclass of RateManager but a separate
+    implementation.
+    """
 
     EARLIEST_TIMESTAMP = datetime.datetime(datetime.MINYEAR, 1, 1)  # maybe useful for testing
 
     def __init__(self, *, interval_seconds, safety_seconds=0, allowed_attempts=1,
                  action="metered action", enabled=True, log=None, wait_hook=None):
+        """
+        Creates a RateManager that cooperates in assuring that a guarded operation happens only at a certain rate.
+
+        The rate is measured as allowed_attempts per interval_seconds.
+
+        Args:
+
+        interval_seconds int: A number of seconds (the theoretical denominator of the allowed rate)
+        safety_seconds int: An amount added to interval_seconds to accommodate real world coordination fuzziness.
+        allowed_attempts int: A number of attempts allowed for every interval_seconds.
+        action str: A noun or noun phrase describing the action being guarded.
+        enabled bool: A boolean controlling whether this facility is enabled. If False, waiting is disabled.
+        log object: A logger object (supporting operations like .debug, .info, .warning, and .error).
+        wait_hook: A hook not recommended for production, but intended for testing to know when waiting happens.
+
+        """
         if not (isinstance(allowed_attempts, int) and allowed_attempts >= 1):
             raise TypeError("The allowed_attempts must be a positive integer: %s" % allowed_attempts)
         # This makes it easy to turn off the feature
@@ -394,16 +517,31 @@ class RateManager:
         self.allowed_attempts = allowed_attempts
         self.action = action
         self.timestamps = [self.EARLIEST_TIMESTAMP] * allowed_attempts
-        self.log = log
+        self.log = log or logging
         self.wait_hook = wait_hook
 
-    def set_wait_hook(self, noticer):
+    def set_wait_hook(self, wait_hook):
         """
         Use this to set the wait hook, which will be a function that notices we had to wait.
+
+        Args:
+
+        wait_hook: a function of two arguments (wait_seconds and next_expiration)
         """
-        self.wait_hook = noticer
+        self.wait_hook = wait_hook
 
     def wait_if_needed(self):
+        """
+        This function is intended to be called immediately prior to each guarded operation.
+
+        This function will wait (using time.sleep) only if necessary, and for the amount necessary,
+        to comply with rate-limiting declared in the creation of this RateManager.
+
+        NOTE WELL: It is presumed that all calls are coming from this source. This doesn't have ESP that would
+        detect or otherwise accommodate externally generated calls, so violations of rate-limiting can still
+        happen that way. This should be sufficient for sequential testing, and better than nothing for
+        production operation.  This is not a substitute for responding to server-initiated throttling protocols.
+        """
         now = datetime.datetime.now()
         expiration_delta = datetime.timedelta(seconds=self.interval_seconds)
         latest_expiration = now + expiration_delta
@@ -417,8 +555,10 @@ class RateManager:
                 soonest_expiration = expiration_time
                 soonest_expiration_pos = i
         sleep_time_needed = (soonest_expiration - now).total_seconds() + self.safety_seconds
-        if self.wait_hook:  # Hook primarily for testing
-            self.wait_hook(wait_seconds=sleep_time_needed, next_expiration=soonest_expiration)
-        time.sleep(sleep_time_needed)
+        if self.enabled:
+            if self.wait_hook:  # Hook primarily for testing
+                self.wait_hook(wait_seconds=sleep_time_needed, next_expiration=soonest_expiration)
+            self.log.warning("Waiting %s seconds before attempting %s." % (sleep_time_needed, self.action))
+            time.sleep(sleep_time_needed)
         # It will have expired now, so grab that slot
         self.timestamps[soonest_expiration_pos] = datetime.datetime.now() + expiration_delta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.33.2"
+version = "0.34.0b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.34.0b0"
+version = "0.33.2.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.33.2.1b1"
+version = "0.34.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.33.2.1b0"
+version = "0.33.2.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -604,104 +604,108 @@ def test_utc_today_str():
     assert re.match(pattern, actual), "utc_today_str() result %s did not match format: %s" % (actual, pattern)
 
 
-def test_lockout_manager():
-
-    protected_action = "simulated action"
-
-    # The function now() will get us the time. This assure us that binding datetime.datetime
-    # will not be affecting us.
-    now = datetime_module.datetime.now
-
-    # real_t0 is the actual wallclock time at the start of this test. We use it only to make sure
-    # that all these other tests are really going through our mock. In spite of longer mocked
-    # timescales, this test should run quickly.
-    real_t0 = now()
-    print("Starting test at", real_t0)
-
-    # dt will be our substitute for datetime.datetime.
-    # (it also has a sleep method that we can substitute for time.sleep)
-    dt = ControlledTime(tick_seconds=1)
-
-    class MockLogger:
-
-        def __init__(self):
-            self.log = []
-
-        def warning(self, msg):
-            self.log.append(msg)
-
-    with mock.patch("datetime.datetime", dt):
-        with mock.patch("time.sleep", dt.sleep):
-            my_log = MockLogger()
-
-            assert isinstance(datetime_module.datetime, ControlledTime)
-
-            lockout_manager = LockoutManager(action=protected_action,
-                                             lockout_seconds=60,
-                                             safety_seconds=1,
-                                             log=my_log)
-            assert not hasattr(lockout_manager, 'client')  # Just for safety, we don't need a client for this test
-
-            t0 = dt.just_now()
-
-            lockout_manager.wait_if_needed()
-
-            t1 = dt.just_now()
-
-            print("t0=", t0)
-            print("t1=", t1)
-
-            # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
-            # and we expect exactly two calls to be made in the called function:
-            #  - Once on entry to get the current time prior to the protected action
-            #  - Once on exit to set the timestamp after the protected action.
-            # We expect no sleeps, so that doesn't play in.
-            assert (t1 - t0).total_seconds() == 2
-
-            assert my_log.log == []
-
-            lockout_manager.wait_if_needed()
-
-            t2 = dt.just_now()
-
-            print("t2=", t2)
-
-            # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
-            # and we expect exactly two calls to be made in the called function, plus we also
-            # expect to sleep for 60 seconds of the 61 seconds it wants to reserve (one second having
-            # passed since the last protected action).
-
-            assert (t2 - t1).total_seconds() == 62
-
-            assert my_log.log == ['Last %s attempt was at 2010-01-01 12:00:02 (1.0 seconds ago).'
-                                  ' Waiting 60.0 seconds before attempting another.' % protected_action]
-
-            my_log.log = []  # Reset the log
-
-            dt.sleep(30)  # Simulate 30 seconds of time passing
-
-            t3 = dt.just_now()
-            print("t3=", t3)
-
-            lockout_manager.wait_if_needed()
-
-            t4 = dt.just_now()
-            print("t4=", t4)
-
-            # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
-            # and we expect exactly two calls to be made in the called function, plus we also
-            # expect to sleep for 30 seconds of the 61 seconds it wants to reserve (31 seconds having
-            # passed since the last protected action).
-
-            assert (t4 - t3).total_seconds() == 32
-
-            assert my_log.log == ['Last %s attempt was at 2010-01-01 12:01:04 (31.0 seconds ago).'
-                                  ' Waiting 30.0 seconds before attempting another.' % protected_action]
-
-    real_t1 = now()
-    print("Done testing at", real_t1)
-    # Whole test should happen much faster, less than a half second
-    assert (real_t1 - real_t0).total_seconds() < 0.5
+# I think we will not need LockoutManager. It's really just a special case of RateManager,
+# though its operations are a little different. This commented-out code should be removed
+# once we have successfully installed a system based on RateManager. -kmp 20-Jul-2020
+#
+# def test_lockout_manager():
+#
+#     protected_action = "simulated action"
+#
+#     # The function now() will get us the time. This assure us that binding datetime.datetime
+#     # will not be affecting us.
+#     now = datetime_module.datetime.now
+#
+#     # real_t0 is the actual wallclock time at the start of this test. We use it only to make sure
+#     # that all these other tests are really going through our mock. In spite of longer mocked
+#     # timescales, this test should run quickly.
+#     real_t0 = now()
+#     print("Starting test at", real_t0)
+#
+#     # dt will be our substitute for datetime.datetime.
+#     # (it also has a sleep method that we can substitute for time.sleep)
+#     dt = ControlledTime(tick_seconds=1)
+#
+#     class MockLogger:
+#
+#         def __init__(self):
+#             self.log = []
+#
+#         def warning(self, msg):
+#             self.log.append(msg)
+#
+#     with mock.patch("datetime.datetime", dt):
+#         with mock.patch("time.sleep", dt.sleep):
+#             my_log = MockLogger()
+#
+#             assert isinstance(datetime_module.datetime, ControlledTime)
+#
+#             lockout_manager = LockoutManager(action=protected_action,
+#                                              lockout_seconds=60,
+#                                              safety_seconds=1,
+#                                              log=my_log)
+#             assert not hasattr(lockout_manager, 'client')  # Just for safety, we don't need a client for this test
+#
+#             t0 = dt.just_now()
+#
+#             lockout_manager.wait_if_needed()
+#
+#             t1 = dt.just_now()
+#
+#             print("t0=", t0)
+#             print("t1=", t1)
+#
+#             # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
+#             # and we expect exactly two calls to be made in the called function:
+#             #  - Once on entry to get the current time prior to the protected action
+#             #  - Once on exit to set the timestamp after the protected action.
+#             # We expect no sleeps, so that doesn't play in.
+#             assert (t1 - t0).total_seconds() == 2
+#
+#             assert my_log.log == []
+#
+#             lockout_manager.wait_if_needed()
+#
+#             t2 = dt.just_now()
+#
+#             print("t2=", t2)
+#
+#             # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
+#             # and we expect exactly two calls to be made in the called function, plus we also
+#             # expect to sleep for 60 seconds of the 61 seconds it wants to reserve (one second having
+#             # passed since the last protected action).
+#
+#             assert (t2 - t1).total_seconds() == 62
+#
+#             assert my_log.log == ['Last %s attempt was at 2010-01-01 12:00:02 (1.0 seconds ago).'
+#                                   ' Waiting 60.0 seconds before attempting another.' % protected_action]
+#
+#             my_log.log = []  # Reset the log
+#
+#             dt.sleep(30)  # Simulate 30 seconds of time passing
+#
+#             t3 = dt.just_now()
+#             print("t3=", t3)
+#
+#             lockout_manager.wait_if_needed()
+#
+#             t4 = dt.just_now()
+#             print("t4=", t4)
+#
+#             # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
+#             # and we expect exactly two calls to be made in the called function, plus we also
+#             # expect to sleep for 30 seconds of the 61 seconds it wants to reserve (31 seconds having
+#             # passed since the last protected action).
+#
+#             assert (t4 - t3).total_seconds() == 32
+#
+#             assert my_log.log == ['Last %s attempt was at 2010-01-01 12:01:04 (31.0 seconds ago).'
+#                                   ' Waiting 30.0 seconds before attempting another.' % protected_action]
+#
+#     real_t1 = now()
+#     print("Done testing at", real_t1)
+#     # Whole test should happen much faster, less than a half second
+#     assert (real_t1 - real_t0).total_seconds() < 0.5
 
 
 def test_rate_manager():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -10,7 +10,8 @@ import webtest
 from dcicutils.misc_utils import (
     PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp, VirtualAppError,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
-    Retry, apply_dict_overrides, utc_today_str, LockoutManager, RateManager
+    Retry, apply_dict_overrides, utc_today_str, RateManager,
+    # LockoutManager,
 )
 from dcicutils.qa_utils import Occasionally, ControlledTime
 from unittest import mock

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -728,6 +728,9 @@ def test_rate_manager():
     class MockLogger:
 
         def __init__(self):
+            self.reset()
+
+        def reset(self):
             self.log = []
 
         def warning(self, msg):
@@ -776,6 +779,11 @@ def test_rate_manager():
             assert (t1 - t0).total_seconds() <= 1  # 4 ticks is MUCH less than one second, even with roundoff error
             assert wait_tester.count == 0
 
+            print(json.dumps(my_log.log, indent=2))
+            assert my_log.log == []
+
+            my_log.reset()
+
             print("Part B")
 
             t0 = dt.just_now()
@@ -792,6 +800,12 @@ def test_rate_manager():
             assert wait_seconds >  55, "Wait time (%s seconds) was shorter than expected." % wait_seconds
             assert wait_seconds <= 65, "Wait time (%s seconds) was longer than expected." % wait_seconds
             assert wait_tester.count == 1
+
+            print(json.dumps(my_log.log, indent=2))
+            [log_msg_1] = my_log.log
+            assert re.match("Waiting 6[0-9][.][0-9]* seconds before attempting simulated action[.]", log_msg_1)
+
+            my_log.reset()
 
             print("Part C")
 
@@ -819,6 +833,12 @@ def test_rate_manager():
             assert wait_seconds > expected_wait - 5, "Wait time (%s seconds) was shorter than expected." % wait_seconds
             assert wait_seconds <= expected_wait + 5, "Wait time (%s seconds) was longer than expected." % wait_seconds
             assert wait_tester.count == 2
+
+            print(json.dumps(my_log.log, indent=2))
+            [log_msg_1] = my_log.log
+            assert re.match("Waiting 3[0-9][.][0-9]* seconds before attempting simulated action[.]", log_msg_1)
+
+            my_log.reset()
 
             print("Part D")
 
@@ -850,6 +870,13 @@ def test_rate_manager():
             assert wait_seconds > expected_wait - 5, "Wait time (%s seconds) was shorter than expected." % wait_seconds
             assert wait_seconds <= expected_wait + 5, "Wait time (%s seconds) was longer than expected." % wait_seconds
             assert wait_tester.count == 4
+
+            print(json.dumps(my_log.log, indent=2))
+            [log_msg_1, log_msg_2] = my_log.log
+            assert re.match("Waiting 3[0-9][.][0-9]* seconds before attempting simulated action[.]", log_msg_1)
+            assert re.match("Waiting 1[0-9][.][0-9]* seconds before attempting simulated action[.]", log_msg_2)
+
+            my_log.reset()
 
             print("End of Parts")
 


### PR DESCRIPTION
Adds a class `RateManager` which does rate-limiting (e.g., to accomplish lockout for a threshold period of time on a guarded operation, or to avoid throttling). This is a generalization of the original `LockoutManager` (which only managed the case of 1 call per interval time).

This does not do synchronization locking in case of race conditions. I think that's still an improvement over what we are doing now, but it might be a useful addition

Note that `LockoutManager` (factored out of snovault's purge code) is included, but only as a comment. Per @willronchetti's comments, `RateManager` should be enough, and so I've eliminated the redundancy. Since there was some investment in producing the other, I've kept it as a comment for now in case we need to revert to or refer to it. But we can make the commented-out code go away soon when `RateManager` is fully installed and running smoothly.
