### PR TITLE
Speed up ff_utils unit tests, and misc small bits of functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,56 @@ dcicutils
 Change Log
 ----------
 
+1.6.0
+=====
+
+* Added an ``integratedx`` mark to possible marks in ``pytest.ini``. These
+  are the same as ``integrated`` but they represent test cases that have
+  an associated unit test that is redundant, so that the ``integratedx``
+  test doesn't have to be run to get full coverage.
+
+* For ``ff_utils``:
+
+  * Split tests into a ``xxx_unit`` and
+    ``xxx_integrated`` version.  The latter is marked with new
+    ``integratedx`` mark.
+
+* For ``env_utils``:
+
+  * Added some test cases.
+
+* For ``s3_utils``:
+
+  * Small remodularization of ``s3Utils`` for easier access to
+    some constants in testing.
+  * Improvements to error reporting in ``s3Utils.get_access_keys()``.
+
+* For ``qa_utils``:
+
+  * In ``MockFileSystem``, fixed a typo in debugging typeout.
+  * In ``MockResponse``:
+
+    * Added a ``url=`` init arg and ``.url`` property.
+    * Added a .text as synonym for ``.content``.
+
+  * In ``MockBotoS3Client``:
+
+    * Extended to handle ``region_name=``.
+    * Added ``mock_other_required_arguments=`` and ``mock_s3_files=``
+      init args for use in testing.
+    * Added ``MockBotoS3Client``, add ``.get_object(Bucket, Key)``.
+
+* For ``ff_utils``:
+
+  * Used ``ValueError`` rather than ``Exception`` in several
+    places errors are raised.
+  * Some very small other refactoring was also done
+    for modularity that should not affect behavior.
+
 1.5.1
 =====
 
-**PR 120: Update ES-py Version
+**PR 120: Update ES-py Version**
 
 * Updates elasticsearch library to 6.8.1 to take a bug fix.
 
@@ -19,7 +65,7 @@ Change Log
 
 **PR 119: More env_utils support**
 
