### PR TITLE
Make LockoutManager available after all

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -216,7 +216,8 @@ class Retry:
             self.wait_multiplier = wait_multiplier
             self.wait_adjustor = self.make_wait_adjustor(wait_increment=wait_increment, wait_multiplier=wait_multiplier)
 
-        def make_wait_adjustor(self, wait_increment=None, wait_multiplier=None):
+        @staticmethod
+        def make_wait_adjustor(wait_increment=None, wait_multiplier=None):
             """
             Returns a function that can be called to adjust wait_seconds based on wait_increment or wait_multiplier
             before doing a retry at each step.
@@ -368,112 +369,108 @@ def utc_today_str():
     return datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y-%m-%d")
 
 
-# I think we will not need LockoutManager. It's really just a special case of RateManager,
-# though its operations are a little different. This commented-out code should be removed
-# once we have successfully installed a system based on RateManager. -kmp 20-Jul-2020
-#
-# class LockoutManager:
-#     """
-#     This class is used as a guard of a critical operation that can only be called within a certain frequency.
-#     e.g.,
-#
-#         class Foo:
-#             def __init__(self):
-#                 # 60 seconds required between calls, with a 1 second margin of error (overhead, clocks varying, etc)
-#                 self.lockout_manager = LockoutManager(action="foo", lockout_seconds=1, safety_seconds=1)
-#             def foo():
-#                 self.lockout_manager.wait_if_needed()
-#                 do_guarded_action()
-#
-#         f = Foo()     # make a Foo
-#         v1 = f.foo()  # will immediately get a value
-#         time.sleep(58)
-#         v2 = f.foo()  # will wait about 2 seconds, then get a value
-#         v3 = f.foo()  # will wait about 60 seconds, then get a value
-#
-#     Conceptually this is a special case of RateManager for n=1, though in practice it arose differently and
-#     the supplementary methods (which we happen to use mostly for testing) differ because the n=1 case is simpler
-#     and admits more questions. So, for now at least, this is not a subclass of RateManager but a separate
-#     implementation.
-#     """
-#
-#     EARLIEST_TIMESTAMP = datetime.datetime(datetime.MINYEAR, 1, 1)  # maybe useful for testing
-#
-#     def __init__(self, *, lockout_seconds, safety_seconds=0, action="metered action", enabled=True, log=None):
-#         """
-#         Creates a LockoutManager that cooperates in assuring a guarded operation is only happens at a certain rate.
-#
-#         The rate is once person lockout_seconds. This is a special case of RateManager and might get phased out
-#         as redundant, but has slightly different operations available for testing.
-#
-#         Args:
-#
-#         lockout_seconds int: A theoretical number of seconds allowed between calls to the guarded operation.
-#         safety_seconds int: An amount added to interval_seconds to accommodate real world coordination fuzziness.
-#         action str: A noun or noun phrase describing the action being guarded.
-#         enabled bool: A boolean controlling whether this facility is enabled. If False, waiting is disabled.
-#         log object: A logger object (supporting operations like .debug, .info, .warning, and .error).
-#         """
-#
-#         # This makes it easy to turn off the feature
-#         self.lockout_enabled = enabled
-#         self.lockout_seconds = lockout_seconds
-#         self.safety_seconds = safety_seconds
-#         self.action = action
-#         self._timestamp = self.EARLIEST_TIMESTAMP
-#         self.log = log or logging
-#
-#     @property
-#     def timestamp(self):
-#         """The timestamp is read-only. Use update_timestamp() to set it."""
-#         return self._timestamp
-#
-#     @property
-#     def effective_lockout_seconds(self):
-#         """
-#         The effective time between calls
-#
-#         Returns: the sum of the lockout and the safety seconds
-#         """
-#         return self.lockout_seconds + self.safety_seconds
-#
-#     def wait_if_needed(self):
-#         """
-#         This function is intended to be called immediately prior to each guarded operation.
-#
-#         This function will wait (using time.sleep) only if necessary, and for the amount necessary,
-#         to comply with rate-limiting declared in the creation of this LockoutManager.
-#
-#         NOTE WELL: It is presumed that all calls are coming from this source. This doesn't have ESP that would
-#         detect or otherwise accommodate externally generated calls, so violations of rate-limiting can still
-#         happen that way. This should be sufficient for sequential testing, and better than nothing for
-#         production operation.  This is not a substitute for responding to server-initiated throttling protocols.
-#         """
-#         now = datetime.datetime.now()
-#         # Note that this quantity is always positive because now is always bigger than the timestamp.
-#         seconds_since_last_purge = (now - self._timestamp).total_seconds()
-#         # Note again that because seconds_since_last_attempt is positive, the wait seconds will
-#         # never exceed self.effective_lockout_seconds, so
-#         #   0 <= wait_seconds <= self.effective_lockout_seconds
-#         wait_seconds = max(0.0, self.effective_lockout_seconds - seconds_since_last_purge)
-#         if wait_seconds > 0.0:
-#             shared_message = ("Last %s attempt was at %s (%s seconds ago)."
-#                               % (self.action, self._timestamp, seconds_since_last_purge))
-#             if self.lockout_enabled:
-#                 action_message = "Waiting %s seconds before attempting another." % wait_seconds
-#                 self.log.warning("%s %s" % (shared_message, action_message))
-#                 time.sleep(wait_seconds)
-#             else:
-#                 action_message = "Continuing anyway because lockout is disabled."
-#                 self.log.warning("%s %s" % (shared_message, action_message))
-#         self.update_timestamp()
-#
-#     def update_timestamp(self):
-#         """
-#         Explicitly sets the reference time point for computation of our lockout.
-#         This is called implicitly by .wait_if_needed(), and for some situations that may be sufficient.
-#         """
-#         self._timestamp = datetime.datetime.now()
+class LockoutManager:
+    """
+    This class is used as a guard of a critical operation that can only be called within a certain frequency.
+    e.g.,
+
+        class Foo:
+            def __init__(self):
+                # 60 seconds required between calls, with a 1 second margin of error (overhead, clocks varying, etc)
+                self.lockout_manager = LockoutManager(action="foo", lockout_seconds=1, safety_seconds=1)
+            def foo():
+                self.lockout_manager.wait_if_needed()
+                do_guarded_action()
+
+        f = Foo()     # make a Foo
+        v1 = f.foo()  # will immediately get a value
+        time.sleep(58)
+        v2 = f.foo()  # will wait about 2 seconds, then get a value
+        v3 = f.foo()  # will wait about 60 seconds, then get a value
+
+    Conceptually this is a special case of RateManager for n=1, though in practice it arose differently and
+    the supplementary methods (which we happen to use mostly for testing) differ because the n=1 case is simpler
+    and admits more questions. So, for now at least, this is not a subclass of RateManager but a separate
+    implementation.
+    """
+
+    EARLIEST_TIMESTAMP = datetime.datetime(datetime.MINYEAR, 1, 1)  # maybe useful for testing
+
+    def __init__(self, *, lockout_seconds, safety_seconds=0, action="metered action", enabled=True, log=None):
+        """
+        Creates a LockoutManager that cooperates in assuring a guarded operation is only happens at a certain rate.
+
+        The rate is once person lockout_seconds. This is a special case of RateManager and might get phased out
+        as redundant, but has slightly different operations available for testing.
+
+        Args:
+
+        lockout_seconds int: A theoretical number of seconds allowed between calls to the guarded operation.
+        safety_seconds int: An amount added to interval_seconds to accommodate real world coordination fuzziness.
+        action str: A noun or noun phrase describing the action being guarded.
+        enabled bool: A boolean controlling whether this facility is enabled. If False, waiting is disabled.
+        log object: A logger object (supporting operations like .debug, .info, .warning, and .error).
+        """
+
+        # This makes it easy to turn off the feature
+        self.lockout_enabled = enabled
+        self.lockout_seconds = lockout_seconds
+        self.safety_seconds = safety_seconds
+        self.action = action
+        self._timestamp = self.EARLIEST_TIMESTAMP
+        self.log = log or logging
+
+    @property
+    def timestamp(self):
+        """The timestamp is read-only. Use update_timestamp() to set it."""
+        return self._timestamp
+
+    @property
+    def effective_lockout_seconds(self):
+        """
+        The effective time between calls
+
+        Returns: the sum of the lockout and the safety seconds
+        """
+        return self.lockout_seconds + self.safety_seconds
+
+    def wait_if_needed(self):
+        """
+        This function is intended to be called immediately prior to each guarded operation.
+
+        This function will wait (using time.sleep) only if necessary, and for the amount necessary,
+        to comply with rate-limiting declared in the creation of this LockoutManager.
+
+        NOTE WELL: It is presumed that all calls are coming from this source. This doesn't have ESP that would
+        detect or otherwise accommodate externally generated calls, so violations of rate-limiting can still
+        happen that way. This should be sufficient for sequential testing, and better than nothing for
+        production operation.  This is not a substitute for responding to server-initiated throttling protocols.
+        """
+        now = datetime.datetime.now()
+        # Note that this quantity is always positive because now is always bigger than the timestamp.
+        seconds_since_last_purge = (now - self._timestamp).total_seconds()
+        # Note again that because seconds_since_last_attempt is positive, the wait seconds will
+        # never exceed self.effective_lockout_seconds, so
+        #   0 <= wait_seconds <= self.effective_lockout_seconds
+        wait_seconds = max(0.0, self.effective_lockout_seconds - seconds_since_last_purge)
+        if wait_seconds > 0.0:
+            shared_message = ("Last %s attempt was at %s (%s seconds ago)."
+                              % (self.action, self._timestamp, seconds_since_last_purge))
+            if self.lockout_enabled:
+                action_message = "Waiting %s seconds before attempting another." % wait_seconds
+                self.log.warning("%s %s" % (shared_message, action_message))
+                time.sleep(wait_seconds)
+            else:
+                action_message = "Continuing anyway because lockout is disabled."
+                self.log.warning("%s %s" % (shared_message, action_message))
+        self.update_timestamp()
+
+    def update_timestamp(self):
+        """
+        Explicitly sets the reference time point for computation of our lockout.
+        This is called implicitly by .wait_if_needed(), and for some situations that may be sufficient.
+        """
+        self._timestamp = datetime.datetime.now()
 
 
 class RateManager:

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -448,14 +448,14 @@ class LockoutManager:
         """
         now = datetime.datetime.now()
         # Note that this quantity is always positive because now is always bigger than the timestamp.
-        seconds_since_last_purge = (now - self._timestamp).total_seconds()
+        seconds_since_last_attempt = (now - self._timestamp).total_seconds()
         # Note again that because seconds_since_last_attempt is positive, the wait seconds will
         # never exceed self.effective_lockout_seconds, so
         #   0 <= wait_seconds <= self.effective_lockout_seconds
-        wait_seconds = max(0.0, self.effective_lockout_seconds - seconds_since_last_purge)
+        wait_seconds = max(0.0, self.effective_lockout_seconds - seconds_since_last_attempt)
         if wait_seconds > 0.0:
             shared_message = ("Last %s attempt was at %s (%s seconds ago)."
-                              % (self.action, self._timestamp, seconds_since_last_purge))
+                              % (self.action, self._timestamp, seconds_since_last_attempt))
             if self.lockout_enabled:
                 action_message = "Waiting %s seconds before attempting another." % wait_seconds
                 self.log.warning("%s %s" % (shared_message, action_message))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.36.0.1b0"
+version = "0.37.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.36.0"
+version = "0.36.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -11,7 +11,7 @@ from dcicutils.misc_utils import (
     PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp, VirtualAppError,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
     Retry, apply_dict_overrides, utc_today_str, RateManager, environ_bool,
-    # LockoutManager,
+    LockoutManager,
 )
 from dcicutils.qa_utils import Occasionally, ControlledTime, override_environ
 from unittest import mock
@@ -607,108 +607,104 @@ def test_utc_today_str():
     assert re.match(pattern, actual), "utc_today_str() result %s did not match format: %s" % (actual, pattern)
 
 
-# I think we will not need LockoutManager. It's really just a special case of RateManager,
-# though its operations are a little different. This commented-out code should be removed
-# once we have successfully installed a system based on RateManager. -kmp 20-Jul-2020
-#
-# def test_lockout_manager():
-#
-#     protected_action = "simulated action"
-#
-#     # The function now() will get us the time. This assure us that binding datetime.datetime
-#     # will not be affecting us.
-#     now = datetime_module.datetime.now
-#
-#     # real_t0 is the actual wallclock time at the start of this test. We use it only to make sure
-#     # that all these other tests are really going through our mock. In spite of longer mocked
-#     # timescales, this test should run quickly.
-#     real_t0 = now()
-#     print("Starting test at", real_t0)
-#
-#     # dt will be our substitute for datetime.datetime.
-#     # (it also has a sleep method that we can substitute for time.sleep)
-#     dt = ControlledTime(tick_seconds=1)
-#
-#     class MockLogger:
-#
-#         def __init__(self):
-#             self.log = []
-#
-#         def warning(self, msg):
-#             self.log.append(msg)
-#
-#     with mock.patch("datetime.datetime", dt):
-#         with mock.patch("time.sleep", dt.sleep):
-#             my_log = MockLogger()
-#
-#             assert isinstance(datetime_module.datetime, ControlledTime)
-#
-#             lockout_manager = LockoutManager(action=protected_action,
-#                                              lockout_seconds=60,
-#                                              safety_seconds=1,
-#                                              log=my_log)
-#             assert not hasattr(lockout_manager, 'client')  # Just for safety, we don't need a client for this test
-#
-#             t0 = dt.just_now()
-#
-#             lockout_manager.wait_if_needed()
-#
-#             t1 = dt.just_now()
-#
-#             print("t0=", t0)
-#             print("t1=", t1)
-#
-#             # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
-#             # and we expect exactly two calls to be made in the called function:
-#             #  - Once on entry to get the current time prior to the protected action
-#             #  - Once on exit to set the timestamp after the protected action.
-#             # We expect no sleeps, so that doesn't play in.
-#             assert (t1 - t0).total_seconds() == 2
-#
-#             assert my_log.log == []
-#
-#             lockout_manager.wait_if_needed()
-#
-#             t2 = dt.just_now()
-#
-#             print("t2=", t2)
-#
-#             # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
-#             # and we expect exactly two calls to be made in the called function, plus we also
-#             # expect to sleep for 60 seconds of the 61 seconds it wants to reserve (one second having
-#             # passed since the last protected action).
-#
-#             assert (t2 - t1).total_seconds() == 62
-#
-#             assert my_log.log == ['Last %s attempt was at 2010-01-01 12:00:02 (1.0 seconds ago).'
-#                                   ' Waiting 60.0 seconds before attempting another.' % protected_action]
-#
-#             my_log.log = []  # Reset the log
-#
-#             dt.sleep(30)  # Simulate 30 seconds of time passing
-#
-#             t3 = dt.just_now()
-#             print("t3=", t3)
-#
-#             lockout_manager.wait_if_needed()
-#
-#             t4 = dt.just_now()
-#             print("t4=", t4)
-#
-#             # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
-#             # and we expect exactly two calls to be made in the called function, plus we also
-#             # expect to sleep for 30 seconds of the 61 seconds it wants to reserve (31 seconds having
-#             # passed since the last protected action).
-#
-#             assert (t4 - t3).total_seconds() == 32
-#
-#             assert my_log.log == ['Last %s attempt was at 2010-01-01 12:01:04 (31.0 seconds ago).'
-#                                   ' Waiting 30.0 seconds before attempting another.' % protected_action]
-#
-#     real_t1 = now()
-#     print("Done testing at", real_t1)
-#     # Whole test should happen much faster, less than a half second
-#     assert (real_t1 - real_t0).total_seconds() < 0.5
+def test_lockout_manager():
+
+    protected_action = "simulated action"
+
+    # The function now() will get us the time. This assure us that binding datetime.datetime
+    # will not be affecting us.
+    now = datetime_module.datetime.now
+
+    # real_t0 is the actual wallclock time at the start of this test. We use it only to make sure
+    # that all these other tests are really going through our mock. In spite of longer mocked
+    # timescales, this test should run quickly.
+    real_t0 = now()
+    print("Starting test at", real_t0)
+
+    # dt will be our substitute for datetime.datetime.
+    # (it also has a sleep method that we can substitute for time.sleep)
+    dt = ControlledTime(tick_seconds=1)
+
+    class MockLogger:
+
+        def __init__(self):
+            self.log = []
+
+        def warning(self, msg):
+            self.log.append(msg)
+
+    with mock.patch("datetime.datetime", dt):
+        with mock.patch("time.sleep", dt.sleep):
+            my_log = MockLogger()
+
+            assert isinstance(datetime_module.datetime, ControlledTime)
+
+            lockout_manager = LockoutManager(action=protected_action,
+                                             lockout_seconds=60,
+                                             safety_seconds=1,
+                                             log=my_log)
+            assert not hasattr(lockout_manager, 'client')  # Just for safety, we don't need a client for this test
+
+            t0 = dt.just_now()
+
+            lockout_manager.wait_if_needed()
+
+            t1 = dt.just_now()
+
+            print("t0=", t0)
+            print("t1=", t1)
+
+            # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
+            # and we expect exactly two calls to be made in the called function:
+            #  - Once on entry to get the current time prior to the protected action
+            #  - Once on exit to set the timestamp after the protected action.
+            # We expect no sleeps, so that doesn't play in.
+            assert (t1 - t0).total_seconds() == 2
+
+            assert my_log.log == []
+
+            lockout_manager.wait_if_needed()
+
+            t2 = dt.just_now()
+
+            print("t2=", t2)
+
+            # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
+            # and we expect exactly two calls to be made in the called function, plus we also
+            # expect to sleep for 60 seconds of the 61 seconds it wants to reserve (one second having
+            # passed since the last protected action).
+
+            assert (t2 - t1).total_seconds() == 62
+
+            assert my_log.log == ['Last %s attempt was at 2010-01-01 12:00:02 (1.0 seconds ago).'
+                                  ' Waiting 60.0 seconds before attempting another.' % protected_action]
+
+            my_log.log = []  # Reset the log
+
+            dt.sleep(30)  # Simulate 30 seconds of time passing
+
+            t3 = dt.just_now()
+            print("t3=", t3)
+
+            lockout_manager.wait_if_needed()
+
+            t4 = dt.just_now()
+            print("t4=", t4)
+
+            # We've set the clock to increment 1 second on every call to datetime.datetime.now(),
+            # and we expect exactly two calls to be made in the called function, plus we also
+            # expect to sleep for 30 seconds of the 61 seconds it wants to reserve (31 seconds having
+            # passed since the last protected action).
+
+            assert (t4 - t3).total_seconds() == 32
+
+            assert my_log.log == ['Last %s attempt was at 2010-01-01 12:01:04 (31.0 seconds ago).'
+                                  ' Waiting 30.0 seconds before attempting another.' % protected_action]
+
+    real_t1 = now()
+    print("Done testing at", real_t1)
+    # Whole test should happen much faster, less than a half second
+    assert (real_t1 - real_t0).total_seconds() < 0.5
 
 
 def test_rate_manager():


### PR DESCRIPTION
We were thinking `LockManager` was redundant if we had `RateManage`r, but I suspect `RateManager` is causing some timing errors. It is slightly more complicated and so could have a bug that's harder to spot. For that reason, I want to go ahead and carry the `LockManager` abstraction, too.