### PR TITLE
Miscellaneous utilities ported from cgap-portal and SubmitCGAP repos

### DIFF
--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -231,6 +231,27 @@ def public_url_mappings(envname):
     return CGAP_PUBLIC_URLS if is_cgap_env(envname) else FF_PUBLIC_URLS
 
 
+def is_cgap_server(server, allow_localhost=False):
+    """
+    Returns True if the given string looks like a CGAP server name. Otherwise returns False.
+
+    If allow_localhost (default False) is True, then 'localhost' will be treated as a CGAP host.
+    """
+    check_true(isinstance(server, str), "Server name must be a string.", error_class=ValueError)
+    return 'cgap' in server or (allow_localhost and 'localhost' in server)
+
+
+def is_fourfront_server(server, allow_localhost=False):
+    """
+    Returns True if the given string looks like a Fourfront server name. Otherwise returns False.
+
+    If allow_localhost (default False) is True, then 'localhost' will be treated as a Fourfront host.
+    """
+    check_true(isinstance(server, str), "Server name must be a string.", error_class=ValueError)
+    return (("fourfront" in server or "4dnucleome" in server) and not is_cgap_server(server)
+            or (allow_localhost and 'localhost' in server))
+
+
 def is_cgap_env(envname):
     """
     Returns True of the given string looks like a CGAP elasticbeanstalk environment name.

--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 
-from .misc_utils import ignored
+from .qa_utils import ignored
 
 
 class EnglishUtils:
@@ -122,9 +122,18 @@ class EnglishUtils:
     def n_of(cls, n, thing, num_format=None):
         """
         Given a number and a noun, returns the name for that many of that noun.
-        e.g., n_of(7, "variant") => "7 variants"
-              n_of(1, "accession") => "1 accession"
+
+        Examples:
+
+            >>> n_of(7, "variant")
+            '7 variants'
+            >>> n_of(1, "accession")
+            '1 accession'
+            >>> n_of(['alpha', 'beta', 'gamma'], 'Greek letter')
+            '3 Greek letters'
         """
+        if isinstance(n, (list, tuple, set, dict)):
+            n = len(n)
         display_n = n
         if num_format:
             res = num_format(n, thing)

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -21,12 +21,10 @@ logging.basicConfig()
 # Using PRINT(...) for debugging, rather than its more familiar lowercase form) for intended programmatic output,
 # makes it easier to find stray print statements that were left behind in debugging. -kmp 30-Mar-2020
 
-_print = print  # Necessary indirection for qa_utils.printed_lines
-
 class _PRINT:
 
     def __init__(self):
-        self._printer = print
+        self._printer = print  # necessary indirection for sake of qa_utils.printed_output
 
     def __call__(self, *args, timestamped=False, **kwargs):
         """
@@ -44,6 +42,7 @@ class _PRINT:
 
 PRINT = _PRINT()
 PRINT.__name__ = 'PRINT'
+
 
 class VirtualAppError(Exception):
     """ Special Exception to be raised by VirtualApp that contains some additional info """

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -682,11 +682,7 @@ def full_class_name(obj):
     """
 
     # Source: https://stackoverflow.com/questions/2020014/get-fully-qualified-class-name-of-an-object-in-python
-    module = obj.__class__.__module__
-    if module is None or module == str.__class__.__module__:
-        return obj.__class__.__name__  # Avoid reporting __builtin__
-    else:
-        return module + '.' + obj.__class__.__name__
+    return full_object_name(obj.__class__)
 
 
 def full_object_name(obj):

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -5,6 +5,7 @@ This file contains functions that might be generally useful.
 import contextlib
 import datetime
 import functools
+import io
 import os
 import logging
 import time
@@ -732,3 +733,8 @@ def keyword_as_title(keyword):
     """
 
     return keyword.replace("_", " ").title()
