### PR TITLE
Additions to env_utils and command_utils, and fixes for C4-278 and C4-279

### DIFF
--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -668,9 +668,12 @@ def create_bs(envname, load_prod, db_endpoint, es_url, for_indexing=False):
     Returns:
         dict: boto3 res from create_environment/update_environment
     """
+    if is_stg_or_prd_env(envname):
+        raise RuntimeError("beanstalk_utils.create_bs is not approved for production use.")
+
     client = boto3.client('elasticbeanstalk', region_name=REGION)
 
-    # deterimine the configuration template for Elasticbeanstal
+    # determine the configuration template for Elasticbeanstalk
     template = 'fourfront-base'
     if for_indexing:
         template = 'fourfront-indexing'
@@ -688,6 +691,7 @@ def create_bs(envname, load_prod, db_endpoint, es_url, for_indexing=False):
     # logic for mirrorEsEnv, which is used to coordinate elasticsearch
     # changes between fourfront data and staging
     if 'fourfront-webprod' in envname:
+        # TODO: This code is obsolete and needs to be upgraded. For now, the use of this on production is disabled.
         other_env = 'fourfront-webprod2' if envname == 'fourfront-webprod' else 'fourfront-webprod'
         mirror_es = get_es_build_status(other_env, max_tries=3)
         if mirror_es:

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -668,6 +668,7 @@ def create_bs(envname, load_prod, db_endpoint, es_url, for_indexing=False):
     Returns:
         dict: boto3 res from create_environment/update_environment
     """
+    # TODO (C4-280): Reconsider this and other functionality.
     if is_stg_or_prd_env(envname):
         raise RuntimeError("beanstalk_utils.create_bs is not approved for production use.")
 

--- a/dcicutils/command_utils.py
+++ b/dcicutils/command_utils.py
@@ -1,0 +1,38 @@
+from .misc_utils import PRINT
+
+
+def yes_or_no(question, quick=None, default=None):
+    """
+    Loops asking a question interactively until it gets a 'yes' or 'no' response. Returns True or False accordingly.
+
+    :param question: The question to ask (without prompts for possible responses, which will be added automatically).
+    :param quick: Whether to allow short-form responses.
+    :param default: Whether to provide a default obtained by just pressing Enter.
+    :return: True or False
+    """
+
+    if quick is None:
+        # If the default is not None, we're accepting Enter for yes, so we might as well accept 'y'.
+        quick = (default is not None)
+
+    affirmatives = ['y', 'yes'] if quick else ['yes']
+    negatives = ['n', 'no'] if quick else ['no']
+    affirmative = affirmatives[0]
+    negative = negatives[0]
+    prompt = ("%s [%s/%s]: "
+              % (question,
+                 affirmative.upper() if default is True else affirmative,
+                 negative.upper() if default is False else negative))
+    while True:
+        answer = input(prompt).strip().lower()
+        if answer in affirmatives:
+            return True
+        elif answer in negatives:
+            return False
+        elif answer is "" and default is not None:
+            return default
+        else:
+            PRINT("Please answer '%s' or '%s'." % (affirmative, negative))
+            if default is not None:
+                PRINT("The default if you just press Enter is '%s'."
+                      % (affirmative if default else negative))

--- a/dcicutils/command_utils.py
+++ b/dcicutils/command_utils.py
@@ -1,7 +1,7 @@
 from .misc_utils import PRINT
 
 
