### PR TITLE
Port quick_deepcopy as copy_json

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -823,3 +823,19 @@ def make_counter(start=0, step=1):
         return value
 
     return counter
+
+
+def copy_json(obj):
+    """ This function is taken and renamed from ENCODE's snovault quick_deepcopy
+
+    Deep copy an object consisting of dicts, lists, and primitives.
+    This is faster than Python's `copy.deepcopy` because it doesn't
+    do bookkeeping to avoid duplicating objects in a cyclic graph.
+    This is intended to work fine for data deserialized from JSON,
+    but won't work for everything.
+    """
+    if isinstance(obj, dict):
+        obj = {k: copy_json(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        obj = [copy_json(v) for v in obj]
+    return obj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.2.1"
+version = "1.2.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -16,6 +16,7 @@ from dcicutils.misc_utils import (
     Retry, apply_dict_overrides, utc_today_str, RateManager, environ_bool,
     LockoutManager, check_true, remove_prefix, remove_suffix, full_class_name, full_object_name, constantly,
     keyword_as_title, file_contents, CachedField, camel_case_to_snake_case, snake_case_to_camel_case, make_counter,
+    copy_json,
 )
 from dcicutils.qa_utils import Occasionally, ControlledTime, override_environ, MockFileSystem
 from unittest import mock
@@ -1282,3 +1283,20 @@ def test_camel_case_to_snake_case(input, expected):
 ])
 def test_snake_case_to_camel_case(input, expected):
     assert snake_case_to_camel_case(input) == expected
+
+
+@pytest.mark.parametrize('obj', [
+    {},
+    {'hello': 'world'},
+    {'foo': 5},
+    {'list': ['a', 'b', 'c']},
+    {'list2': [1, 2, 3]},
+    {'list_of_objects': [
+        {'hello': 'world', 'foo': 'bar'},
+        {'hello': 'dog', 'foo': 'cat'}
+    ]},
+    {'object': {'of objects': {'of more objects': {'even more': 'and more'}}}}
+])
+def test_copy_json(obj):
+    """ Tests some basic cases for copy_json """
+    assert copy_json(obj) == obj

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -1300,3 +1300,14 @@ def test_snake_case_to_camel_case(input, expected):
 def test_copy_json(obj):
     """ Tests some basic cases for copy_json """
     assert copy_json(obj) == obj
+
+
+def test_copy_json_side_effects():
+    obj = {'foo': [1, 2, 3], 'bar': [{'x': 4, 'y': 5}, {'x': 2, 'y': 7}]}
+    obj_copy = copy_json(obj)
+    obj['foo'][1] = 20
+    obj['bar'][0]['y'] = 500
+    obj['bar'][1] = 17
+    assert obj == {'foo': [1, 20, 3], 'bar': [{'x': 4, 'y': 500}, 17]}
+    assert obj_copy == {'foo': [1, 2, 3], 'bar': [{'x': 4, 'y': 5}, {'x': 2, 'y': 7}]}
+


### PR DESCRIPTION
- Brings in the `quick_deepcopy` function from https://github.com/ENCODE-DCC/snovault/blob/d14ae8cb4e3bf4bb76ade583f914ec7283a91379/src/snovault/util.py#L91 and renames it `copy_json`
- Add some basic tests