+
+
+def file_contents(filename, binary=False):
+    with io.open(filename, 'rb' if binary else 'r') as fp:
+        return fp.read()

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -20,8 +20,29 @@ logging.basicConfig()
 # Using PRINT(...) for debugging, rather than its more familiar lowercase form) for intended programmatic output,
 # makes it easier to find stray print statements that were left behind in debugging. -kmp 30-Mar-2020
 
-PRINT = print
+_print = print  # Necessary indirection for qa_utils.printed_lines
 
+class _PRINT:
+
+    def __init__(self):
+        self._printer = print
+
+    def __call__(self, *args, timestamped=False, **kwargs):
+        """
+        Prints its args space-separated, as 'print' would, possibly with an hh:mm:ss timestamp prepended.
+
+        :param args: an object to be printed
+        :param with_time: a boolean specifying whether to prepend a timestamp
+        """
+        if timestamped:
+            hh_mm_ss = str(datetime.datetime.now().strftime("%H:%M:%S"))
+            self._printer(hh_mm_ss, *args, **kwargs)
+        else:
+            self._printer(*args, **kwargs)
+
+
+PRINT = _PRINT()
+PRINT.__name__ = 'PRINT'
 
 class VirtualAppError(Exception):
     """ Special Exception to be raised by VirtualApp that contains some additional info """
@@ -650,3 +671,68 @@ def remove_suffix(suffix, text, required=False):
         else:
             return text
     return text[:len(text)-len(suffix)]
+
+
+def full_class_name(obj):
+    """
+    Returns the fully-qualified name of the class of the given obj (an object).
+
+    For built-in classes, just the class name is returned.
+    For other classes, the class name with the module name prepended (separated by a dot) is returned.
+    """
+
+    # Source: https://stackoverflow.com/questions/2020014/get-fully-qualified-class-name-of-an-object-in-python
+    module = obj.__class__.__module__
+    if module is None or module == str.__class__.__module__:
+        return obj.__class__.__name__  # Avoid reporting __builtin__
+    else:
+        return module + '.' + obj.__class__.__name__
+
+
+def full_object_name(obj):
+    """
+    Returns the fully-qualified name the given obj, if it has a name, or None otherwise.
+
+    For built-in classes, just the class name is returned.
+    For other objects, the name with the module name prepended (separated by a dot) is returned.
+    If the object has no __module__ or __name__ attribute, None is returned.
+    """
+
+    try:
+        module = obj.__module__
+        if module is None or module == str.__class__.__module__:
+            return obj.__name__  # Avoid reporting __builtin__
+        else:
+            return module + '.' + obj.__name__
+    except Exception:
+        return None
+
+
+def constantly(value):
+    def fn(*args, **kwargs):
+        ignored(args, kwargs)
+        return value
+    return fn
+
+
+def keyword_as_title(keyword):
+    """
+    Given a dictionary key or other token-like keyword, return a prettier form of it use as a display title.
+
+    Underscores are replaced by spaces, but hyphens are not.
+    It is assumed that underscores are word-separators but a hyphenated word is still a hyphenated word.
+
+    Examples:
+
+        >>> keyword_as_title('foo')
+        'Foo'
+        >>> keyword_as_title('some_text')
+        'Some Text'
+        >>> keyword_as_title('mary_smith-jones')
+        'Mary Smith-Jones'
+
+    :param keyword: a string to be used as a keyword, for example a dictionary key
+    :return: a string to be used in a title: text in title case with underscores replaced by spaces.
+    """
+
+    return keyword.replace("_", " ").title()

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -534,8 +534,25 @@ class MockBotoS3Client:
         with self.s3_files.open(os.path.join(Bucket, Key), 'wb') as fp:
             fp.write(data)
 
