### PR TITLE
Repair handling of sentry_dsn in deployment_utils (C4-361)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ Change Log
 ----------
 
 
+1.3.1
+=====
+
+* Fixes to ``deployment_utils``:
+
+  * Fix overzealous error reporting about environment variable conflicts when the values don't differ.
+  * Add support for ``--sentry_dsn``.
+
+
 1.3.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,10 +20,13 @@ Change Log
   * Uses better binding technology for binding environment variables.
   * Factors in a change to the tests to not use a deprecated
     name (Deployer changed to IniFileMaker) for one of the classes.
+  * PEP8 adjustments.
 
 * Fixes to ``qa_utils``:
 
   * Don't do changelog cross-check for beta versions.
+
+* PEP8 adjustments to ``test_env_utils`` and ``test_s3_utils``.
 
 
 1.3.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,20 @@ Change Log
 1.3.1
 =====
 
+**PR 117: Repair handling of sentry_dsn in deployment_utils (C4-361)**
+
 * Fixes to ``deployment_utils``:
 
-  * Fix overzealous error reporting about environment variable conflicts when the values don't differ.
-  * Add support for ``--sentry_dsn``.
+  * Changes the handling of sentry DSN as an argument (``--sentry_dsn``)
+    to the deployer.
+  * Doesn't raise an error if environment variables collide but with the same value.
+  * Uses better binding technology for binding environment variables.
+  * Factors in a change to the tests to not use a deprecated
+    name (Deployer changed to IniFileMaker) for one of the classes.
+
+* Fixes to ``qa_utils``:
+
+  * Don't do changelog cross-check for beta versions.
 
 
 1.3.0

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -743,7 +743,7 @@ class VersionChecker:
         return version
 
     VERSION_LINE_PATTERN = re.compile("^[#* ]*([0-9]+[.][^ \t\n]*)([ \t\n].*)?$")
-    VERSION_IS_BETA_PATTERN = re.compile("^.*[0-9][Bb][0-9]$")
+    VERSION_IS_BETA_PATTERN = re.compile("^.*[0-9][Bb][0-9]+$")
 
     @classmethod
     def _check_change_history(cls, version=None):

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -743,9 +743,16 @@ class VersionChecker:
         return version
 
     VERSION_LINE_PATTERN = re.compile("^[#* ]*([0-9]+[.][^ \t\n]*)([ \t\n].*)?$")
+    VERSION_IS_BETA_PATTERN = re.compile("^.*[0-9][Bb][0-9]$")
 
     @classmethod
     def _check_change_history(cls, version=None):
+
+        if version and cls.VERSION_IS_BETA_PATTERN.match(version):
+            # Don't require beta versions to match up in change log.
+            # We don't just strip the version and look at that because sometimes we use other numbers on betas.
+            # Better to just not do it at all.
+            return
 
         changelog_file = getattr_customized(cls, "CHANGELOG")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.3.0.1b0" # to become "1.3.1"
+version = "1.3.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.3.1"
+version = "1.3.0.1b0" # to become "1.3.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.3.0"
+version = "1.3.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -9,7 +9,11 @@ import sys
 from io import StringIO
 from unittest import mock
 
-from dcicutils.deployment_utils import EBDeployer, IniFileManager, boolean_setting, CreateMappingOnDeployManager
+from dcicutils.deployment_utils import (
+    IniFileManager, boolean_setting, CreateMappingOnDeployManager,
+    # TODO: This isn't yet tested.
+    # EBDeployer,
+)
 from dcicutils.env_utils import is_cgap_env
 from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -4,7 +4,7 @@ import os
 from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env, BEANSTALK_PROD_MIRRORS,
     FF_ENV_PRODUCTION_BLUE, FF_ENV_PRODUCTION_GREEN, FF_ENV_WEBPROD, FF_ENV_WEBPROD2, FF_ENV_MASTERTEST,
