### PR TITLE
Add VirtualApp.put_json (C4-272)

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -101,6 +101,20 @@ class VirtualApp:
         except webtest.AppError as e:
             raise VirtualAppError(msg='HTTP POST failed.', url=url, body=obj, raw_exception=e)
 
+    def put_json(self, url, obj, **kwargs):
+        """ Wrapper for TestApp.put_json that logs the outgoing PUT
+
+        :param url: url to PUT to
+        :param obj: object body to PUT
+        :param kwargs: args to pass to the PUT
+        :return: result of PUT
+        """
+        logging.info('OUTGOING HTTP PUT on url: %s with object: %s' % (url, obj))
+        try:
+            return self.wrapped_app.put_json(url, obj, **kwargs)
+        except webtest.AppError as e:
+            raise VirtualAppError(msg='HTTP PUT failed.', url=url, body=obj, raw_exception=e)
+
     def patch_json(self, url, fields, **kwargs):
         """ Wrapper for TestApp.patch_json that logs the outgoing PATCH
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "0.40.0"
+version = "0.41.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Per [C4-272](https://hms-dbmi.atlassian.net/browse/C4-272), this adds a `put_json` method to `VirtualApp`. I patterned it after what `post_json` does, since I think they're syntactically the same and differ only in effect. From a unit testing point of view, this just tests that the underlying app gets called with the right method. 

I did visually peruse the code and determine that `webapp.TestApp` in fact has a `.put_json` method (though I didn't write a test for that detail).
