### PR TITLE
Fix problem with retry code re-raising after timeout (C4-266) and a testing issue (C4-267)

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -304,8 +304,8 @@ class Retry:
                     try:
                         success = function(*args, **kwargs)
                         return success
-                    except Exception as last_error:
-                        pass
+                    except Exception as e:
+                        last_error = e
                 if last_error is not None:
                     raise last_error
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -282,6 +282,10 @@ class Retry:
                 wait_multiplier=cls._defaulted(wait_multiplier, cls.DEFAULT_WAIT_MULTIPLIER),
             )
 
+            check_true(isinstance(retries_allowed, int) and retries_allowed >= 0,
+                       "The retries_allowed must be a non-negative integer.",
+                       error_class=ValueError)
+
             # See the 'retrying' method to understand what this is about. -kmp 8-Jul-2020
             if function_name != 'anonymous':
                 cls._RETRY_OPTIONS_CATALOG[function_name] = function_profile  # Only for debugging.
@@ -290,6 +294,7 @@ class Retry:
             def wrapped_function(*args, **kwargs):
                 tries_allowed = function_profile.tries_allowed
                 wait_seconds = function_profile.wait_seconds or 0
+                last_error = None
                 for i in range(tries_allowed):
                     if i > 0:
                         if i > 1:
@@ -299,9 +304,10 @@ class Retry:
                     try:
                         success = function(*args, **kwargs)
                         return success
-                    except Exception:
+                    except Exception as last_error:
                         pass
-                raise
+                if last_error is not None:
+                    raise last_error
 
             return wrapped_function
 
@@ -597,3 +603,16 @@ def environ_bool(var, default=False):
         return default
     else:
         return os.environ[var].lower() == "true"
+
+
+def check_true(test_value: object,
+               message: str,
+               error_class: Type[Exception] = RuntimeError):
+    """
+    If the first argument does not evaluate to a true value, an error is raised.
+
+    The error, if one is raised, will be of type error_class, and its message will be given by message.
+    The error_class defaults to RuntimeError, but may be any Exception class.
+    """
+    if not test_value:
+        raise error_class(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.38.0"
+version = "0.38.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -844,7 +844,7 @@ def test_faceted_search_exp_set(integrated_ff):
     pub = {'Publication': 'No value'}
     pub.update(for_all)
     resp = ff_utils.faceted_search(**pub)
-    assert len(resp) == 10
+    assert len(resp) == 9
     mods = {'Modifications': 'Stable Transfection'}
     mods.update(for_all)
     resp = ff_utils.faceted_search(**mods)

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -12,7 +12,7 @@ from dcicutils.misc_utils import (
     PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp, VirtualAppError,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
     Retry, apply_dict_overrides, utc_today_str, RateManager, environ_bool,
-    LockoutManager,
+    LockoutManager, check_true
 )
 from dcicutils.qa_utils import Occasionally, ControlledTime, override_environ
 from unittest import mock
@@ -974,3 +974,14 @@ def test_environ_bool():
         assert environ_bool("FOO") is False
         assert environ_bool("FOO", default=None) is False
         assert environ_bool("FOO", None) is False
+
+
+def test_check_true():
+
+    x = [1, 2, 3]
+    check_true(x == [1, 2, 3], "x is not a list of one, two, and three.")
+
+    msg = "x is not a list of four, five, and six."
+    with pytest.raises(RuntimeError) as e:
+        check_true(x == [4, 5, 6], msg)
+    assert msg in str(e)


### PR DESCRIPTION
Python was giving us a hard time about a call to `raise` with no arguments (a re-raise) that happened outside an `except:` context. That used to work, I think, but it's probably fine if it doesn't. I rewrote the logic to be more robust against that.

In the process, I pulled over one utility function I wrote for CGAP because it was useful in this context. I often want to write `assert` in production code but am conscious of the fact it's not really designed for that. `check_true` will do a similar thing but will raise `RuntimeError` (by default) or some other error you ask it to.

I ran into [Some utils builds are getting a miscount in test_faceted_search_exp_set (C4-267)](https://hms-dbmi.atlassian.net/browse/C4-267) along the way unit testing and have fixed that here, too.