-def yes_or_no(question, quick=None, default=None):
+def _ask_boolean_question(question, quick=None, default=None):
     """
     Loops asking a question interactively until it gets a 'yes' or 'no' response. Returns True or False accordingly.
 
@@ -29,10 +29,35 @@ def yes_or_no(question, quick=None, default=None):
             return True
         elif answer in negatives:
             return False
-        elif answer is "" and default is not None:
+        elif answer == "" and default is not None:
             return default
         else:
             PRINT("Please answer '%s' or '%s'." % (affirmative, negative))
             if default is not None:
                 PRINT("The default if you just press Enter is '%s'."
                       % (affirmative if default else negative))
+
+
+def yes_or_no(question):
+    """
+    Asks a 'yes' or 'no' question.
+
+    Either 'y' or 'yes' (in any case) is an acceptable affirmative.
+    Either 'n' or 'no' (in any case) is an acceptable negative.
+    The response must be confirmed by pressing Enter.
+    There is no default. If Enter is pressed after other text than the valid responses, the user is reprompted.
+    """
+    return _ask_boolean_question(question, quick=False)
+
+
+def y_or_n(question, default=None):
+    """
+    Asks a 'y' or 'n' question.
+
+    Either 'y' or 'yes' (in any case) is an acceptable affirmative.
+    Either 'n' or 'no' (in any case) is an acceptable negative.
+    The response must be confirmed by pressing Enter.
+    If Enter is pressed with no input text, the default is returned if there is one, or else the user is re-prompted.
+    If Enter is pressed after other text than the valid responses, the user is reprompted.
+    """
+    return _ask_boolean_question(question, quick=True, default=default)

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,5 +1,5 @@
 import os
-from .misc_utils import get_setting_from_context
+from .misc_utils import get_setting_from_context, check_true
 
 
 FF_ENV_DEV = 'fourfront-dev'  # Maybe not used
@@ -358,3 +358,39 @@ def infer_foursight_from_env(request, envname):
                 return FF_STAGING_IDENTIFIER
         else:
             return envname[len('fourfront-'):]  # if not data/staging, behaves exactly like CGAP
+
+
+def full_env_name(envname):
+    """
+    Given the possibly-short name of a Fourfront or CGAP beanstalk environment, return the long name.
+
+    The short name is allowed to omit 'fourfront-' but the long name is not.
+
+    Examples:
+        full_env_name('cgapdev') => 'fourfront-cgapdev'
+        full_env_name('fourfront-cgapdev') => 'fourfront-cgapdev'
+
+    Args:
+        envname str: the short or long name of a beanstalk environment
+
+    Returns:
+        a string that is the long name of the specified beanstalk environment
+    """
+    if envname in ('data', 'staging'):
+        raise ValueError("The special token '%s' is not a beanstalk environment name." % envname)
+    elif not envname.startswith('fourfront-'):
+        return 'fourfront-' + envname
+    else:
+        return envname
+
+
+def full_cgap_env_name(envname):
+    check_true(isinstance(envname, str) and "cgap" in envname, "The envname is not a CGAP env name.",
+               error_class=ValueError)
+    return full_env_name(envname)
+
+
+def full_fourfront_env_name(envname):
+    check_true(isinstance(envname, str) and "cgap" not in envname, "The envname is not a Fourfront env name.",
+               error_class=ValueError)
+    return full_env_name(envname)

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -11,8 +11,6 @@ import time
 import warnings
 import webtest  # importing the library makes it easier to mock testing
 
-from typing import Type
-
 
 # Is this the right place for this? I feel like this should be done in an application, not a library.
 # -kmp 27-Apr-2020
@@ -171,11 +169,13 @@ def get_setting_from_context(settings, ini_var, env_var=None, default=None):
 
 
 @contextlib.contextmanager
-def filtered_warnings(action, message: str = "", category: Type[Warning] = Warning,
-                      module: str = "", lineno: int = 0, append: bool = False):
+def filtered_warnings(action, message="", category=None, module="", lineno=0, append=False):
     """
     Context manager temporarily filters deprecation messages for the duration of the body.
-    Used otherwise the same as warnings.filterwarnings would be used.
+
+    Except for its dynamic scope, this is used otherwise the same as warnings.filterwarnings would be used.
+
+    If category is unsupplied, it should be a class object that is Warning (the default) or one of its subclasses.
 
     For example:
 