-    FF_ENV_HOTSEAT, FF_ENV_STAGING, FF_ENV_WEBDEV, FF_ENV_WOLF,
+    FF_ENV_HOTSEAT, FF_ENV_WEBDEV, FF_ENV_WOLF,
     CGAP_ENV_PRODUCTION_BLUE, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_WEBPROD, CGAP_ENV_MASTERTEST,
     CGAP_ENV_HOTSEAT, CGAP_ENV_STAGING, CGAP_ENV_WEBDEV, CGAP_ENV_WOLF,
     CGAP_ENV_PRODUCTION_BLUE_NEW, CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_WEBPROD_NEW, CGAP_ENV_MASTERTEST_NEW,
@@ -220,18 +220,42 @@ def test_is_stg_or_prd_env():
     assert is_stg_or_prd_env("fourfront-webprod") is True
     assert is_stg_or_prd_env("fourfront-webprod2") is True
 
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_BLUE) is True
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_GREEN) is True
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_BLUE) is True
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_GREEN) is True
+    assert is_stg_or_prd_env(FF_ENV_WEBPROD) is True
+    assert is_stg_or_prd_env(FF_ENV_WEBPROD2) is True
+
     assert is_stg_or_prd_env("fourfront-yellow") is False
     assert is_stg_or_prd_env("fourfront-mastertest") is False
     assert is_stg_or_prd_env("fourfront-mastertest-1") is False
     assert is_stg_or_prd_env("fourfront-wolf") is False
 
+    assert is_stg_or_prd_env(FF_ENV_HOTSEAT) is False
+    assert is_stg_or_prd_env(FF_ENV_MASTERTEST) is False
+    assert is_stg_or_prd_env(FF_ENV_WOLF) is False
+    assert is_stg_or_prd_env(FF_ENV_WEBDEV) is False
+
     assert is_stg_or_prd_env("fourfront-cgap") is True
     assert is_stg_or_prd_env("fourfront-cgap-blue") is True
     assert is_stg_or_prd_env("fourfront-cgap-green") is True
 
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_BLUE) is True
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_BLUE_NEW) is True
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_GREEN) is True
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_GREEN_NEW) is True
+    assert is_stg_or_prd_env(CGAP_ENV_WEBPROD) is True
+    assert is_stg_or_prd_env(CGAP_ENV_WEBPROD_NEW) is True
+
     assert is_stg_or_prd_env("fourfront-cgap-yellow") is False
     assert is_stg_or_prd_env("fourfront-cgapwolf") is False
     assert is_stg_or_prd_env("fourfront-cgaptest") is False
+
+    assert is_stg_or_prd_env(CGAP_ENV_HOTSEAT) is False
+    assert is_stg_or_prd_env(CGAP_ENV_MASTERTEST) is False
+    assert is_stg_or_prd_env(CGAP_ENV_WOLF) is False
+    assert is_stg_or_prd_env(CGAP_ENV_WEBDEV) is False
 
     assert is_stg_or_prd_env("cgap-green") is True
     assert is_stg_or_prd_env("cgap-blue") is True
@@ -245,10 +269,24 @@ def test_is_stg_or_prd_env():
 
 def test_is_test_env():
 
+    assert is_test_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_test_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_test_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_test_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_test_env(FF_ENV_WEBPROD) is False
+    assert is_test_env(FF_ENV_WEBPROD2) is False
+
     assert is_test_env(FF_ENV_HOTSEAT) is True
     assert is_test_env(FF_ENV_MASTERTEST) is True
     assert is_test_env(FF_ENV_WOLF) is True
     assert is_test_env(FF_ENV_WEBDEV) is True
+
+    assert is_test_env(CGAP_ENV_PRODUCTION_BLUE) is False
+    assert is_test_env(CGAP_ENV_PRODUCTION_BLUE_NEW) is False
+    assert is_test_env(CGAP_ENV_PRODUCTION_GREEN) is False
+    assert is_test_env(CGAP_ENV_PRODUCTION_GREEN_NEW) is False
+    assert is_test_env(CGAP_ENV_WEBPROD) is False
+    assert is_test_env(CGAP_ENV_WEBPROD_NEW) is False
 
     assert is_test_env(CGAP_ENV_HOTSEAT) is True
     assert is_test_env(CGAP_ENV_MASTERTEST) is True
