### PR TITLE
Add url_path_join

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Change Log
 **PR 124: Add url_path_join**
 
 * Add ``misc_utils.url_path_join`` for merging parts of URLs.
+* Add ``make retest`` to rerun failed tests from previous test run.
 
 1.7.1
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ dcicutils
 Change Log
 ----------
 
+1.8.0
+=====
+
+**PR 124: Add url_path_join**
+
+* Add ``misc_utils.url_path_join`` for merging parts of URLs.
+
 1.7.1
 =====
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ build:  # builds
 test:  # runs default tests, which are the unit tests
 	make test-units
 
+retest:  # runs only failed tests from the last test run. (if no failures, it seems to run all?? -kmp 17-Dec-2020)
+	pytest -vv --last-failed
+
 test-all:
 	pytest -vv
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -1060,6 +1060,24 @@ def getattr_customized(thing, key):
         return value
 
 
+def url_path_join(*fragments):
+    """
+    Concatenates its arguments, returning a string with exactly one slash ('/') separating each of the path fragments.
+
+    So, whether the path_fragments are ('foo', 'bar') or ('foo/', 'bar') or ('foo', '/bar') or ('foo/', '/bar')
+    or even ('foo//', '///bar'), the result will be 'foo/bar'. The left side of the first thing and the
+    right side of the last thing are unaffected.
+
+    :param fragments: a list of URL path fragments
+    :return: a slash-separated concatentation of the given path fragments
+    """
+    fragments = fragments or ("",)
+    result = fragments[0]  # Tolerate an empty list
+    for thing in fragments[1:]:
+        result = result.rstrip("/") + "/" + thing.lstrip("/")
+    return result
+
+
 # Deprecated names, still supported for a while.
 HMS_TZ = REF_TZ
 hms_now = ref_now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.7.1"
+version = "1.8.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -17,7 +17,7 @@ from dcicutils.misc_utils import (
     Retry, apply_dict_overrides, utc_today_str, RateManager, environ_bool,
     LockoutManager, check_true, remove_prefix, remove_suffix, full_class_name, full_object_name, constantly,
     keyword_as_title, file_contents, CachedField, camel_case_to_snake_case, snake_case_to_camel_case, make_counter,
-    CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json,
+    CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json, url_path_join,
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
     DatetimeCoercionFailure,
 )
@@ -1729,3 +1729,12 @@ def test_customized_class():
                                                  % test_class_prefix):
             PRINT(getattr_customized(SampleClass2, 'FAVORITE_SONG'))
         assert printed.last is None
+
+
+def test_url_path_join():
+
+    assert url_path_join('foo', 'bar') == 'foo/bar'
+    assert url_path_join('foo/', 'bar') == 'foo/bar'
+    assert url_path_join('foo', '/bar') == 'foo/bar'
+    assert url_path_join('foo/', '/bar') == 'foo/bar'
+    assert url_path_join('//foo//', '///bar//') == '//foo/bar//'


### PR DESCRIPTION
Add `misc_utils.url_path_join` for putting slash-separated pieces of a URL path together.