-* Add ``env_utils.classify_server_url`.
+* Add ``env_utils.classify_server_url``.
 
 
 1.4.0

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,17 @@ build:  # builds
 	make configure
 	poetry install
 
-test:
+test:  # runs default tests, which are the unit tests
+	make test-units
+
+test-all:
+	pytest -vv
+
+test-units:  # runs unit tests (and integration tests not backed by a unit test)
 	pytest -vv -m "not integratedx"
+
+test-integrations:  # runs integration tests
+	pytest -vv -m "integrated or integratedx"
 
 update:  # updates dependencies
 	poetry update

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:  # builds
 	poetry install
 
 test:
-	pytest -vv
+	pytest -vv -m "not integratedx"
 
 update:  # updates dependencies
 	poetry update

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1171,6 +1171,7 @@ def get_authentication_with_server(auth=None, ff_env=None):
     if not isinstance(auth, dict) or not {'key', 'secret', 'server'} <= set(auth.keys()):
         # must have ff_env if we want to get the key
         if not ff_env:
+            # TODO: Refactor these ValueErrors to do messaging in an error class where it doesn't clutter functionality.
             raise ValueError("ERROR GETTING SERVER!"
                              "\nMust provide dictionary auth with 'server' or ff environment."
                              " You gave: %s (auth), %s (ff_env)"

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 
 class s3Utils(object):  # NOQA - This class name violates style rules, but a lot of things might break if we change it.
 
+    SYS_BUCKET_TEMPLATE = "elasticbeanstalk-%s-system"
+    OUTFILE_BUCKET_TEMPLATE = "elasticbeanstalk-%s-wfoutput"
+    RAW_BUCKET_TEMPLATE = "elasticbeanstalk-%s-files"
+    BLOB_BUCKET_TEMPLATE = "elasticbeanstalk-%s-blobs"
+
     def __init__(self, outfile_bucket=None, sys_bucket=None, raw_file_bucket=None,
                  blob_bucket=None, env=None):
         """
@@ -35,18 +40,23 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
                     self.url = get_beanstalk_real_url(env)
                     env = prod_bucket_env(env)
             # we use standardized naming schema, so s3 buckets always have same prefix
-            sys_bucket = "elasticbeanstalk-%s-system" % env
-            outfile_bucket = "elasticbeanstalk-%s-wfoutput" % env
-            raw_file_bucket = "elasticbeanstalk-%s-files" % env
-            blob_bucket = "elasticbeanstalk-%s-blobs" % env
+            sys_bucket = self.SYS_BUCKET_TEMPLATE % env
+            outfile_bucket = self.OUTFILE_BUCKET_TEMPLATE % env
+            raw_file_bucket = self.RAW_BUCKET_TEMPLATE % env
+            blob_bucket = self.BLOB_BUCKET_TEMPLATE % env
 
         self.sys_bucket = sys_bucket
         self.outfile_bucket = outfile_bucket
         self.raw_file_bucket = raw_file_bucket
         self.blob_bucket = blob_bucket
 
-    def get_access_keys(self, name='access_key_admin'):
+    ACCESS_KEYS_S3_KEY = 'access_key_admin'
+
+    def get_access_keys(self, name=ACCESS_KEYS_S3_KEY):
         keys = self.get_key(keyfile_name=name)
+        if not isinstance(keys, dict):
+            raise ValueError("Remotely stored access keys are not in the expected form")
+
         if isinstance(keys.get('default'), dict):
             keys = keys['default']
         if self.url:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.6.0"
+version = "1.7.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.5.1"
+version = "1.6.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 markers =
   working: test should work
-  integrated: this is an integration test
-  integratedx: this integration test redundantly tests functionality covered in unit tests
-  file_operation: this test utilizes files
+  integrated: an integration test
+  integratedx: an excludable integration test, redundantly testing functionality also covered by a unit test
+  file_operation: a test that utilizes files

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
   working: test should work
-  integrated: this is an integrated test
+  integrated: this is an integration test
+  integratedx: this integration test redundantly tests functionality covered in unit tests
   file_operation: this test utilizes files

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -4,7 +4,7 @@ import os
 from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env, BEANSTALK_PROD_MIRRORS,
     FF_ENV_PRODUCTION_BLUE, FF_ENV_PRODUCTION_GREEN, FF_ENV_WEBPROD, FF_ENV_WEBPROD2, FF_ENV_MASTERTEST,
-    FF_ENV_HOTSEAT, FF_ENV_STAGING, FF_ENV_WEBDEV, FF_ENV_WOLF,
+    FF_ENV_HOTSEAT, FF_ENV_WEBDEV, FF_ENV_WOLF,
     CGAP_ENV_PRODUCTION_BLUE, CGAP_ENV_PRODUCTION_GREEN, CGAP_ENV_WEBPROD, CGAP_ENV_MASTERTEST,
     CGAP_ENV_HOTSEAT, CGAP_ENV_STAGING, CGAP_ENV_WEBDEV, CGAP_ENV_WOLF,
     CGAP_ENV_PRODUCTION_BLUE_NEW, CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_WEBPROD_NEW, CGAP_ENV_MASTERTEST_NEW,
@@ -220,18 +220,42 @@ def test_is_stg_or_prd_env():
     assert is_stg_or_prd_env("fourfront-webprod") is True
     assert is_stg_or_prd_env("fourfront-webprod2") is True
 
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_BLUE) is True
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_GREEN) is True
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_BLUE) is True
+    assert is_stg_or_prd_env(FF_ENV_PRODUCTION_GREEN) is True
+    assert is_stg_or_prd_env(FF_ENV_WEBPROD) is True
+    assert is_stg_or_prd_env(FF_ENV_WEBPROD2) is True
+
     assert is_stg_or_prd_env("fourfront-yellow") is False
     assert is_stg_or_prd_env("fourfront-mastertest") is False
     assert is_stg_or_prd_env("fourfront-mastertest-1") is False
     assert is_stg_or_prd_env("fourfront-wolf") is False
 
+    assert is_stg_or_prd_env(FF_ENV_HOTSEAT) is False
+    assert is_stg_or_prd_env(FF_ENV_MASTERTEST) is False
+    assert is_stg_or_prd_env(FF_ENV_WOLF) is False
+    assert is_stg_or_prd_env(FF_ENV_WEBDEV) is False
+
     assert is_stg_or_prd_env("fourfront-cgap") is True
     assert is_stg_or_prd_env("fourfront-cgap-blue") is True
     assert is_stg_or_prd_env("fourfront-cgap-green") is True
 
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_BLUE) is True
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_BLUE_NEW) is True
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_GREEN) is True
+    assert is_stg_or_prd_env(CGAP_ENV_PRODUCTION_GREEN_NEW) is True
+    assert is_stg_or_prd_env(CGAP_ENV_WEBPROD) is True
+    assert is_stg_or_prd_env(CGAP_ENV_WEBPROD_NEW) is True
+
     assert is_stg_or_prd_env("fourfront-cgap-yellow") is False
     assert is_stg_or_prd_env("fourfront-cgapwolf") is False
     assert is_stg_or_prd_env("fourfront-cgaptest") is False
+
+    assert is_stg_or_prd_env(CGAP_ENV_HOTSEAT) is False
+    assert is_stg_or_prd_env(CGAP_ENV_MASTERTEST) is False
+    assert is_stg_or_prd_env(CGAP_ENV_WOLF) is False
+    assert is_stg_or_prd_env(CGAP_ENV_WEBDEV) is False
 
     assert is_stg_or_prd_env("cgap-green") is True
     assert is_stg_or_prd_env("cgap-blue") is True
@@ -245,10 +269,24 @@ def test_is_stg_or_prd_env():
 
 def test_is_test_env():
 
+    assert is_test_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_test_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_test_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_test_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_test_env(FF_ENV_WEBPROD) is False
+    assert is_test_env(FF_ENV_WEBPROD2) is False
+
     assert is_test_env(FF_ENV_HOTSEAT) is True
     assert is_test_env(FF_ENV_MASTERTEST) is True
     assert is_test_env(FF_ENV_WOLF) is True
     assert is_test_env(FF_ENV_WEBDEV) is True
+
+    assert is_test_env(CGAP_ENV_PRODUCTION_BLUE) is False
+    assert is_test_env(CGAP_ENV_PRODUCTION_BLUE_NEW) is False
+    assert is_test_env(CGAP_ENV_PRODUCTION_GREEN) is False
+    assert is_test_env(CGAP_ENV_PRODUCTION_GREEN_NEW) is False
+    assert is_test_env(CGAP_ENV_WEBPROD) is False
+    assert is_test_env(CGAP_ENV_WEBPROD_NEW) is False
 
     assert is_test_env(CGAP_ENV_HOTSEAT) is True
     assert is_test_env(CGAP_ENV_MASTERTEST) is True
@@ -260,10 +298,24 @@ def test_is_test_env():
 
 def test_is_hotseat_env():
 
+    assert is_hotseat_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_hotseat_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_hotseat_env(FF_ENV_PRODUCTION_BLUE) is False
+    assert is_hotseat_env(FF_ENV_PRODUCTION_GREEN) is False
+    assert is_hotseat_env(FF_ENV_WEBPROD) is False
+    assert is_hotseat_env(FF_ENV_WEBPROD2) is False
+
     assert is_hotseat_env(FF_ENV_HOTSEAT) is True
     assert is_hotseat_env(FF_ENV_MASTERTEST) is False
     assert is_hotseat_env(FF_ENV_WOLF) is False
     assert is_hotseat_env(FF_ENV_WEBDEV) is False
+
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_BLUE) is False
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_BLUE_NEW) is False
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_GREEN) is False
+    assert is_hotseat_env(CGAP_ENV_PRODUCTION_GREEN_NEW) is False
+    assert is_hotseat_env(CGAP_ENV_WEBPROD) is False
+    assert is_hotseat_env(CGAP_ENV_WEBPROD_NEW) is False
 
     assert is_hotseat_env(CGAP_ENV_HOTSEAT) is True
     assert is_hotseat_env(CGAP_ENV_MASTERTEST) is False
@@ -359,13 +411,13 @@ def test_get_mirror_env_from_context_with_environ_has_env():
 
         settings = {'env.name': FF_ENV_WEBPROD}
         mirror = get_mirror_env_from_context(settings, allow_environ=False, allow_guess=False)
-        assert mirror == None  # env name in environ suppressed, but guessing disallowed
+        assert mirror is None  # env name in environ suppressed, but guessing disallowed
 
     with mock.patch.object(os, "environ", {"ENV_NAME": CGAP_ENV_WEBPROD}):
 
         settings = {}
         mirror = get_mirror_env_from_context(settings, allow_environ=True)
-        assert mirror == None  # env name explicitly declared, then a guess (but no CGAP mirror)
+        assert mirror is None  # env name explicitly declared, then a guess (but no CGAP mirror)
 
         settings = {}
         mirror = get_mirror_env_from_context(settings, allow_environ=True, allow_guess=False)
@@ -493,10 +545,14 @@ def test_infer_foursight_env():
     assert infer_foursight_from_env(mock_request(), FF_ENV_HOTSEAT) == 'hotseat'
 
     # (active) fourfront production environments
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-blue') == FF_PRODUCTION_IDENTIFIER
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-green') == FF_PRODUCTION_IDENTIFIER
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-blue') == FF_STAGING_IDENTIFIER
-    assert infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-green') == FF_STAGING_IDENTIFIER
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-blue')
+            == FF_PRODUCTION_IDENTIFIER)
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_PRD), 'fourfront-green')
+            == FF_PRODUCTION_IDENTIFIER)
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-blue')
+            == FF_STAGING_IDENTIFIER)
+    assert (infer_foursight_from_env(mock_request(domain=FF_PUBLIC_DOMAIN_STG), 'fourfront-green')
+            == FF_STAGING_IDENTIFIER)
 
     # (active) cgap environments
     assert infer_foursight_from_env(mock_request(), CGAP_ENV_DEV) == 'cgapdev'


### PR DESCRIPTION
This makes the unit tests for `dcicutils.ff_utils` run faster, and makes other incidental small changes.

The general approach is to keep existing unit tests of `ff_utils`, most of which are really integration tests, but to add a real unit test that is faster and more comprehensive. Where such unit tests get written, the integration test will be marked `integrationx` instead of `integration`, and such tests will be excluded from normal runs by `make test`, speeding things up. We can arrange another mechanism for periodically running just integration tests or all the tests, or something like that, but I wasn't focused on that for now.

See the `CHANGLOG.rst` for details.  Note that at the time the PR was created, this doesn't make everything a unit test, but it's work in progress.