@@ -260,10 +298,24 @@ def test_is_test_env():
 
 def test_is_hotseat_env():
 
+    assert is_hotseat_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_hotseat_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_hotseat_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_hotseat_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_hotseat_env(FF_ENV_WEBPROD) is False
+    assert is_hotseat_env(FF_ENV_WEBPROD2) is False
+
     assert is_hotseat_env(FF_ENV_HOTSEAT) is True
     assert is_hotseat_env(FF_ENV_MASTERTEST) is False
     assert is_hotseat_env(FF_ENV_WOLF) is False
     assert is_hotseat_env(FF_ENV_WEBDEV) is False
+
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_BLUE) is False
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_BLUE_NEW) is False
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_GREEN) is False
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_GREEN_NEW) is False
+    assert is_hotseat_env(CGAP_ENV_WEBPROD) is False
+    assert is_hotseat_env(CGAP_ENV_WEBPROD_NEW) is False
 
     assert is_hotseat_env(CGAP_ENV_HOTSEAT) is True
     assert is_hotseat_env(CGAP_ENV_MASTERTEST) is False
@@ -359,13 +411,13 @@ def test_get_mirror_env_from_context_with_environ_has_env():
 
         settings = {'env.name': FF_ENV_WEBPROD}
         mirror = get_mirror_env_from_context(settings, allow_environ=False, allow_guess=False)
-        assert mirror == None  # env name in environ suppressed, but guessing disallowed
+        assert mirror is None  # env name in environ suppressed, but guessing disallowed
 
     with mock.patch.object(os, "environ", {"ENV_NAME": CGAP_ENV_WEBPROD}):
 
         settings = {}
         mirror = get_mirror_env_from_context(settings, allow_environ=True)
-        assert mirror == None  # env name explicitly declared, then a guess (but no CGAP mirror)
+        assert mirror is None  # env name explicitly declared, then a guess (but no CGAP mirror)
 
         settings = {}
         mirror = get_mirror_env_from_context(settings, allow_environ=True, allow_guess=False)
@@ -493,10 +545,14 @@ def test_infer_foursight_env():
     assert infer_foursight_from_env(mock_request(), FF_ENV_HOTSEAT) == 'hotseat'
 
     # (active) fourfront production environments
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-blue') == FF_PRODUCTION_IDENTIFIER
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-green') == FF_PRODUCTION_IDENTIFIER
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-blue') == FF_STAGING_IDENTIFIER
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-green') == FF_STAGING_IDENTIFIER
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-blue')
+            == FF_PRODUCTION_IDENTIFIER)
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-green')
+            == FF_PRODUCTION_IDENTIFIER)
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-blue')
+            == FF_STAGING_IDENTIFIER)
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-green')
+            == FF_STAGING_IDENTIFIER)
 
     # (active) cgap environments
     assert infer_foursight_from_env(mock_request(), CGAP_ENV_DEV) == 'cgapdev'

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1198,16 +1198,9 @@ def test_version_checker_use_dcicutils_changelog():
 
 def test_version_checker_with_missing_changelog():
 
-    path_exists = os.path.exists
+    mfs = MockFileSystem(files={'pyproject.toml': '[tool.poetry]\nname = "foo"\nversion = "1.2.3"'})
 
-    def mocked_exists(filename):
-        if filename.endswith("CHANGELOG.rst"):
-            print("Faking that %s does not exist." % filename)
-            return False
-        else:
-            return path_exists(filename)
-
-    with mock.patch("os.path.exists", mocked_exists):
+    with mock.patch("os.path.exists", mfs.exists):
 
         class MyVersionChecker(VersionChecker):
 

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -10,13 +10,14 @@ from unittest import mock
 
 
 @pytest.mark.parametrize('ff_ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev', 'fourfront-hotseat'])
