### PR TITLE
Changelog warnings (C4-511) and publish fixes (C4-512)

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -32,5 +32,5 @@ jobs:
           PYPI_USER: ${{ secrets.PYPI_USER }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: | 
-          pip install poetry
+          make configure
           make publish-for-ga

--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -33,4 +33,4 @@ jobs:
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: | 
           pip install poetry
-          poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD
+          make publish-for-ga

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,9 @@ Change Log
 
 **PR 128: Changelog Warnings (C4-511) and Publish Fixes (C4-512)**
 
-* Make changelog problems warn rather than fail testing.
+* Make changelog problems issue a warning rather than fail testing.
 * Make publication for GitHub Actions (GA) not query interactively for confirmation.
+* Fix bug in handling of ``encoding=`` in the ``open`` operation of ``MockFileSystem``.
 
 1.8.4
 =====
@@ -25,7 +26,6 @@ Change Log
 =====
 
 **No PR: Just fixes to GA PyPi deploy**
-
 
 1.8.2
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,15 @@ Change Log
 
 * Make changelog problems issue a warning rather than fail testing.
 * Make publication for GitHub Actions (GA) not query interactively for confirmation.
-* Fix bug in handling of ``encoding=`` in the ``open`` operation of ``MockFileSystem``.
+
+Some other fixes are included because the ``test_unzip_s3_to_s3``
+and ``test_unzip_s3_to_s3_2`` tests were intermittently failing.
+Those tests were refactored, and the following additional support was added:
+
+* In ``MockBotoS3Client``, added support for some cases of:
+  * ``.put_object()``
+  * ``.list_objects()``
+
 
 1.8.4
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ dcicutils
 Change Log
 ----------
 
+1.8.5
+=====
+
+**PR 128: Changelog Warnings (C4-511) and Publish Fixes (C4-512)**
+
+* Make changelog problems warn rather than fail testing.
+* Make publication for GitHub Actions (GA) not query interactively for confirmation.
+
 1.8.4
 =====
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ update:  # updates dependencies
 publish:
 	scripts/publish
 
+publish-for-ga:
+	scripts/publish --noconfirm
+
 help:
 	@make info
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.8.4"
+version = "1.8.5"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.8.5"
+version = "1.9.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+do_confirm=yes
+
+while true; do
+    if [ "$1" = "--help" ]; then
+       echo "Syntax: $0 [ --noconfirm | --help ]*"
+       echo ""
+       echo "Publishes the repository to pypi, after doing various consistency checks."
+       echo ""
+       echo "By default, if all looks good, you will be asked interactively for confirmation."
+       echo "In a script, you may want --noconfirm to suppress this query."
+       exit 1
+    elif [ "$1" = "--noconfirm" ]; then
+       do_confirm=no
+       shift 1
+    elif [ $# -ne 0 ]; then
+       echo "Unexpected argument: $1"
+       exit 1
+    else
+       break
+    fi
+done
+
 if [ -z "$PYPI_USER" ]; then
     echo '$PYPI_USER is not set.'
     exit 1
@@ -32,12 +54,14 @@ if [ -z "$tagged" ]; then
   exit 1
 fi
 
-read -p "Are you sure you want to publish $(poetry version) to PyPi? "
-REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
-if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
-then
-  echo "Publishing aborted."
-  exit 1
+if [ "${do_confirm}" = "yes" ]; then
+  read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+  REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+  if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+  then
+    echo "Publishing aborted."
+    exit 1
+  fi
 fi
 
 poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD


### PR DESCRIPTION
This fixes two primary issues:

* A missing changelog issue is an error, and @willronchetti wanted it downgraded to a warning.
* GitHub Actions publication was not using the script because of prompting. This amends the `scripts/publish` script to take a `--noconfirm` argument and sets up a `publish-for-ga` target for `make` so that we can use that to do publication.

Along the way I also did:

* Improve support in `MockFileSystem.open` for an `encoding=` argument. There was some missing data flow.
* To get some testing to not fail under GA, added support in `MockBotoS3Client` for `.put_object()` and `.list_objects()`.
