### PR TITLE
C4-245 Multi-Get API

### DIFF
--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -104,15 +104,18 @@ def get_bulk_uuids_embedded(client, index, uuids, is_generator=False):
 
     :returns: list of embedded views of the given uuids, if any
     """
+    def return_generator(resp):
+        for d in resp['docs']:
+            yield d['_source']['embedded']
+
     final_result = []
     response = client.mget(body={  # XXX: this could still be slow even if you use is_generator
         'docs': [{'_id': _id,
                   'source': ['embedded.*'],
                   '_index': index} for _id in uuids]
         })
-    if is_generator:
-        for doc in response['docs']:
-            yield doc['_source']['embedded']
+    if is_generator is True:
+        return return_generator(response)
     else:
         for doc in response['docs']:
             final_result.append(doc['_source']['embedded'])

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -882,7 +882,7 @@ def expand_es_metadata(uuid_list, key=None, ff_env=None, store_frame='raw', add_
     returns a dictionary with item types (schema name), and list of items in defined frame
     Sometimes, certain fields need to be skipped (i.e. relations), you can use ignore fields.
     Args:
-        uuid_list (array):               Starting node for search, only use uuids.
+        uuid_list (list):                Starting node for search, only use uuids.
         key (dict):                      standard ff_utils authentication key
         ff_env (str):                    standard ff environment string
         store_frame (str, default 'raw'):Depending on use case, can store frame raw or object or embedded

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -12,17 +12,30 @@ import pytz
 from .misc_utils import PRINT, ignored, Retry
 
 
+def show_elapsed_time(start, end):
+    """ Helper method for below that is the default - just prints the elapsed time. """
+    print('Elapsed: %s' % (end - start))
+
+
 @contextlib.contextmanager
-def timed():
-    """ A simple context manager that will time how long it spends in context. Useful for debugging. """
+def timed(reporter=None, debug=None):
+    """ A simple context manager that will time how long it spends in context. Useful for debugging.
+
+        :param reporter: lambda x, y where x and y are the start and finish times respectively, default PRINT
+        :param debug: lambda x where x is an exception, default NO ACTION
+    """
+    if reporter is None:
+        reporter = show_elapsed_time
     start = time.time()
     try:
         yield
-    except Exception:
+    except Exception as e:
+        if debug is not None:
+            debug(e)
         raise
     finally:
         end = time.time()
-        print('Elapsed: %s' % (end - start))
+        reporter(start, end)
 
 
 def mock_not_called(name):

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -14,7 +14,7 @@ from .misc_utils import PRINT, ignored, Retry
 
 def show_elapsed_time(start, end):
     """ Helper method for below that is the default - just prints the elapsed time. """
-    print('Elapsed: %s' % (end - start))
+    PRINT('Elapsed: %s' % (end - start))
 
 
 @contextlib.contextmanager

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -4,11 +4,25 @@ qa_utils: Tools for use in quality assurance testing.
 
 import contextlib
 import datetime
+import time
 import io
 import os
 import pytz
 
 from .misc_utils import PRINT, ignored, Retry
+
+
+@contextlib.contextmanager
+def timed():
+    """ A simple context manager that will time how long it spends in context. Useful for debugging. """
+    start = time.time()
+    try:
+        yield
+    except Exception:
+        raise
+    finally:
+        end = time.time()
+        print('Elapsed: %s' % (end - start))
 
 
 def mock_not_called(name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.37.0"
+version = "0.37.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -1,6 +1,7 @@
 import pytest
-
-from dcicutils.es_utils import create_es_client, execute_lucene_query_on_es
+from dcicutils.qa_utils import timed
+from dcicutils.ff_utils import expand_es_metadata
+from dcicutils.es_utils import create_es_client, execute_lucene_query_on_es, get_bulk_uuids_embedded
 
 
 @pytest.fixture
@@ -27,3 +28,33 @@ def test_lucene_query_basic(es_client_fixture):
     }
     results = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query=test_query)
     assert len(results) == 1
+
+
+@pytest.mark.integrated
+def test_get_bulk_uuids_embedded(es_client_fixture):
+    """ Tests getting some bulk uuids acquired from search. """
+    uuids = ['1a12362f-4eb6-4a9c-8173-776667226988']  # only one uuid first
+    result = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+    assert len(result) == 1
+
+    # one page of results, should give us 10
+    users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
+    uuids = [doc['_id'] for doc in users]
+    result = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+    assert len(result) == 10
+
+
+@pytest.mark.integrated
+def test_get_bulk_uuids_outperforms_expand_es_metadata(integrated_ff, es_client_fixture):
+    """ Tests that the new method out performs the new one. """
+    users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
+    uuids = [doc['_id'] for doc in users]
+
+    # this extracts the 10 desired uuids in embedded view using mget in 200 ms
+    with timed():
+        get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+
+    # this gets 19 total uuids in 1700ms (~850 ms adjusted, so roughly 4x slower)
+    with timed():
+        expand_es_metadata(uuids, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+    raise Exception  # uncomment this to prove to yourself that the new method is much faster - Will

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -34,7 +34,8 @@ def test_lucene_query_basic(es_client_fixture):
 def test_get_bulk_uuids_embedded(es_client_fixture):
     """ Tests getting some bulk uuids acquired from search. """
     uuids = ['1a12362f-4eb6-4a9c-8173-776667226988']  # only one uuid first
-    result1 = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+    pytest.set_trace()
+    result1 = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids, is_generator=False)
     assert len(result1) == 1
     assert result1[0]['uuid'] == uuids[0]  # check uuid
     assert result1[0]['lab']['awards'] is not None  # check embedding
@@ -63,13 +64,10 @@ def test_get_bulk_uuids_outperforms_get_es_metadata(integrated_ff, es_client_fix
     def set_current_time(start, end):  # noqa I want this default argument to be mutable
         times.append(end - start)
 
-    # this extracts the 10 desired uuids in embedded view using mget in ~200 ms
     with timed(reporter=set_current_time):
         get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids, is_generator=False)
     assert len(times) == 1
-
-    # this gets 19 total uuids in 1700ms (~850 ms adjusted, so roughly 4x slower)
     with timed(reporter=set_current_time):
         get_es_metadata(uuids, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
     assert len(times) == 2
-    assert times[0] < (times[1] / 2)  # should always be much faster (normalized for # of uuids retrieved)
+    assert times[0] < times[1]  # should always be much faster (normalized for # of uuids retrieved)

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 from dcicutils.qa_utils import timed
 from dcicutils.ff_utils import expand_es_metadata
 from dcicutils.es_utils import create_es_client, execute_lucene_query_on_es, get_bulk_uuids_embedded
@@ -36,12 +37,18 @@ def test_get_bulk_uuids_embedded(es_client_fixture):
     uuids = ['1a12362f-4eb6-4a9c-8173-776667226988']  # only one uuid first
     result = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
     assert len(result) == 1
+    assert result[0]['uuid'] == uuids[0]  # check uuid
+    assert result[0]['lab']['awards'] is not None  # check embedding
+    assert result[0]['lab']['awards'][0]['project'] is not None
+
 
     # one page of results, should give us 10
     users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
     uuids = [doc['_id'] for doc in users]
     result = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
     assert len(result) == 10
+    for doc in result:
+        assert doc['uuid'] in uuids  # check uuids
 
 
 @pytest.mark.integrated
@@ -49,12 +56,18 @@ def test_get_bulk_uuids_outperforms_expand_es_metadata(integrated_ff, es_client_
     """ Tests that the new method out performs the new one. """
     users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
     uuids = [doc['_id'] for doc in users]
+    current_time = [None]  # pass by reference
 
-    # this extracts the 10 desired uuids in embedded view using mget in 200 ms
-    with timed():
+    def set_current_time(start, end, t=current_time):  # noqa I want this default argument to be mutable
+        t[0] = end - start
+
+    # this extracts the 10 desired uuids in embedded view using mget in ~200 ms
+    with timed(reporter=set_current_time):
         get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+    assert current_time is not None
+    time1 = copy.deepcopy(current_time)  # store the actual result
 
     # this gets 19 total uuids in 1700ms (~850 ms adjusted, so roughly 4x slower)
-    with timed():
+    with timed(reporter=set_current_time):
         expand_es_metadata(uuids, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
-    #raise Exception  # uncomment this to prove to yourself that the new method is much faster - Will
+    assert time1[0] < (current_time[0] / 2)  # noqa should always be much faster

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -34,7 +34,6 @@ def test_lucene_query_basic(es_client_fixture):
 def test_get_bulk_uuids_embedded(es_client_fixture):
     """ Tests getting some bulk uuids acquired from search. """
     uuids = ['1a12362f-4eb6-4a9c-8173-776667226988']  # only one uuid first
-    pytest.set_trace()
     result1 = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids, is_generator=False)
     assert len(result1) == 1
     assert result1[0]['uuid'] == uuids[0]  # check uuid

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -57,4 +57,4 @@ def test_get_bulk_uuids_outperforms_expand_es_metadata(integrated_ff, es_client_
     # this gets 19 total uuids in 1700ms (~850 ms adjusted, so roughly 4x slower)
     with timed():
         expand_es_metadata(uuids, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
-    raise Exception  # uncomment this to prove to yourself that the new method is much faster - Will
+    #raise Exception  # uncomment this to prove to yourself that the new method is much faster - Will

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -41,7 +41,6 @@ def test_get_bulk_uuids_embedded(es_client_fixture):
     assert result[0]['lab']['awards'] is not None  # check embedding
     assert result[0]['lab']['awards'][0]['project'] is not None
 
-
     # one page of results, should give us 10
     users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
     uuids = [doc['_id'] for doc in users]

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -1,7 +1,6 @@
 import pytest
-import copy
 from dcicutils.qa_utils import timed
-from dcicutils.ff_utils import expand_es_metadata
+from dcicutils.ff_utils import get_es_metadata
 from dcicutils.es_utils import create_es_client, execute_lucene_query_on_es, get_bulk_uuids_embedded
 
 
@@ -35,23 +34,27 @@ def test_lucene_query_basic(es_client_fixture):
 def test_get_bulk_uuids_embedded(es_client_fixture):
     """ Tests getting some bulk uuids acquired from search. """
     uuids = ['1a12362f-4eb6-4a9c-8173-776667226988']  # only one uuid first
-    result = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
-    assert len(result) == 1
-    assert result[0]['uuid'] == uuids[0]  # check uuid
-    assert result[0]['lab']['awards'] is not None  # check embedding
-    assert result[0]['lab']['awards'][0]['project'] is not None
+    result1 = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+    assert len(result1) == 1
+    assert result1[0]['uuid'] == uuids[0]  # check uuid
+    assert result1[0]['lab']['awards'] is not None  # check embedding
+    assert result1[0]['lab']['awards'][0]['project'] is not None
 
     # one page of results, should give us 10
     users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
     uuids = [doc['_id'] for doc in users]
-    result = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
-    assert len(result) == 10
-    for doc in result:
+    result2 = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+    assert len(result2) == 10
+    for doc in result2:
         assert doc['uuid'] in uuids  # check uuids
+
+    result3 = get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids, is_generator=True)
+    for doc in result3:
+        assert doc['uuid'] in uuids  # check uuids from gen
 
 
 @pytest.mark.integrated
-def test_get_bulk_uuids_outperforms_expand_es_metadata(integrated_ff, es_client_fixture):
+def test_get_bulk_uuids_outperforms_get_es_metadata(integrated_ff, es_client_fixture):
     """ Tests that the new method out performs the new one. """
     users = execute_lucene_query_on_es(client=es_client_fixture, index='fourfront-mastertestuser', query={})
     uuids = [doc['_id'] for doc in users]
@@ -62,11 +65,11 @@ def test_get_bulk_uuids_outperforms_expand_es_metadata(integrated_ff, es_client_
 
     # this extracts the 10 desired uuids in embedded view using mget in ~200 ms
     with timed(reporter=set_current_time):
-        get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids)
+        get_bulk_uuids_embedded(es_client_fixture, 'fourfront-mastertestuser', uuids, is_generator=False)
     assert len(times) == 1
 
     # this gets 19 total uuids in 1700ms (~850 ms adjusted, so roughly 4x slower)
     with timed(reporter=set_current_time):
-        expand_es_metadata(uuids, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
+        get_es_metadata(uuids, key=integrated_ff['ff_key'], ff_env=integrated_ff['ff_env'])
     assert len(times) == 2
     assert times[0] < (times[1] / 2)  # should always be much faster (normalized for # of uuids retrieved)


### PR DESCRIPTION
- Allow authenticated users to use the `get_bulk_uuids_embedded` function to get the embedded view of many uuids (of the same item type from a single index). The idea is for this method to replace `expand_es_metadata` where possible as it seems to perform much better.