-def test_s3Utils_creation(ff_ordinary_envname):
+def test_s3utils_creation_ff_ordinary(ff_ordinary_envname):
     util = s3Utils(env=ff_ordinary_envname)
     assert util.sys_bucket == 'elasticbeanstalk-%s-system' % ff_ordinary_envname
 
 
-def test_s3Utils_creation_ff_stg():
+def test_s3utils_creation_ff_stg():
     print("In test_s3Utils_creation_ff_stg. It is now", str(datetime.datetime.now()))
+
     def test_stg(ff_staging_envname):
         util = s3Utils(env=ff_staging_envname)
         actual_props = {
@@ -31,6 +32,7 @@ def test_s3Utils_creation_ff_stg():
             'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
             'url': FF_PUBLIC_URL_STG,
         }
+
     test_stg('staging')
     # NOTE: These values should not be parameters because we don't know how long PyTest caches the
     #       parameter values before using them. By doing the test this way, we hold the value for as
@@ -39,8 +41,9 @@ def test_s3Utils_creation_ff_stg():
     test_stg(stg_beanstalk_env)
 
 
-def test_s3Utils_creation_ff_prd():
+def test_s3utils_creation_ff_prd():
     print("In test_s3Utils_creation_ff_prd. It is now", str(datetime.datetime.now()))
+
     def test_prd(ff_production_envname):
         util = s3Utils(env=ff_production_envname)
         actual_props = {
@@ -55,6 +58,7 @@ def test_s3Utils_creation_ff_prd():
             'raw_file_bucket': 'elasticbeanstalk-fourfront-webprod-files',
             'url': FF_PUBLIC_URL_PRD,
         }
+
     test_prd('data')
     # NOTE: These values should not be parameters because we don't know how long PyTest caches the
     #       parameter values before using them. By doing the test this way, we hold the value for as
@@ -63,8 +67,15 @@ def test_s3Utils_creation_ff_prd():
     test_prd(prd_beanstalk_env)
 
 
-def test_s3Utils_creation_cgap_prd():
+@pytest.mark.parametrize('cgap_ordinary_envname', ['fourfront-cgaptest', 'fourfront-cgapdev', 'fourfront-cgapwolf'])
+def test_s3utils_creation_cgap_ordinary(cgap_ordinary_envname):
+    util = s3Utils(env=cgap_ordinary_envname)
+    assert util.sys_bucket == 'elasticbeanstalk-%s-system' % cgap_ordinary_envname
+
+
+def test_s3utils_creation_cgap_prd():
     print("In test_s3Utils_creation_cgap_prd. It is now", str(datetime.datetime.now()))
+
     def test_prd(cgap_production_envname):
         util = s3Utils(env=cgap_production_envname)
         actual_props = {
@@ -79,6 +90,7 @@ def test_s3Utils_creation_cgap_prd():
             'raw_file_bucket': 'elasticbeanstalk-fourfront-cgap-files',
             'url': CGAP_PUBLIC_URL_PRD,
         }
+
     test_prd('cgap')
     # NOTE: These values should not be parameters because we don't know how long PyTest caches the
     #       parameter values before using them. By doing the test this way, we hold the value for as
@@ -87,20 +99,13 @@ def test_s3Utils_creation_cgap_prd():
     test_prd(compute_cgap_prd_env())  # Hopefully returns 'fourfront-cgap' but just in case we're into new naming
 
 
-def test_s3Utils_creation_cgap_stg():
+def test_s3utils_creation_cgap_stg():
     print("In test_s3Utils_creation_cgap_prd. It is now", str(datetime.datetime.now()))
     # For now there is no CGAP stg...
     assert compute_cgap_stg_env() is None, "There seems to be a CGAP staging environment. Tests need updating."
 
 
-@pytest.mark.parametrize('ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev',
-                                              'fourfront-cgaptest', 'fourfront-cgapdev', 'fourfront-cgapwolf'])
-def test_s3Utils_creation(ordinary_envname):
-    util = s3Utils(env=ordinary_envname)
-    assert util.sys_bucket == 'elasticbeanstalk-%s-system' % ordinary_envname
-
-
-def test_s3Utils_get_keys_for_data():
+def test_s3utils_get_keys_for_data():
     util = s3Utils(env='data')
     keys = util.get_access_keys()
     assert keys['server'] == 'https://data.4dnucleome.org'
