### PR TITLE
C4-503 Grab Environment API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ dcicutils
 Change Log
 ----------
 
+1.8.2
+=====
+
+**PR 126: C4-503 Grab Environment API**
+
+* Adds get_beanstalk_environment_variables, which will return information 
+  necessary to simulate any application given the caller has the appropriate 
+  access keys.
+* Removes an obsolete tag from create_db_snapshot, which was set erroneously.
+
 1.8.1
 =====
 

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -409,11 +409,11 @@ def get_beanstalk_environment_variables(env):
         Ensure that if you are using this you are not logging the output of this anywhere.
     """
     options = _get_beanstalk_configuration_settings(env)
-    env = []
+    env = {}
     for option in options:
         if 'Namespace' in option:
             if option['Namespace'] == ENV_VARIABLE_NAMESPACE:
-                env.append((option['OptionName'], option['Value']))
+                env[option['OptionName']] = option['Value']
     return env
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.8.1"
+version = "1.8.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_beanstalk_utils.py
+++ b/test/test_beanstalk_utils.py
@@ -362,7 +362,7 @@ def test_compute_prd_env_for_project():
             'OptionName': 'super_secret',
             'Value': 'i am secret'
          }
-     ], [('super_secret', 'i am secret')]),
+     ], {'super_secret': 'i am secret'}),
     ([
          {
             'Namespace': bs.ENV_VARIABLE_NAMESPACE,
@@ -374,7 +374,19 @@ def test_compute_prd_env_for_project():
             'OptionName': 'not_secret',
             'Value': 'i dont care about this value'
          }
-     ], [('super_secret', 'i am secret')])
+     ], {'super_secret': 'i am secret'}),
+    ([
+         {
+            'Namespace': 'identifier',
+            'OptionName': 'something',
+            'Value': 'important'
+         },
+         {
+            'Namespace': 'something else',
+            'OptionName': 'not_secret',
+            'Value': 'i dont care about this value'
+         }
+     ], {})
 ])
 def test_get_beanstalk_env_variables(options, expected):
     with mock.patch('dcicutils.beanstalk_utils._get_beanstalk_configuration_settings') as mock_api:

--- a/test/test_beanstalk_utils.py
+++ b/test/test_beanstalk_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import boto3
 import io
 import json
@@ -352,3 +353,31 @@ def test_compute_prd_env_for_project():
             mock_describer.side_effect = _mocked_describe_beanstalk_environments
             assert bs._compute_prd_env_for_project('cgap') == 'cgap-env-2'
             assert bs._compute_prd_env_for_project('ff') == 'ff-env-2'
+
+
+@pytest.mark.parametrize('options, expected', [
+    ([
+         {
+            'Namespace': bs.ENV_VARIABLE_NAMESPACE,
+            'OptionName': 'super_secret',
+            'Value': 'i am secret'
+         }
+     ], [('super_secret', 'i am secret')]),
+    ([
+         {
+            'Namespace': bs.ENV_VARIABLE_NAMESPACE,
+            'OptionName': 'super_secret',
+            'Value': 'i am secret'
+         },
+         {
+            'Namespace': 'something else',
+            'OptionName': 'not_secret',
+            'Value': 'i dont care about this value'
+         }
+     ], [('super_secret', 'i am secret')])
+])
+def test_get_beanstalk_env_variables(options, expected):
+    with mock.patch('dcicutils.beanstalk_utils._get_beanstalk_configuration_settings') as mock_api:
+        mock_api.return_value = options  # do not call out to AWS
+        actual = bs.get_beanstalk_environment_variables('unused')
+        assert actual == expected

--- a/test/test_beanstalk_utils.py
+++ b/test/test_beanstalk_utils.py
@@ -386,7 +386,19 @@ def test_compute_prd_env_for_project():
             'OptionName': 'not_secret',
             'Value': 'i dont care about this value'
          }
-     ], {})
+     ], {}),
+    ([
+         {
+            'Namespace': bs.ENV_VARIABLE_NAMESPACE,
+            'OptionName': 'super_secret',
+            'Value': 'i am secret'
+         },
+         {
+            'Namespace': bs.ENV_VARIABLE_NAMESPACE,
+            'OptionName': 'not_secret',
+            'Value': 'this one shows up too though'
+         }
+     ], {'super_secret': 'i am secret', 'not_secret': 'this one shows up too though'}),
 ])
 def test_get_beanstalk_env_variables(options, expected):
     with mock.patch('dcicutils.beanstalk_utils._get_beanstalk_configuration_settings') as mock_api:


### PR DESCRIPTION
- Adds `get_beanstalk_environment_variables`, which will return information necessary to simulate any application given the caller has the appropriate access keys.
- Removes an `obsolete` tag from `create_db_snapshot`, which was set erroneously.