### PR TITLE
Fix integrated ES setup (C4-275)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.38.1"
+version = "0.38.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,14 +3,15 @@ import boto3
 import pytest
 import os
 import requests
+import time
 
 from dcicutils.misc_utils import check_true
 from dcicutils.s3_utils import s3Utils
-from dcicutils.ff_utils import authorized_request
+from dcicutils.ff_utils import authorized_request, get_health_page
 from dcicutils.beanstalk_utils import describe_beanstalk_environments, REGION
 
 
-def _discover_es_info(envname):
+def _discover_es_health(envname):
     try:
         eb_client = boto3.client('elasticbeanstalk', region_name=REGION)
         # Calling describe_beanstalk_environments is pretty much the same as doing eb_client.describe_environments(...)
@@ -22,9 +23,21 @@ def _discover_es_info(envname):
                 # TODO: It would be nice if we were using https: for everything. -kmp 14-Aug-2020
                 res = requests.get("http://%s/health?format=json" % cname)
                 health_json = res.json()
-                return health_json['elasticsearch'], health_json['namespace']
+                return health_json
     except Exception as e:
         raise RuntimeError("Unable to discover elasticsearch info for %s:\n%s: %s" % (envname, e.__class__.__name__, e))
+
+
+def _discover_es_info(envname):
+    discovered_health_json = _discover_es_health(envname)
+    time.sleep(1)  # Reduce throttling risk
+    ff_health_json = get_health_page(ff_env=envname)
+    # Consistency check that both utilities are returning the same info.
+    assert discovered_health_json['beanstalk_env'] == ff_health_json['beanstalk_env']
+    assert discovered_health_json['elasticsearch'] == ff_health_json['elasticsearch']
+    assert discovered_health_json['namespace'] == ff_health_json['namespace']
+    # This should be all we actually need:
+    return discovered_health_json['elasticsearch'], discovered_health_json['namespace']
 
 
 # XXX: Refactor to config
@@ -43,7 +56,7 @@ TEST_DIR = os.path.join(os.path.dirname(__file__))
 @pytest.fixture(scope='session')
 def basestring():
     try:
-        basestring = basestring
+        basestring = basestring  # noQA - PyCharm static analysis doesn't understand this Python 2.7 compatibility issue
     except NameError:
         basestring = str
     return basestring
@@ -61,11 +74,13 @@ def integrated_ff():
     integrated['ff_env'] = INTEGRATED_ENV
     integrated['es_url'] = INTEGRATED_ES
     # do this to make sure env is up (will error if not)
-    res = authorized_request(integrated['ff_key']['server'], auth=integrated['ff_key'])
+    res = authorized_request(integrated['ff_key']['server'],  # noQA - PyCharm fears the ['server'] part won't be there.
+                             auth=integrated['ff_key'])
     if res.status_code != 200:
         raise Exception('Environment %s is not ready for integrated status. Requesting '
                         'the homepage gave status of: %s' % (INTEGRATED_ENV, res.status_code))
     return integrated
+
 
 @pytest.fixture(scope='session')
 def integrated_s3_info():
@@ -76,14 +91,14 @@ def integrated_s3_info():
     test_filename = '__test_data/test_file.txt'
     zip_filename = '__test_data/fastqc_report.zip'
     zip_filename2 = '__test_data/madqc_report.zip'
-    s3Obj = s3Utils(env=INTEGRATED_ENV)
+    s3_obj = s3Utils(env=INTEGRATED_ENV)
     # for now, always upload these files
-    s3Obj.s3.put_object(Bucket=s3Obj.outfile_bucket, Key=test_filename,
-                          Body=str.encode('thisisatest'))
+    s3_obj.s3.put_object(Bucket=s3_obj.outfile_bucket, Key=test_filename,
+                         Body=str.encode('thisisatest'))
     zip_path = os.path.join(TEST_DIR, 'data_files', os.path.basename(zip_filename))
-    s3Obj.s3.upload_file(Filename=str(zip_path), Bucket=s3Obj.outfile_bucket, Key=zip_filename)
+    s3_obj.s3.upload_file(Filename=str(zip_path), Bucket=s3_obj.outfile_bucket, Key=zip_filename)
     zip_path2 = os.path.join(TEST_DIR, 'data_files', os.path.basename(zip_filename2))
-    s3Obj.s3.upload_file(Filename=str(zip_path2), Bucket=s3Obj.outfile_bucket, Key=zip_filename2)
+    s3_obj.s3.upload_file(Filename=str(zip_path2), Bucket=s3_obj.outfile_bucket, Key=zip_filename2)
 
-    return {'s3Obj': s3Obj, 'filename': test_filename, 'zip_filename': zip_filename,
+    return {'s3Obj': s3_obj, 'filename': test_filename, 'zip_filename': zip_filename,
             'zip_filename2': zip_filename2}

--- a/test/test_jh_utils.py
+++ b/test/test_jh_utils.py
@@ -4,6 +4,8 @@ import os
 import datetime
 import pytest
 from dcicutils import s3_utils
+from dcicutils.qa_utils import override_environ
+
 pytestmark = pytest.mark.working
 
 
@@ -15,10 +17,19 @@ def initialize_jh_env(server):
 
 
 def test_import_fails_without_initialization():
-    # this fails because proper env variables were not set up
-    with pytest.raises(Exception) as exec_info:
-        from dcicutils import jh_utils  # NOQA
-    assert 'ERROR USING JUPYTERHUB_UTILS!' in str(exec_info.value)
+
+    # Loading this library fails if proper env variables were not set up.
+    # TODO: I'm not sure I think that's a good idea. Functions should fail, imports should not. -kmp 14-Aug-2020
+
+    with override_environ(FF_ACCESS_KEY=None):
+        with pytest.raises(Exception) as exec_info:
+            from dcicutils import jh_utils  # NOQA
+        assert 'ERROR USING JUPYTERHUB_UTILS!' in str(exec_info.value)
+
+    with override_environ(FF_ACCESS_SECRET=None):
+        with pytest.raises(Exception) as exec_info:
+            from dcicutils import jh_utils  # NOQA
+        assert 'ERROR USING JUPYTERHUB_UTILS!' in str(exec_info.value)
 
 
 @pytest.mark.integrated


### PR DESCRIPTION
This contains a fix for C4-275, which was due to a wired notion of where the ES is for `fourfront-mastertest`. Now it will be discovered by looking at its health page.

I also fixed another issue that was probably broken only for me, where if you already have certain env variables set in your local environment, a test that supposedly checked what happens when you don't initialize failed because it assumed the variables wouldn't be set by default.  Better to set up the appropriate environment.

And I added more complete test coverage for s3_utils, bringing it up to 100%