@@ -113,27 +118,27 @@ def test_s3Utils_get_keys_for_data():
     assert keys_fs['server'] == keys['server']
 
 
-def test_s3Utils_get_keys_for_staging():
+def test_s3utils_get_keys_for_staging():
     util = s3Utils(env='staging')
     keys = util.get_ff_key()
     assert keys['server'] == 'http://staging.4dnucleome.org'
 
 
-def test_s3Utils_get_jupyterhub_key(basestring):
+def test_s3utils_get_jupyterhub_key(basestring):
     util = s3Utils(env='data')
     key = util.get_jupyterhub_key()
     assert 'secret' in key
     assert key['server'] == 'https://jupyter.4dnucleome.org'
 
 
-def test_s3Utils_get_higlass_key():
+def test_s3utils_get_higlass_key():
     util = s3Utils(env='staging')
     keys = util.get_higlass_key()
     assert isinstance(keys, dict)
     assert 3 == len(keys.keys())
 
 
-def test_s3Utils_get_google_key():
+def test_s3utils_get_google_key():
     util = s3Utils(env='staging')
     keys = util.get_google_key()
     assert isinstance(keys, dict)
@@ -143,20 +148,22 @@ def test_s3Utils_get_google_key():
         assert keys[dict_key]
 
 
-def test_s3Utils_get_access_keys_with_old_style_default():
+def test_s3utils_get_access_keys_with_old_style_default():
     util = s3Utils(env='fourfront-mastertest')
     with mock.patch.object(util, "get_key") as mock_get_key:
         actual_key = {'key': 'some-key', 'server': 'some-server'}
+
         def mocked_get_key(keyfile_name):
             ignored(keyfile_name)
             key_wrapper = {'default': actual_key}
             return key_wrapper
+
         mock_get_key.side_effect = mocked_get_key
         key = util.get_access_keys()
         assert key == actual_key
 
 
-def test_s3Utils_get_key_non_json_data():
+def test_s3utils_get_key_non_json_data():
 
     util = s3Utils(env='fourfront-mastertest')
 
@@ -171,7 +178,7 @@ def test_s3Utils_get_key_non_json_data():
         assert util.get_key() == non_json_string
 
 
-def test_s3Utils_delete_key():
+def test_s3utils_delete_key():
 
     sample_key_name = "--- reserved_key_name_for_unit_testing ---"
 
@@ -181,7 +188,7 @@ def test_s3Utils_delete_key():
 
         def make_mocked_delete_object(expected_bucket, expected_key):
 
-            def mocked_delete_object(Bucket, Key):
+            def mocked_delete_object(Bucket, Key):  # noQA - AWS chooses the arg names
                 assert Bucket == expected_bucket
                 assert Key == expected_key
 
@@ -204,7 +211,7 @@ def test_s3Utils_delete_key():
         assert mock_delete_object.call_count == 2
 
 
-def test_s3Utils_s3_put():
+def test_s3utils_s3_put():
 
     util = s3Utils(env='fourfront-mastertest')
 
@@ -233,7 +240,7 @@ def test_s3Utils_s3_put():
             }
 
 
-def test_s3Utils_s3_put_secret():
+def test_s3utils_s3_put_secret():
 
     util = s3Utils(env='fourfront-mastertest')
     standard_algorithm = "AES256"


### PR DESCRIPTION
This does:

* Changes the handling of sentry DSN as an argument (`--sentry_dsn`) to the deployer
* Doesn't raise an error if environment variables collide but with the same value.
* Uses better binding technology for binding environment variables.
* Factors in a change to the tests to not use a deprecated name (`Deployer` changed to `IniFileMaker`) for one of the classes 

This part of a fix for [C4-361](https://hms-dbmi.atlassian.net/browse/C4-361), but not a complete fix.