### PR TITLE
Small improvements toward a better future

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -117,6 +117,15 @@ class VirtualApp:
         except webtest.AppError as e:
             raise VirtualAppError(msg='HTTP PATCH failed.', url=url, body=fields, raw_exception=e)
 
+    @property
+    def app(self):
+        """ Returns the .app of the wrapped_app.
+
+            For example, this allows one to refer to myapp.app.registry without having to know
+            if myapp is a TestApp or a VirtualApp.
+        """
+        return self.wrapped_app.app
+
 
 def ignored(*args, **kwargs):
     """
@@ -570,3 +579,24 @@ class RateManager:
             time.sleep(sleep_time_needed)
         # It will have expired now, so grab that slot. We have to recompute the 'now' time because we slept in between.
         self.timestamps[soonest_expiration_pos] = datetime.datetime.now() + expiration_delta
+
+
+def environ_bool(var, default=False):
+    """
+    Returns True if the named environment variable is set to 'true' (in any alphabetic case), False if something else.
+
+    If the variable value is not set, the default is returned. False is the default default.
+    This function is intended to allow boolean parameters to be initialized from environment variables.
+    e.g.,
+        DEBUG_FOO = environ_bool("FOO")
+    or. if a special value is desired when the variable is not set:
+        DEBUG_FOO = environ_bool("FOO", default=None)
+
+    Args:
+        var str: The name of an environment variable.
+        default object: Any object.
+    """
+    if var not in os.environ:
+        return default
+    else:
+        return os.environ[var].lower() == "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.35.1"
+version = "0.36.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Just a couple of small changes that will allow code to later be nicer in `CGAP` and `Fourfront`. No immediate urgency:
* In `misc_utils`, make it possible to `.app` on `VirtualApp` directly so that one doesn't have to write `vapp.wrapped_app.app` to get that value. This would eliminate the need to conditionalize `VirtualApp` vs `TestApp` in a few places.
* In `misc_utils`, add `environ_bool` so that one can do `FOOBAR = environ_bool('FOOBAR')` rather than a more complicated string that gets the string in `FOOBAR` and coerces it to a boolean. Unit tests are added. (There's a weird change from `self.reset()` to instead do `self.log = []` that may seem pointless, PyCharm was fussing that an attribute was getting outside of `__init__.py` and I couldn't be bothered to fight it about that.
* Bump minor version for new functionality.