### PR TITLE
More time functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,21 @@ Change Log
 ----------
 
 
+1.6.0
+=====
+
+**PR 120: More time functions**
+
+In ``misc_utils``:
+
+* Add ``as_ref_datetime`` to convert times to the reference timezone (US/Eastern by default).
+* Add ``as_utc_datetime`` to convert times to UTC.
+* Rename ``HMS_TZ`` to ``REF_TZ``, but keep ``HMS_TZ`` as a synonym for compatibility for now.
+* Rename ``hms_now`` to ``ref_now``, but again keep ``hms_now`` as a synonym for compatibility for now.
+
+The rationale for these changes is that if we deploy at other locations, it may not be HMS that is relevant, so we could be at some place with another timezone.
+
+
 1.5.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,12 @@ Change Log
 
 In ``misc_utils``:
 
+* Fix ``as_datetime`` to raise an error on bad input, allowing `raise_error=False`
+  to suppress that if needed.
 * Add ``as_ref_datetime`` to convert times to the reference timezone (US/Eastern by default).
 * Add ``as_utc_datetime`` to convert times to UTC.
+* Extend ``in_datetime_interval`` to parse all string arguments using
+  ``as_ref_datetime``.
 * Rename ``HMS_TZ`` to ``REF_TZ``, but keep ``HMS_TZ`` as a synonym for compatibility for now.
 * Rename ``hms_now`` to ``ref_now``, but again keep ``hms_now`` as a synonym for compatibility for now.
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -465,12 +465,27 @@ def as_datetime(dt, tz=None):
 
 
 def as_ref_datetime(dt):
+    """
+    Parses a given datetime, returning a rendition of that tie in the reference timezone (US/Eastern by default).
+
+    If the input time is a string or a naive datetime with no timezon, it is assumed to be in the reference timezone
+    (which is US/Eastern by default).
+    If the time is already a datetime, no parsing occurs, but the time is still adjusted to present as it would in the
+    reference timeszone.
+    """
     dt = as_datetime(dt, tz=REF_TZ)
     hms_dt = dt.astimezone(REF_TZ)
     return hms_dt
 
 
 def as_utc_datetime(dt):
+    """
+    Parses a given datetime, returning a rendition of that tie in UTC.
+
+    If the input time is a string or a naive datetime with no timezon, it is assumed to be in the reference timezone
+    (which is US/Eastern by default). UTC is only used as the output format, not as an assumption about the input.
+    If the time is already a datetime, no parsing occurs, but the time is still adjusted to present as it would in UTC.
+    """
     dt = as_datetime(dt, tz=REF_TZ)
     utc_dt = dt.astimezone(pytz.UTC)
     return utc_dt

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -523,10 +523,11 @@ def in_datetime_interval(when, *, start=None, end=None):
     Returns true if the first argument ('when') is in the range given by the other arguments.
 
     The comparison is upper- and lower-inclusive.
+    The string will be parsed as a datetime in the reference timezone (REF_TZ) if it doesn't have an explicit timezone.
     """
-    when = as_datetime(when)  # This is not allowed to be None, but it might be a str, and we need datetimes to compare.
-    start = start and as_datetime(start)
-    end = end and as_datetime(end)
+    when = as_ref_datetime(when)  # This is not allowed to be None, but it might be a str, and we need datetimes to compare.
+    start = start and as_ref_datetime(start)
+    end = end and as_ref_datetime(end)
     return (not start or start <= when) and (not end or end >= when)
 
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -439,7 +439,7 @@ def as_seconds(*, seconds=0, minutes=0, hours=0, days=0, weeks=0, milliseconds=0
     return seconds
 
 
-HMS_TZ = pytz.timezone("US/Eastern")
+REF_TZ = pytz.timezone(os.environ.get("REF_TZ") or "US/Eastern")
 
 
 def as_datetime(dt, tz=None):
@@ -464,6 +464,18 @@ def as_datetime(dt, tz=None):
         return None
 
 
+def as_ref_datetime(dt):
+    dt = as_datetime(dt, tz=REF_TZ)
+    hms_dt = dt.astimezone(REF_TZ)
+    return hms_dt
+
+
+def as_utc_datetime(dt):
+    dt = as_datetime(dt, tz=REF_TZ)
+    utc_dt = dt.astimezone(pytz.UTC)
+    return utc_dt
+
+
 def in_datetime_interval(when, *, start=None, end=None):
     """
     Returns true if the first argument ('when') is in the range given by the other arguments.