@@ -185,6 +185,8 @@ def filtered_warnings(action, message: str = "", category: Type[Warning] = Warni
     Note: This is not threadsafe. It's OK while loading system and during testing,
           but not in worker threads.
     """
+    if category is None:
+        category = Warning
     with warnings.catch_warnings():
         warnings.filterwarnings(action, message=message, category=category, module=module,
                                 lineno=lineno, append=append)
@@ -605,15 +607,15 @@ def environ_bool(var, default=False):
         return os.environ[var].lower() == "true"
 
 
-def check_true(test_value: object,
-               message: str,
-               error_class: Type[Exception] = RuntimeError):
+def check_true(test_value, message, error_class=None):
     """
     If the first argument does not evaluate to a true value, an error is raised.
 
     The error, if one is raised, will be of type error_class, and its message will be given by message.
     The error_class defaults to RuntimeError, but may be any Exception class.
     """
+    if error_class is None:
+        error_class = RuntimeError
     if not test_value:
         raise error_class(message)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.39.0"
+version = "0.40.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_command_utils.py
+++ b/test/test_command_utils.py
@@ -1,0 +1,78 @@
+import contextlib
+import pytest
+
+from unittest import mock
+from dcicutils import command_utils as command_utils_module
+from dcicutils.command_utils import yes_or_no
+
+
+@mock.patch.object(command_utils_module, "PRINT")
+@mock.patch.object(command_utils_module, "input")
+def test_yes_or_no(mock_input, mock_print):
+
+    class OutOfInputs(Exception):
+        pass
+
+    def mocked_input(*args, **kwargs):
+        if not inputs:
+            raise OutOfInputs()
+        return inputs.pop()
+
+    @contextlib.contextmanager
+    def input_series(*items):
+        assert not inputs, "There are previously unused inputs."
+        for item in reversed(items):
+            inputs.append(item)
+        yield
+        assert not inputs, "Did not use all inputs."
+
+    def expect_printed(*expected):
+        def mocked_print(*what):
+            printed = " ".join(what)
+            assert printed in expected
+        return mocked_print
+
+    mock_input.side_effect = mocked_input
+
+    mock_print.side_effect = expect_printed("Please answer 'yes' or 'no'.")
+
+    inputs = []
+
+    with input_series('yes'):
+        assert yes_or_no("foo?") is True
+
+    with input_series('no'):
+        assert yes_or_no("foo?") is False
+
+    with input_series('foo', 'bar', '', 'y'):  # None of these are OK
+        with pytest.raises(OutOfInputs):
+            yes_or_no("foo?")
+
+    with input_series('', 'y', 'n', 'maybe', 'yes'):
+        assert yes_or_no("foo?") is True
+
+    with input_series('', 'y', 'n', 'maybe', 'no'):
+        assert yes_or_no("foo?") is False
+
+    mock_print.side_effect = expect_printed(
+        "The default if you just press Enter is 'y'.",
+        "Please answer 'y' or 'n'.")
+
+    with input_series('y'):
+        assert yes_or_no("foo?", quick=True) is True
+
+    with input_series('n'):
+        assert yes_or_no("foo?", default=True) is False
+
+    with input_series(''):
+        assert yes_or_no("foo?", quick=True, default=True) is True
+
+    with input_series('foo', 'bar', ''):
+        assert yes_or_no("foo?", default=True) is True
+
+    mock_print.side_effect = expect_printed(
+        "The default if you just press Enter is 'n'.",
+        "Please answer 'y' or 'n'.")
+
+    with input_series('foo', 'bar', ''):
+        assert yes_or_no("foo?", default=False) is False

--- a/test/test_command_utils.py
+++ b/test/test_command_utils.py
@@ -3,76 +3,134 @@ import pytest
 
 from unittest import mock
 from dcicutils import command_utils as command_utils_module
-from dcicutils.command_utils import yes_or_no
+from dcicutils.command_utils import _ask_boolean_question, yes_or_no, y_or_n
 
 
-@mock.patch.object(command_utils_module, "PRINT")
-@mock.patch.object(command_utils_module, "input")
-def test_yes_or_no(mock_input, mock_print):
+@contextlib.contextmanager
+def print_expected(*expected):
 
-    class OutOfInputs(Exception):
-        pass
+    def mocked_print(*what):
+        printed = " ".join(what)
+        assert printed in expected
 
-    def mocked_input(*args, **kwargs):
-        if not inputs:
-            raise OutOfInputs()
-        return inputs.pop()
+    with mock.patch.object(command_utils_module, "PRINT") as mock_print:
+        mock_print.side_effect = mocked_print
+        yield
 
-    @contextlib.contextmanager
-    def input_series(*items):
-        assert not inputs, "There are previously unused inputs."
+
+class OutOfInputs(Exception):
+    pass
+
+
+@contextlib.contextmanager
+def input_series(*items):
+    with mock.patch.object(command_utils_module, "input") as mock_input:
+
+        def mocked_input(*args, **kwargs):
+            if not inputs:
+                raise OutOfInputs()
+            return inputs.pop()
+
+        mock_input.side_effect = mocked_input
+
+        inputs = []
+
         for item in reversed(items):
             inputs.append(item)
         yield
         assert not inputs, "Did not use all inputs."
 
-    def expect_printed(*expected):
-        def mocked_print(*what):
-            printed = " ".join(what)
-            assert printed in expected
-        return mocked_print
 
-    mock_input.side_effect = mocked_input
+def test_ask_boolean_question():
 
-    mock_print.side_effect = expect_printed("Please answer 'yes' or 'no'.")
+    with print_expected("Please answer 'yes' or 'no'."):
 
-    inputs = []
+        with input_series('yes'):
+            assert _ask_boolean_question("foo?") is True
 
-    with input_series('yes'):
-        assert yes_or_no("foo?") is True
+        with input_series('no'):
+            assert _ask_boolean_question("foo?") is False
 
-    with input_series('no'):
-        assert yes_or_no("foo?") is False
+        with input_series('foo', 'bar', '', 'y'):  # None of these are OK
+            with pytest.raises(OutOfInputs):
+                _ask_boolean_question("foo?")
 
-    with input_series('foo', 'bar', '', 'y'):  # None of these are OK
-        with pytest.raises(OutOfInputs):
-            yes_or_no("foo?")
+        with input_series('', 'y', 'n', 'maybe', 'yes'):
+            assert _ask_boolean_question("foo?") is True
 
-    with input_series('', 'y', 'n', 'maybe', 'yes'):
-        assert yes_or_no("foo?") is True
+        with input_series('', 'y', 'n', 'maybe', 'no'):
+            assert _ask_boolean_question("foo?") is False
 
-    with input_series('', 'y', 'n', 'maybe', 'no'):
-        assert yes_or_no("foo?") is False
+    with print_expected("The default if you just press Enter is 'y'.",
+                        "Please answer 'y' or 'n'."):
 
-    mock_print.side_effect = expect_printed(
-        "The default if you just press Enter is 'y'.",
-        "Please answer 'y' or 'n'.")
+        with input_series('y'):
+            assert _ask_boolean_question("foo?", quick=True) is True
 
-    with input_series('y'):
-        assert yes_or_no("foo?", quick=True) is True
+        with input_series('n'):
+            assert _ask_boolean_question("foo?", default=True) is False
 
-    with input_series('n'):
-        assert yes_or_no("foo?", default=True) is False
+        with input_series(''):
+            assert _ask_boolean_question("foo?", quick=True, default=True) is True
 
-    with input_series(''):
-        assert yes_or_no("foo?", quick=True, default=True) is True
+        with input_series(''):
+            assert _ask_boolean_question("foo?", quick=True, default=False) is False
 
-    with input_series('foo', 'bar', ''):
-        assert yes_or_no("foo?", default=True) is True
+        with input_series('foo', 'bar', ''):
+            assert _ask_boolean_question("foo?", default=True) is True
 
-    mock_print.side_effect = expect_printed(
-        "The default if you just press Enter is 'n'.",
-        "Please answer 'y' or 'n'.")
+    with print_expected("The default if you just press Enter is 'n'.",
+                        "Please answer 'y' or 'n'."):
 
-    with input_series('foo', 'bar', ''):
-        assert yes_or_no("foo?", default=False) is False
+        with input_series('foo', 'bar', ''):
+            assert _ask_boolean_question("foo?", default=False) is False
+
+
+def test_yes_or_no():
+
+    with print_expected("Please answer 'yes' or 'no'."):
+
+        with input_series('yes'):
+            assert yes_or_no("foo?") is True
+
+        with input_series('no'):
+            assert yes_or_no("foo?") is False
+
+        with input_series('foo', 'bar', '', 'y'):  # None of these are OK
+            with pytest.raises(OutOfInputs):
+                yes_or_no("foo?")
+
+        with input_series('', 'y', 'n', 'maybe', 'yes'):
+            assert yes_or_no("foo?") is True
+
+        with input_series('', 'y', 'n', 'maybe', 'no'):
+            assert yes_or_no("foo?") is False
+
+
+def test_y_or_n():
+
+    with print_expected("The default if you just press Enter is 'y'.",
+                        "Please answer 'y' or 'n'."):
+        with input_series('y'):
+            assert y_or_n("foo?") is True
+
+        with input_series('n'):
+            assert y_or_n("foo?") is False
+
+        with input_series('', 'x', ''):
+            with pytest.raises(OutOfInputs):
+                y_or_n("foo?")
+
+        with input_series(''):
+            assert y_or_n("foo?", default=True) is True
+
+        with input_series(''):
+            assert y_or_n("foo?", default=False) is False
+
+        with input_series('foo', 'bar', ''):
+            assert y_or_n("foo?", default=True) is True
+
+    with print_expected("The default if you just press Enter is 'n'.",
+                        "Please answer 'y' or 'n'."):
+        with input_series('foo', 'bar', ''):
+            assert y_or_n("foo?", default=False) is False

--- a/test/test_data_utils.py
+++ b/test/test_data_utils.py
@@ -114,6 +114,7 @@ def test_generate_sample_fastq_gzip_content_with_gunzip():
 
 
 def test_normalize_suffixes():
+    """Test normalize_suffixes, which assures a certain suffix is present, possibly also with a compression suffix."""
 
     assert normalize_suffixes("foo", FASTQ_SUFFIXES) == ("foo.fastq", False)
     assert normalize_suffixes("foo", FASTQ_SUFFIXES, compressed=None) == ("foo.fastq", False)
@@ -133,7 +134,8 @@ def test_normalize_suffixes():
     assert normalize_suffixes("foo.fastq", FASTQ_SUFFIXES, compressed=True) == ("foo.fastq.gz", True)
 
 
-def test_c4_278():
+def test_fix_for_jira_ticket_c4_278():
+    """Test that C4-278 is fixed."""
 
     # These tests came from C4-278
     # These next two tests are probably enough to test the bug.

--- a/test/test_data_utils.py
+++ b/test/test_data_utils.py
@@ -1,10 +1,12 @@
 import io
+import pytest
 import os
 import tempfile
 
-from dcicutils.data_utils import gunzip_content, generate_sample_fastq_file, generate_sample_fastq_content
-from dcicutils.misc_utils import ignored
-from dcicutils.qa_utils import NotReallyRandom
+from dcicutils.data_utils import (
+    gunzip_content, generate_sample_fastq_file, generate_sample_fastq_content, normalize_suffixes, FASTQ_SUFFIXES,
+)
+from dcicutils.qa_utils import NotReallyRandom, MockFileSystem
 from unittest import mock
 from .conftest_settings import TEST_DIR
 
@@ -109,3 +111,74 @@ def test_generate_sample_fastq_gzip_content_with_gunzip():
             binary_content = fp.read()
         unzipped = gunzip_content(content=binary_content)
         assert unzipped == SAMPLE_CONTENT_2x10
+
+
+def test_normalize_suffixes():
+
+    assert normalize_suffixes("foo", FASTQ_SUFFIXES) == ("foo.fastq", False)
+    assert normalize_suffixes("foo", FASTQ_SUFFIXES, compressed=None) == ("foo.fastq", False)
+    assert normalize_suffixes("foo", FASTQ_SUFFIXES, compressed=False) == ("foo.fastq", False)
+    assert normalize_suffixes("foo", FASTQ_SUFFIXES, compressed=True) == ("foo.fastq.gz", True)
+
+    assert normalize_suffixes("foo.gz", FASTQ_SUFFIXES) == ("foo.fastq.gz", True)
+    assert normalize_suffixes("foo.gz", FASTQ_SUFFIXES, compressed=None) == ("foo.fastq.gz", True)
+    assert normalize_suffixes("foo.gz", FASTQ_SUFFIXES, compressed=True) == ("foo.fastq.gz", True)
+
+    with pytest.raises(RuntimeError):  # This case is self-contradictory so raises an error.
+        normalize_suffixes("foo.gz", FASTQ_SUFFIXES, compressed=False)
+
+    assert normalize_suffixes("foo.fastq", FASTQ_SUFFIXES) == ("foo.fastq", False)
+    assert normalize_suffixes("foo.fastq", FASTQ_SUFFIXES, compressed=None) == ("foo.fastq", False)
+    assert normalize_suffixes("foo.fastq", FASTQ_SUFFIXES, compressed=False) == ("foo.fastq", False)
+    assert normalize_suffixes("foo.fastq", FASTQ_SUFFIXES, compressed=True) == ("foo.fastq.gz", True)
+
+
+def test_c4_278():
+
+    # These tests came from C4-278
+    # These next two tests are probably enough to test the bug.
+
+    assert normalize_suffixes('test1.fastq.gz', FASTQ_SUFFIXES, compressed=True) == ("test1.fastq.gz", True)
+
+    with pytest.raises(RuntimeError):
+        normalize_suffixes('test1.fastq.gz', FASTQ_SUFFIXES, compressed=False)
+
+    # What follows here is probably overkill, but it illustrates some useful techniques in mocking, and it serves
+    # as a practical test that the recent support for opening byte streams in the MockFileSystem works.
+    # -kmp 18-Aug-2020
+
+    mfs = MockFileSystem()
+
+    def mock_didnt_compress(file, mode):
+        """We don't expect to call this function, but should complain if it does get called."""
+        raise AssertionError("Compression was not attempted: io.open(%r, %r)" % (file, mode))
+
+    def mock_gzip_open_for_write(file, mode):
+        """Writes a prefix followed by an ordinary bytes stream of uncompressed data for mocking purposes."""
+        assert mode == 'w'
+        opener = mfs.open(file, 'wb')
+        opener.stream.write(b"MockCompressed:")
+        return opener
+
+    with mock.patch("random.choice", NotReallyRandom().choice):
+        # By using a separate copy of NotReallyRandom(), we can simulate the inner core of what the call to
+        # generate_sample_fastq_file will return in the next code block.
+        # Note that our mock will NOT do compression at the internal level, regardless of the filename.
+        expected_content_1 = ("MockCompressed:%s" % generate_sample_fastq_content(num=20, length=25)).encode('utf-8')
+
+    with mock.patch("random.choice", NotReallyRandom().choice):
+        # In principle, depending on whether the bug is fixed, we don't know which of io.open or gzip.open will be used.
+        with mock.patch("io.open", mock_didnt_compress):
+            with mock.patch("gzip.open", mock_gzip_open_for_write):
+
+                # The bug report specifies two situations.
+                # The first is that generate_sample_fastq_file(input_filename, num=20, length=25, compressed=True)
+                # genenerates the file "test1.fastq.gz.fastq.gz" rather than just "test1.fastq.gz".
+                input_filename = 'test1.fastq.gz'
+                generated_filename = generate_sample_fastq_file(input_filename, num=20, length=25, compressed=True)
+                assert generated_filename == input_filename  # The bug was that it generated a different name
+                assert mfs.files.get(generated_filename) == expected_content_1
+
+                # The bug report specifies that this gives a wrong result, too,
+                with pytest.raises(RuntimeError):
+                    generate_sample_fastq_file(input_filename, num=20, length=25, compressed=False)

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -13,7 +13,8 @@ from dcicutils.env_utils import (
     prod_bucket_env, public_url_mappings, CGAP_PUBLIC_URLS, FF_PUBLIC_URLS, FF_PROD_BUCKET_ENV, CGAP_PROD_BUCKET_ENV,
     infer_repo_from_env, data_set_for_env, get_bucket_env, infer_foursight_from_env, FF_PRODUCTION_IDENTIFIER,
     FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV,
-    FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env
+    FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env,
+    full_env_name, full_cgap_env_name, full_fourfront_env_name,
 )
 from unittest import mock
 
@@ -471,3 +472,72 @@ def test_is_indexer_env():
     assert not is_indexer_env('fourfront-green')
     assert not is_indexer_env('fourfront-mastertest')
     assert not is_indexer_env('fourfront-cgapwolf')
+
+
+def test_full_env_name():
+
+    assert full_env_name('cgapdev') == 'fourfront-cgapdev'
+    assert full_env_name('mastertest') == 'fourfront-mastertest'
+
+    assert full_env_name('fourfront-cgapdev') == 'fourfront-cgapdev'
+    assert full_env_name('fourfront-mastertest') == 'fourfront-mastertest'
+
+    # Does not require a registered env
+    assert full_env_name('foo') == 'fourfront-foo'
+    assert full_env_name('cgapfoo') == 'fourfront-cgapfoo'
+
+    # But 'staging' and 'data' are special and don't work here.
+    with pytest.raises(ValueError):
+        full_env_name('staging')
+
+    with pytest.raises(ValueError):
+        full_env_name('data')
+
+
+def test_full_cgap_env_name():
+    assert full_cgap_env_name('cgapdev') == 'fourfront-cgapdev'
+    assert full_cgap_env_name('fourfront-cgapdev') == 'fourfront-cgapdev'
+
+    # Does not require a registered env
+    assert full_cgap_env_name('cgapfoo') == 'fourfront-cgapfoo'
+
+    with pytest.raises(ValueError):
+        full_cgap_env_name('mastertest')
+
+    with pytest.raises(ValueError):
+        full_cgap_env_name('fourfront-mastertest')
+
+    with pytest.raises(ValueError):
+        full_cgap_env_name('foo')
+
+    # Special names 'staging' and 'data' don't work here.
+    with pytest.raises(ValueError):
+        full_cgap_env_name('staging')
+
+    with pytest.raises(ValueError):
+        full_cgap_env_name('data')
+
+
+def test_full_fourfront_env_name():
+
+    assert full_fourfront_env_name('mastertest') == 'fourfront-mastertest'
+    assert full_fourfront_env_name('fourfront-mastertest') == 'fourfront-mastertest'
+
+    # Does not require a registered env
+    assert full_fourfront_env_name('foo') == 'fourfront-foo'
+
+    with pytest.raises(ValueError):
+        full_fourfront_env_name('cgapdev')
+
+    with pytest.raises(ValueError):
+        full_fourfront_env_name('fourfront-cgapdev')
+
+    with pytest.raises(ValueError):
+        full_fourfront_env_name('cgapfoo')
+
+    # Special names 'staging' and 'data' don't work here.
+    with pytest.raises(ValueError):
+        full_fourfront_env_name('staging')
+
+    with pytest.raises(ValueError):
+        full_fourfront_env_name('data')

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -1,9 +1,12 @@
 import pytest
 import json
 import time
+
 from dcicutils import ff_utils, s3_utils
 from unittest import mock
 from botocore.exceptions import ClientError
+
+
 pytestmark = pytest.mark.working
 
 
@@ -1053,7 +1056,7 @@ def test_expand_es_metadata_ignore_fields(integrated_ff):
     for pos_case in ['workflow_run_awsem', 'workflow', 'file_reference', 'software', 'workflow_run_sbg']:
         assert pos_case in store
     for neg_case in ['quality_metric_pairsqc',  'quality_metric_fastqc']:
-        neg_case not in store
+        assert neg_case not in store
 
 
 @pytest.mark.integrated


### PR DESCRIPTION
Various changes, mostly in service of `SubmitCGAP`:

* New function `command_utils.yes_or_no` for use by `SubmitCGAP`.
* New functions `full_env_name`, `full_cgap_env_name`, and `full_fourfront_env_name` in `env_utils`.
* Fix for [file naming bug in dcicutils.data_utils (C4-278)](https://hms-dbmi.atlassian.net/browse/C4-278).
* Fix for [python 3.5 incompatibility for dcicutils v0.39.0 (C4-279)](https://hms-dbmi.atlassian.net/browse/C4-279).

Opportunistic:

* Disable `beanstalk_utils.create_bs` in staging & production. (There was a comment in the doc string saying not to do it, but it seemed prudent to add enforcement.)
