### PR TITLE
Various bits of functionality in support of 4dn-status (C4-363)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,28 @@ Change Log
 ----------
 
 
+1.4.0
+=====
+
+**PR 118: Various bits of functionality in support of 4dn-status (C4-363)**
+
+* New feature in ``qa_utils``:
+
+  * ControlledTime can now be used as a mock for the datetime module itself
+    in some situations, though some care is required.
+
+* New features in ``misc_utils``:
+
+  * ``as_seconds`` so that, for example ``as_seconds(minutes=3)``
+    can be used to get 180.
+  * ``hms_now`` to get the value of ``datetime.datetime.now()``
+    in HMS local time (EST or EDT as appropriate).
+  * ``in_datetime_interval`` to test that a given time is within
+    a given time interval.
+  * ``as_datetime`` to coerce a properly formatted ``str`` to
+    a ``datetime.datetime``.
+
+
 1.3.1
 =====
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -444,9 +444,11 @@ HMS_TZ = pytz.timezone("US/Eastern")
 
 def as_datetime(dt, tz=None):
     """
-    Parses the given datetime, returning a datetime.datetime object.
+    Parses the given date/time (which may be a string or a datetime.datetime), returning a datetime.datetime object.
 
-    If the given datetime is already such an object, it is returned.
+    If the given datetime is already such an object, it is just returned.
+    If it is a string, it should be in a format such as 'yyyy-mm-dd hh:mm:ss' or 'yyyy-mm-dd hh:mm:ss-nnnn'
+    (with -nnnn being a timezone specification).
     """
     if dt is None:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.3.1"
+version = "1.4.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -5,6 +5,7 @@ import pytest
 import pytz
 import re
 import subprocess
+import sys
 import time
 import uuid
 
@@ -370,6 +371,30 @@ def test_controlled_time_sleep():
     t.sleep(10)
 
     assert (t.just_now() - t0).total_seconds() == 10
+
+
+def test_controlled_time_datetime():
+
+    module_type = type(sys.modules['builtins'])
+
+    dt_args = (2016, 1, 1, 12, 34, 56)
+
+    t = ControlledTime(datetime.datetime(*dt_args), tick_seconds=1)
+    t0 = t.just_now()
+
+    # At this point, datetime is still the imported datetime module.
+    assert isinstance(datetime, module_type)
+
+    # This is like using mock.patch on our own datetime
+    with override_dict(globals(), datetime=t):
+
+        # At this point, we've installed a ControlledTime instance as our datetime module.
+        assert not isinstance(datetime, module_type)
+        assert isinstance(datetime, ControlledTime)
+        assert isinstance(datetime.datetime, ControlledTime.ProxyDatetimeClass)
+        # Make sure we can make a datetime.datetime object even with the mock
+        assert datetime.datetime(*dt_args) == t0
+        assert datetime.datetime.now() == t0 + datetime.timedelta(seconds=1)
 
 
 def test_controlled_time_documentation_scenario():


### PR DESCRIPTION
@willronchetti suggested bits of functionality in a recent 4dn-status PR (in the brig repo) should move here. This is mostly the fulfillment of that suggestion. I made some better names and added some testing.

* In `qa_utils`, this makes a `ControlledTime` instance be someone one can use as a mock for the `datetime` module itself, by giving it a `datetime` property that is sort of like the `datetime.datetime` class, though obviously it is not the _actual_ class so mocking has to be done with care. Some code wanting to use such mocks may want to receive that type via alternate means so that the function `datetime.datetime` can be mocked without affecting the type `datetime.datetime`. Such are mocks.
* In `misc_utils`, this adds:
  * `as_seconds` so that, for example `as_seconds(minutes=3)` can be used to get 180.
  * `hms_now` to get the value of `datetime.datetime.now()` in HMS local time (EST or EDT as appropriate).
  * `in_datetime_interval` to test that a given time is within a given time interval.
  * `as_datetime` to coerce a properly formatted `str` to a `datetime.datetime`.