@@ -475,9 +487,12 @@ def in_datetime_interval(when, *, start=None, end=None):
     return (not start or start <= when) and (not end or end >= when)
 
 
-def hms_now():
-    """Returns the current time in the HMS timezone (US/Eastern, which may be EST or EDT, depending on time of year)."""
-    return as_datetime(datetime.datetime.now(), HMS_TZ)
+def ref_now():
+    """Returns the current time in the portal's reference timezone, as determined by REF_TZ.
+
+       Because this software originates at Harvard Medical School, the reference timezone defaults to US/Eastern.
+       It can be set to another value by binding the REF_TZ environment variable."""
+    return as_datetime(datetime.datetime.now(), REF_TZ)
 
 
 class LockoutManager:
@@ -999,3 +1014,8 @@ def getattr_customized(thing, key):
         raise UncustomizedInstance(instance=thing, field=key)
     else:
         return value
+
+
+# Deprecated names, still supported for a while.
+HMS_TZ = REF_TZ
+hms_now = ref_now

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -524,6 +524,7 @@ def in_datetime_interval(when, *, start=None, end=None):
 
     The comparison is upper- and lower-inclusive.
     """
+    when = as_datetime(when)  # This is not allowed to be None, but it might be a str, and we need datetimes to compare.
     start = start and as_datetime(start)
     end = end and as_datetime(end)
     return (not start or start <= when) and (not end or end >= when)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.5.0"
+version = "1.6.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -752,7 +752,7 @@ def test_as_ref_datetime():
         assert str(result) == '2015-07-04 12:00:00-04:00'
 
     # Note that if this were in winter instead of summer, a different timezone marker would come back
-    for t  in (datetime_module.datetime(2015, 1, 4, 12), '2015-01-04T12:00:00-05:00', '2015-01-04 12:00:00-05:00'):
+    for t in (datetime_module.datetime(2015, 1, 4, 12), '2015-01-04T12:00:00-05:00', '2015-01-04 12:00:00-05:00'):
         assert str(as_ref_datetime(t)) == '2015-01-04 12:00:00-05:00'
 
     # Things that parse as a date equivalent to noon Jul 4, 2014 in UTC time because that is given explicitly,
@@ -782,8 +782,8 @@ def test_as_utc_datetime():
     t0_utc = pytz.UTC.localize(datetime_module.datetime(2015, 7, 4, 12, 0, 0))
     t0_hms = REF_TZ.localize(datetime_module.datetime(2015, 7, 4, 12, 0, 0))
 
-    t4_utc = datetime_module.datetime(2015, 7, 4, 16, 0, 0, tzinfo=pytz.UTC)  # 4 hour offset from t0 UTC
-    t5_utc = datetime_module.datetime(2015, 7, 4, 17, 0, 0, tzinfo=pytz.UTC)  # 5 hour offset from t0 UTC
+    t4_utc = datetime_module.datetime(2015, 7, 4, 16, 0, 0, tzinfo=pytz.UTC)  # same as t0_hms, but UTC is 4 hour offset
+    t5_utc = datetime_module.datetime(2015, 1, 4, 17, 0, 0, tzinfo=pytz.UTC)  # 5 hour offset from default ref time
 
     # Things that parse as a date equivalent to noon Jul 4, 2014 in UTC time
     for t in (t0, t0_hms, t4_utc,
@@ -796,17 +796,20 @@ def test_as_utc_datetime():
         assert result != t0
         assert result != t0_utc
         assert result == t0_hms
+        assert result == t4_utc
         assert str(result) == '2015-07-04 16:00:00+00:00'
 
     # Note that if this were in winter instead of summer, a different timezone marker would come back
-    for t  in (datetime_module.datetime(2015, 1, 4, 12),
-               '2015-01-04T12:00:00-0500',
-               '2015-01-04 12:00:00-0500',
-               '2015-01-04T12:00:00-05:00',
-               '2015-01-04 12:00:00-05:00',
-               '2015-01-04T17:00:00Z',
-               '2015-01-04 17:00:00Z'):
-        assert str(as_utc_datetime(t)) == '2015-01-04 17:00:00+00:00'
+    for t in (datetime_module.datetime(2015, 1, 4, 12),
+              '2015-01-04T12:00:00-0500',
+              '2015-01-04 12:00:00-0500',
+              '2015-01-04T12:00:00-05:00',
+              '2015-01-04 12:00:00-05:00',
+              '2015-01-04T17:00:00Z',
+              '2015-01-04 17:00:00Z'):
+        result = as_utc_datetime(t)
+        assert result == t5_utc
+        assert str(result) == '2015-01-04 17:00:00+00:00'
 
     # Things that parse as a date equivalent to noon Jul 4, 2014 in UTC time because that is given explicitly,
     # but the result is still expressed in HMS time notation.

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -18,7 +18,7 @@ from dcicutils.misc_utils import (
     LockoutManager, check_true, remove_prefix, remove_suffix, full_class_name, full_object_name, constantly,
     keyword_as_title, file_contents, CachedField, camel_case_to_snake_case, snake_case_to_camel_case, make_counter,
     CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json,
-    as_seconds, hms_now, in_datetime_interval, as_datetime,
+    as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ, MockFileSystem, printed_output, raises_regexp
@@ -693,14 +693,20 @@ def test_as_seconds():
     assert as_seconds(milliseconds=250) == 0.25
 
 
-def test_hms_now():
+def test_hms_tz():
+
+    assert HMS_TZ == REF_TZ, "HMS_TZ was deprectead, but is still expected to be a synonym for REF_TZ."
+
+
+@pytest.mark.parametrize('now', [hms_now, ref_now])  # hms_now is a deprecated name for ref_now
+def test_hms_now_and_ref_now(now):
 
     t0 = datetime_module.datetime(2015, 7, 4, 12, 0, 0)
     dt = ControlledTime(t0)
 
     with mock.patch("dcicutils.misc_utils.datetime", dt):
 
-        t1 = hms_now()
+        t1 = now()
         t1_utc = t1.replace(tzinfo=pytz.UTC)
         assert t1.replace(tzinfo=None) == t0 + datetime_module.timedelta(seconds=1)
         delta = (t1 - t1_utc)
@@ -724,6 +730,99 @@ def test_as_datetime():
     assert as_datetime('2015-07-04 12:00:00Z') != t0
     assert as_datetime('2015-07-04 12:00:00Z') == t0_utc
     assert as_datetime('2015-07-04 12:00:00-0000') == t0_utc
+
+
+def test_as_ref_datetime():
+
+    t0 = datetime_module.datetime(2015, 7, 4, 12, 0, 0)
+    t0_utc = pytz.UTC.localize(datetime_module.datetime(2015, 7, 4, 12, 0, 0))
+    t0_hms = REF_TZ.localize(datetime_module.datetime(2015, 7, 4, 12, 0, 0))
+
+    # Things that parse as a date equivalent to noon Jul 4, 2014 in HMS time
+    for t in (t0, t0_hms,
+              '2015-07-04T12:00:00',
+              '2015-07-04 12:00:00',
+              '2015-07-04T12:00:00-0400',
+              '2015-07-04 12:00:00-0400'):
+        result = as_ref_datetime(t)
+        assert result.tzinfo
+        assert result != t0
+        assert result != t0_utc
+        assert result == t0_hms
+        assert str(result) == '2015-07-04 12:00:00-04:00'
+
+    # Note that if this were in winter instead of summer, a different timezone marker would come back
+    for t  in (datetime_module.datetime(2015, 1, 4, 12), '2015-01-04T12:00:00-05:00', '2015-01-04 12:00:00-05:00'):
+        assert str(as_ref_datetime(t)) == '2015-01-04 12:00:00-05:00'
+
+    # Things that parse as a date equivalent to noon Jul 4, 2014 in UTC time because that is given explicitly,
+    # but the result is still expressed in HMS time notation.
+    for t in (t0_utc,
+              '2015-07-04T12:00:00Z',
+              '2015-07-04 12:00:00Z',
+              '2015-07-04T12:00:00-0000',
+              '2015-07-04 12:00:00-0000',
+              '2015-07-04T12:00:00+0000',
+              '2015-07-04 12:00:00+0000',
+              '2015-07-04T12:00:00-00:00',
+              '2015-07-04 12:00:00-00:00',
+              '2015-07-04T12:00:00+00:00',
+              '2015-07-04 12:00:00+00:00'):
+        result = as_ref_datetime(t)
+        assert result.tzinfo
+        assert result != t0
+        assert result == t0_utc  # The times are equivalent even if the notation is different
+        assert result != t0_hms
+        assert str(result) == '2015-07-04 08:00:00-04:00'  # The result notation is different than the UTC input
+
+
+def test_as_utc_datetime():
+
+    t0 = datetime_module.datetime(2015, 7, 4, 12)
+    t0_utc = pytz.UTC.localize(datetime_module.datetime(2015, 7, 4, 12, 0, 0))
+    t0_hms = REF_TZ.localize(datetime_module.datetime(2015, 7, 4, 12, 0, 0))
+
+    t4_utc = datetime_module.datetime(2015, 7, 4, 16, 0, 0, tzinfo=pytz.UTC)  # 4 hour offset from t0 UTC
+    t5_utc = datetime_module.datetime(2015, 7, 4, 17, 0, 0, tzinfo=pytz.UTC)  # 5 hour offset from t0 UTC
+
+    # Things that parse as a date equivalent to noon Jul 4, 2014 in UTC time
+    for t in (t0, t0_hms, t4_utc,
+              '2015-07-04T12:00:00',  # HMS time implied
+              '2015-07-04 12:00:00',  # HMS time implied
+              '2015-07-04T16:00:00Z',
+              '2015-07-04 16:00:00Z'):
+        result = as_utc_datetime(t)
+        assert result.tzinfo
+        assert result != t0
+        assert result != t0_utc
+        assert result == t0_hms
+        assert str(result) == '2015-07-04 16:00:00+00:00'
+
+    # Note that if this were in winter instead of summer, a different timezone marker would come back
+    for t  in (datetime_module.datetime(2015, 1, 4, 12),
+               '2015-01-04T12:00:00-0500',
+               '2015-01-04 12:00:00-0500',
+               '2015-01-04T12:00:00-05:00',
+               '2015-01-04 12:00:00-05:00',
+               '2015-01-04T17:00:00Z',
+               '2015-01-04 17:00:00Z'):
+        assert str(as_utc_datetime(t)) == '2015-01-04 17:00:00+00:00'
+
+    # Things that parse as a date equivalent to noon Jul 4, 2014 in UTC time because that is given explicitly,
+    # but the result is still expressed in HMS time notation.
+    for t in (t0_utc,
+              '2015-07-04T12:00:00Z',
+              '2015-07-04 12:00:00Z',
+              '2015-07-04T12:00:00-0000',
+              '2015-07-04 12:00:00-0000',
+              '2015-07-04T12:00:00+0000',
+              '2015-07-04 12:00:00+0000'):
+        result = as_utc_datetime(t)
+        assert result.tzinfo
+        assert result != t0
+        assert result == t0_utc
+        assert result != t0_hms
+        assert str(result) == '2015-07-04 12:00:00+00:00'
 
 
 def test_in_datetime_interval():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -732,6 +732,18 @@ def test_as_datetime():
     assert as_datetime('2015-07-04 12:00:00Z') == t0_utc
     assert as_datetime('2015-07-04 12:00:00-0000') == t0_utc
 
+    with raises_regexp(DatetimeCoercionFailure,
+                       re.escape("Cannot coerce to datetime: 2018-01-02 25:00:00")):
+        as_datetime("2018-01-02 25:00:00")  # There is no 25 o'clock
+
+    assert as_datetime("2018-01-02 25:00:00", raise_error=False) is None
+
+    with raises_regexp(DatetimeCoercionFailure,
+                       re.escape("Cannot coerce to datetime: 2018-01-02 25:00:00 (for timezone UTC)")):
+        as_datetime("2018-01-02 25:00:00", pytz.UTC)  # There is no 25 o'clock
+
+    assert as_datetime("2018-01-02 25:00:00", pytz.UTC, raise_error=False) is None
+
 
 def test_as_ref_datetime():
 
@@ -885,6 +897,10 @@ def test_in_datetime_interval():
 
     for t, expected in in_t1_and_beforehand_range_scenarios:
         assert in_datetime_interval(t, end=t3) is expected
+
+    with pytest.raises(DatetimeCoercionFailure):
+        # This will raise an error because the 'end=' argument has bad syntax.
+        in_datetime_interval("2015-01-01 23:59:00", start="2015-01-01 22:00:00", end="2015-01-01 25:00:00")
 
 
 def test_lockout_manager_timestamp():


### PR DESCRIPTION
**Description of Change**

In `misc_utils`:

* Add `as_ref_datetime` to convert times to the reference timezone (US/Eastern by default).
* Add `as_utc_datetime` to convert times to UTC.
* Rename `HMS_TZ` to `REF_TZ`, but keep `HMS_TZ` as a synonym for compatibility for now.
* Rename `hms_now` to `ref_now`, but again keep `hms_now` as a synonym for compatibility for now.

**Rationale**

If we deploy at other locations, it may not be HMS that is relevant, so we could be at some place with another timezone.