-    def upload_file(self, Filename, Bucket, Key, **kwargs):
+    def upload_file(self, Filename, Bucket, Key, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
         if kwargs:
             raise MockKeysNotImplemented("upload_file", kwargs.keys())
+
         with io.open(Filename, 'rb') as fp:
             self.upload_fileobj(Fileobj=fp, Bucket=Bucket, Key=Key)
+
+    def download_fileobj(self, Bucket, Key, Fileobj, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
+        if kwargs:
+            raise MockKeysNotImplemented("upload_file", kwargs.keys())
+
+        with self.s3_files.open(os.path.join(Bucket, Key), 'rb') as fp:
+            data = fp.read()
+        print("Downloading bucket %s key %s (%s bytes) to %s"
+              % (Bucket, Key, len(data), Fileobj))
+        Fileobj.write(data)
+
+    def download_file(self, Bucket, Key, Filename, **kwargs):
+        if kwargs:
+            raise MockKeysNotImplemented("upload_file", kwargs.keys())
+        with io.open(Filename, 'wb') as fp:
+            self.download_fileobj(Bucket=Bucket, Key=Key, Fileobj=fp)

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -9,6 +9,7 @@ import io
 import os
 import pytz
 
+from json import dumps as json_dumps, loads as json_loads
 from .misc_utils import PRINT, ignored, Retry
 
 
@@ -394,6 +395,9 @@ class MockFileSystem:
 
 
 class NotReallyRandom:
+    """
+    This can be used as a substitute for random to return numbers in a more predictable order.
+    """
 
     def __init__(self):
         self.counter = 0
@@ -412,3 +416,126 @@ class NotReallyRandom:
 
     def choice(self, things):
         return things[self._random_int(len(things))]
+
+
+class MockResponse:
+    """
+    This class is useful for mocking requests.Response (the class that comes back from requests.get and friends).
+
+    This mock is useful because requests.Response is a pain to initialize and the common cases are simple to set
+    up here by just passing arguments.
+
+    Note, too, that requests.Response differs from pyramid.Response in that in requests.Response the way to get
+    the JSON out of a response is to use the .json() method, whereas in pyramid.Response it would just be
+    a .json property access. So since this is for mocking requests.Response, we implement the function.
+    """
+
+    def __init__(self, status_code=200, json=None, content=None):
+        self.status_code = status_code
+        if json is not None and content is not None:
+            raise Exception("MockResponse cannot have both content and json.")
+        elif content is not None:
+            self.content = content
+        elif json is None:
+            self.content = ""
+        else:
+            self.content = json_dumps(json)
+
+    def __str__(self):
+        if self.content:
+            return "<MockResponse %s %s>" % (self.status_code, self.content)
+        else:
+            return "<MockResponse %s>" % (self.status_code,)
+
+    def json(self):
+        return json_loads(self.content)
+
+    def raise_for_status(self):
+        if self.status_code >= 300:
+            raise Exception("%s raised for status." % self)
+
+
+class _PrintCapturer:
+    """
+    This class is used internally to the 'printed_lines' context manager to maintain state information
+    on what has been printed so far by PRINT within the indicated context.
+    """
+
+    def __init__(self):
+        self.lines = []
+        self.last = None
+
+    def mock_print_handler(self, *args, **kwargs):
+        text = " ".join(map(str, args))
+        print(text, **kwargs)
+        # This only captures non-file output output.
+        if kwargs.get('file') is None:
+            self.last = text
+            self.lines.append(text)
+
+
+@contextlib.contextmanager
+def printed_lines():
+    """
+    This context manager is used to capture output from dcicutils.PRINT for testing.
+
+    The 'printed' object obtained in the 'as' clause of this context manager has two attributes of note:
+
+    * .last contains the last (i.e., most recent) line of output
+    * .lines contains all the lines of output in a list
+
+    These values are updated dynamically as output occurs.
+    (Only output that is not to a file will be captured.)
+
+    Example:
+
+        def show_succcessor(n):
+            PRINT("The successor of %s is %s." % (n, n+1))
+
+        def test_show_successor():
+            with printed_lines() as printed:
+                assert printed.last is None
+                assert printed.lines == []
+                show_successor(3)
+                assert printed.last = 'The successor of 3 is 4.'
+                assert printed.lines == ['The successor of 3 is 4.']
+                show_successor(4)
+                assert printed.last == 'The successor of 4 is 5.'
+                assert printed.lines == ['The successor of 3 is 4.', 'The successor of 4 is 5.']
+    """
+
+    printed = _PrintCapturer()
+    with local_attrs(PRINT, _printer=printed.mock_print_handler):
+        yield printed
+
+
+class MockKeysNotImplemented(NotImplementedError):
+
+    def __init__(self, operation, keys):
+        self.operation = operation
+        self.keys = keys
+        super().__init__("Mocked %s does not implement keywords: %s" % (operation, ", ".join(keys)))
+
+
+class MockBotoS3Client:
+    """
+    This is a mock of certain S3 functionality.
+    """
+
+    def __init__(self):
+        self.s3_files = MockFileSystem()
+
+    def upload_fileobj(self, Fileobj, Bucket, Key, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
+        if kwargs:
+            raise MockKeysNotImplemented("upload_fileobj", kwargs.keys())
+        data = Fileobj.read()
+        print("Uploading %s (%s bytes) to bucket %s key %s"
+              % (Fileobj, len(data), Bucket, Key))
+        with self.s3_files.open(os.path.join(Bucket, Key), 'wb') as fp:
+            fp.write(data)
+
+    def upload_file(self, Filename, Bucket, Key, **kwargs):
+        if kwargs:
+            raise MockKeysNotImplemented("upload_file", kwargs.keys())
+        with io.open(Filename, 'rb') as fp:
+            self.upload_fileobj(Fileobj=fp, Bucket=Bucket, Key=Key)

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -457,7 +457,7 @@ class MockResponse:
 
 class _PrintCapturer:
     """
-    This class is used internally to the 'printed_lines' context manager to maintain state information
+    This class is used internally to the 'printed_output' context manager to maintain state information
     on what has been printed so far by PRINT within the indicated context.
     """
 
@@ -475,7 +475,7 @@ class _PrintCapturer:
 
 
 @contextlib.contextmanager
-def printed_lines():
+def printed_output():
     """
     This context manager is used to capture output from dcicutils.PRINT for testing.
 
@@ -493,7 +493,7 @@ def printed_lines():
             PRINT("The successor of %s is %s." % (n, n+1))
 
         def test_show_successor():
-            with printed_lines() as printed:
+            with printed_output() as printed:
                 assert printed.last is None
                 assert printed.lines == []
                 show_successor(3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.0.0b1"
+version = "1.1.0b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -14,7 +14,7 @@ from dcicutils.env_utils import (
     infer_repo_from_env, data_set_for_env, get_bucket_env, infer_foursight_from_env, FF_PRODUCTION_IDENTIFIER,
     FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env,
-    full_env_name, full_cgap_env_name, full_fourfront_env_name,
+    full_env_name, full_cgap_env_name, full_fourfront_env_name, is_cgap_server, is_fourfront_server,
 )
 from unittest import mock
 
@@ -127,6 +127,71 @@ def test_blue_green_mirror_env():
     assert blue_green_mirror_env('xyz-blue-1') == 'xyz-green-1'
     assert blue_green_mirror_env('xyz-blueish') == 'xyz-greenish'
     assert blue_green_mirror_env('xyz-greenish') == 'xyz-blueish'
+
+
+def test_is_cgap_server():
+
+    with pytest.raises(ValueError):
+        is_cgap_server(None)
+
+    assert is_cgap_server("https://data.4dnucleome.org") is False
+    assert is_cgap_server("https://staging.4dnucleome.org") is False
+    assert is_cgap_server("https://cgap.hms.harvard.edu") is True
+
+    assert is_cgap_server("http://data.4dnucleome.org") is False
+    assert is_cgap_server("http://staging.4dnucleome.org") is False
+    assert is_cgap_server("http://cgap.hms.harvard.edu") is True
+
+    assert is_cgap_server("data.4dnucleome.org") is False
+    assert is_cgap_server("staging.4dnucleome.org") is False
+    assert is_cgap_server("cgap.hms.harvard.edu") is True
+
+    assert is_cgap_server("fourfront-mastertest.something.elasticsomething.com") is False
+    assert is_cgap_server("fourfront-webdev.something.elasticsomething.com") is False
+    assert is_cgap_server("fourfront-hotseat.something.elasticsomething.com") is False
+    assert is_cgap_server("fourfront-foo.something.elasticsomething.com") is False
+    assert is_cgap_server("fourfront-cgap.something.elasticsomething.com") is True
+    assert is_cgap_server("fourfront-cgapdev.something.elasticsomething.com") is True
+    assert is_cgap_server("fourfront-cgaptest.something.elasticsomething.com") is True
+    assert is_cgap_server("fourfront-cgapwolf.something.elasticsomething.com") is True
+    assert is_cgap_server("fourfront-cgapfoo.something.elasticsomething.com") is True
+
+    assert is_cgap_server("localhost") is False
+    assert is_cgap_server("localhost", allow_localhost=True) is True
+
+    assert is_cgap_server("www.google.com") is False
+
+
+def test_is_fourfront_server():
+    with pytest.raises(ValueError):
+        is_fourfront_server(None)
+
+    assert is_fourfront_server("https://data.4dnucleome.org") is True
+    assert is_fourfront_server("https://staging.4dnucleome.org") is True
+    assert is_fourfront_server("https://cgap.hms.harvard.edu") is False
+
+    assert is_fourfront_server("http://data.4dnucleome.org") is True
+    assert is_fourfront_server("http://staging.4dnucleome.org") is True
+    assert is_fourfront_server("http://cgap.hms.harvard.edu") is False
+
+    assert is_fourfront_server("data.4dnucleome.org") is True
+    assert is_fourfront_server("staging.4dnucleome.org") is True
+    assert is_fourfront_server("cgap.hms.harvard.edu") is False
+
+    assert is_fourfront_server("fourfront-mastertest.something.elasticsomething.com") is True
+    assert is_fourfront_server("fourfront-webdev.something.elasticsomething.com") is True
+    assert is_fourfront_server("fourfront-hotseat.something.elasticsomething.com") is True
+    assert is_fourfront_server("fourfront-foo.something.elasticsomething.com") is True
+    assert is_fourfront_server("fourfront-cgap.something.elasticsomething.com") is False
+    assert is_fourfront_server("fourfront-cgapdev.something.elasticsomething.com") is False
+    assert is_fourfront_server("fourfront-cgaptest.something.elasticsomething.com") is False
+    assert is_fourfront_server("fourfront-cgapwolf.something.elasticsomething.com") is False
+    assert is_fourfront_server("fourfront-cgapfoo.something.elasticsomething.com") is False
+
+    assert is_fourfront_server("localhost") is False
+    assert is_fourfront_server("localhost", allow_localhost=True) is True
+
+    assert is_fourfront_server("www.google.com") is False
 
 
 def test_is_cgap_env():

--- a/test/test_lang_utils.py
+++ b/test/test_lang_utils.py
@@ -57,6 +57,10 @@ def test_n_of():
     assert EnglishUtils.n_of(2, "day") == "2 days"
     assert EnglishUtils.n_of(2.5, "day") == "2.5 days"
 
+    assert EnglishUtils.n_of(7, "variant") == '7 variants'
+    assert EnglishUtils.n_of(1, "accession") == '1 accession'
+    assert EnglishUtils.n_of(['alpha', 'beta', 'gamma'], 'Greek letter') == '3 Greek letters'
+
 
 def test_relative_time_string():
 

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -413,6 +413,9 @@ def test_virtual_app_crud_failure():
         def post_json(self, url, object, **kwargs):  # noqa - the name of this argument is not chosen by us here
             raise webtest.AppError(simulated_error_message)
 
+        def put_json(self, url, object, **kwargs):  # noqa - the name of this argument is not chosen by us here
+            raise webtest.AppError(simulated_error_message)
+
         def patch_json(self, url, fields, **kwargs):
             raise webtest.AppError(simulated_error_message)
 
@@ -428,6 +431,7 @@ def test_virtual_app_crud_failure():
         operations = [
             lambda: vapp.get(some_url),
             lambda: vapp.post_json(some_url, {'a': 1, 'b': 2, 'c': 3}),
+            lambda: vapp.put_json(some_url, {'a': 1, 'b': 2, 'c': 3}),
             lambda: vapp.patch_json(some_url, {'b': 5})
         ]
 

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -13,7 +13,7 @@ from dcicutils.misc_utils import Retry, PRINT
 from dcicutils.qa_utils import (
     mock_not_called, local_attrs, override_environ, show_elapsed_time, timed,
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom,
-    MockResponse, printed_lines,
+    MockResponse, printed_output,
 )
 # The following line needs to be separate from other imports. It is PART OF A TEST.
 from dcicutils.qa_utils import notice_pytest_fixtures   # Use care if editing this line. It is PART OF A TEST.
@@ -837,7 +837,7 @@ def test_mock_response():
 
 def test_uppercase_print_with_printed_output():
 
-    with printed_lines() as printed:
+    with printed_output() as printed:
 
         assert printed.lines == []
 
@@ -853,7 +853,7 @@ def test_uppercase_print_with_printed_output():
 def test_uppercase_print_with_time():
 
     # Test uses WITHOUT timestamps
-    with printed_lines() as printed:
+    with printed_output() as printed:
 
         assert printed.lines == []
         assert printed.last is None
@@ -871,7 +871,7 @@ def test_uppercase_print_with_time():
     timestamp_pattern = re.compile(r'^[0-9][0-9]:[0-9][0-9]:[0-9][0-9] (.*)$')
 
     # Test uses WITH timestamps
-    with printed_lines() as printed:
+    with printed_output() as printed:
 
         PRINT("This", "is", "a", "test.", timestamped=True)
         PRINT("This, too.", timestamped=True)
@@ -884,7 +884,7 @@ def test_uppercase_print_with_time():
 
         assert trimmed == ["This is a test.", "This, too."]
 
-    with printed_lines() as printed:
+    with printed_output() as printed:
 
         PRINT("This", "is", "a", "test.", timestamped=True)
         PRINT("This, too.")

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -9,10 +9,11 @@ import time
 import uuid
 
 from dcicutils import qa_utils
-from dcicutils.misc_utils import Retry
+from dcicutils.misc_utils import Retry, PRINT
 from dcicutils.qa_utils import (
     mock_not_called, local_attrs, override_environ, show_elapsed_time, timed,
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom,
+    MockResponse, printed_lines,
 )
 # The following line needs to be separate from other imports. It is PART OF A TEST.
 from dcicutils.qa_utils import notice_pytest_fixtures   # Use care if editing this line. It is PART OF A TEST.
@@ -700,7 +701,6 @@ def test_mock_file_system():
                 assert not os.path.exists(filename)
 
 
-
 class _MockPrinter:
 
     def __init__(self):
@@ -789,3 +789,107 @@ def test_not_really_random():
 
     r = NotReallyRandom()
     assert [r.randint(3, 5) for _ in range(10)] == [3, 4, 5, 3, 4, 5, 3, 4, 5, 3]
+
+
+def test_mock_response():
+
+    # Cannot specify both json and content
+    with pytest.raises(Exception):
+        MockResponse(200, content="foo", json={"foo": "bar"})
+
+    ok_empty_response = MockResponse(status_code=200)
+
+    assert ok_empty_response.content == ""
+
+    with pytest.raises(Exception):
+        ok_empty_response.json()
+
+    assert str(ok_empty_response) == '<MockResponse 200>'
+
+    ok_empty_response.raise_for_status()  # This should raise no error
+
+    ok_response = MockResponse(status_code=200, json={'foo': 'bar'})
+
+    assert ok_response.status_code == 200
+    assert ok_response.json() == {'foo': 'bar'}
+
+    assert str(ok_response) == '<MockResponse 200 {"foo": "bar"}>'
+
+    ok_response.raise_for_status()  # This should raise no error
+
+    ok_non_json_response = MockResponse(status_code=200, content="foo")
+
+    assert ok_non_json_response.status_code == 200
+    assert ok_non_json_response.content == "foo"
+    with pytest.raises(Exception):
+        ok_non_json_response.json()
+
+    error_response = MockResponse(status_code=400, json={'message': 'bad stuff'})
+
+    assert error_response.status_code == 400
+    assert error_response.json() == {'message': "bad stuff"}
+
+    assert str(error_response) == '<MockResponse 400 {"message": "bad stuff"}>'
+
+    with pytest.raises(Exception):
+        error_response.raise_for_status()
+
+
+def test_uppercase_print_with_printed_output():
+
+    with printed_lines() as printed:
+
+        assert printed.lines == []
+
+        PRINT("foo")
+        assert printed.lines == ["foo"]
+        assert printed.last == "foo"
+
+        PRINT("bar")
+        assert printed.lines == ["foo", "bar"]
+        assert printed.last == "bar"
+
+
+def test_uppercase_print_with_time():
+
+    # Test uses WITHOUT timestamps
+    with printed_lines() as printed:
+
+        assert printed.lines == []
+        assert printed.last is None
+
+        PRINT("This", "is", "a", "test.")
+
+        assert printed.lines == ["This is a test."]
+        assert printed.last == "This is a test."
+
+        PRINT("This, too.")
+
+        assert printed.lines == ["This is a test.", "This, too."]
+        assert printed.last == "This, too."
+
+    timestamp_pattern = re.compile(r'^[0-9][0-9]:[0-9][0-9]:[0-9][0-9] (.*)$')
+
+    # Test uses WITH timestamps
+    with printed_lines() as printed:
+
+        PRINT("This", "is", "a", "test.", timestamped=True)
+        PRINT("This, too.", timestamped=True)
+
+        trimmed = []
+        for line in printed.lines:
+            matched = timestamp_pattern.match(line)
+            assert matched, "Timestamp missing or in bad form: %s" % line
+            trimmed.append(matched.group(1))
+
+        assert trimmed == ["This is a test.", "This, too."]
+
+    with printed_lines() as printed:
+
+        PRINT("This", "is", "a", "test.", timestamped=True)
+        PRINT("This, too.")
+
+        line0, line1 = printed.lines
+
+        assert timestamp_pattern.match(line0)
+        assert not timestamp_pattern.match(line1)

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1037,8 +1037,14 @@ def test_mock_boto_s3_client_limitations():
 
         with pytest.raises(MockKeysNotImplemented):
             mock_s3_client.download_file(Filename="foo", Bucket="bucketname", Key="keyname",
-                                          Config='not-implemented')
+                                         Config='not-implemented')
 
         with pytest.raises(MockKeysNotImplemented):
             mock_s3_client.download_fileobj(Fileobj=io.BytesIO(), Bucket="bucketname", Key="keyname",
                                             Config='not-implemented')
+
+
+def test_mock_keys_not_implemented():
+
+    err = MockKeysNotImplemented(keys=['foo', 'bar'], operation="some-operation")
+    assert str(err) == 'Mocked some-operation does not implement keywords: foo, bar'


### PR DESCRIPTION
This contains functionality that was in the `cgap-portal` and `SubmitCGAP` repo but that we had flagged as better to live in `dcicutils` so it can be shared for use in other places. In a few cases, I renamed or enhanced the feature slightly to be of more general utility. There might be some missing tests since the versions that existed in the other repos were sometimes in test files and test files don't have their own test files. Overall, the testing situation should be improved, though, from where the code was before. It's still fine in review to flag issues. There may be some missing doc strings in some cases, too. But I wanted to get this PR up for review in case there was other stuff I should be attending to.

This is background / low priority. Nothing depends on this happening on any particular schedule. I worked on it this weekend while watching movies. :)