### PR TITLE
Fix problematic pytest dependency (C4-521)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ dcicutils
 Change Log
 ----------
 
+1.9.1
+=====
+
+* Fix problem in 1.9.0 with unwanted dependency on
+  ``pytest.PytestConfigWarning`` (C4-521).
+* Added some unit tests to run instead of integration tests for
+  ``s3_utils`` in a number of cases.
+
+
 1.9.0
 =====
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -940,7 +940,11 @@ class VersionChecker:
     PYPROJECT = CustomizableProperty('PYPROJECT', description="The repository-relative name of the pyproject file.")
     CHANGELOG = CustomizableProperty('CHANGELOG', description="The repository-relative name of the change log.")
 
-    WARNING_CATEGORY = pytest.PytestConfigWarning
+    # I wanted to use pytest.PytestConfigWarning, but that creates a dependency
+    # on particular versions of pytest, and we don't export a delivery
+    # constraint of a particular pytest version. So RuntimeWarning is a
+    # safer setting for now. -kmp 14-Jan-2021
+    WARNING_CATEGORY = RuntimeWarning
 
     @classmethod
     def check_version(cls):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.9.0"
+version = "1.9.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,5 @@ markers =
   working: test should work
   integrated: an integration test
   integratedx: an excludable integration test, redundantly testing functionality also covered by a unit test
+  unit: a proper unit test
   file_operation: a test that utilizes files

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,11 +52,6 @@ INTEGRATED_ES, INTEGRATED_ES_NAMESPACE = _discover_es_info(INTEGRATED_ENV)
 check_true(INTEGRATED_ENV == INTEGRATED_ES_NAMESPACE, "INTEGRATED_ENV and INTEGRATED_ES_NAMESPACE are not the same.")
 
 
-@pytest.fixture()
-def integrated_env():
-    return {'ffenv': INTEGRATED_ENV}
-
-
 @pytest.fixture(scope='session')
 def basestring():
     try:
@@ -87,14 +82,19 @@ def integrated_ff():
 
 
 @pytest.fixture(scope='session')
-def zip_filenames():
+def integrated_names():
+
+    test_filename = '__test_data/test_file.txt'
 
     zip_filename = '__test_data/fastqc_report.zip'
     zip_filename2 = '__test_data/madqc_report.zip'
 
     zip_path = os.path.join(TEST_DIR, 'data_files', os.path.basename(zip_filename))
     zip_path2 = os.path.join(TEST_DIR, 'data_files', os.path.basename(zip_filename2))
+
     return {
+        'ffenv': INTEGRATED_ENV,
+        'filename': test_filename,
         # short filenames or s3 key names (informally, s3 filenames)
         'zip_filename': zip_filename,
         'zip_filename2': zip_filename2,
@@ -105,26 +105,27 @@ def zip_filenames():
 
 
 @pytest.fixture(scope='session')
-def integrated_s3_info(zip_filenames):
+def integrated_s3_info(integrated_names):
     """
     Ensure the test files are present in the s3 sys bucket of the integrated
     environment (probably 'fourfront-mastertest') and return some info on them
     """
-    test_filename = '__test_data/test_file.txt'
+    test_filename = integrated_names['filename']
+
     s3_obj = s3Utils(env=INTEGRATED_ENV)
     # for now, always upload these files
     s3_obj.s3.put_object(Bucket=s3_obj.outfile_bucket, Key=test_filename,
                          Body=str.encode('thisisatest'))
-    s3_obj.s3.upload_file(Filename=zip_filenames['zip_path'],
+    s3_obj.s3.upload_file(Filename=integrated_names['zip_path'],
                           Bucket=s3_obj.outfile_bucket,
-                          Key=zip_filenames['zip_filename'])
-    s3_obj.s3.upload_file(Filename=zip_filenames['zip_path2'],
+                          Key=integrated_names['zip_filename'])
+    s3_obj.s3.upload_file(Filename=integrated_names['zip_path2'],
                           Bucket=s3_obj.outfile_bucket,
-                          Key=zip_filenames['zip_filename2'])
+                          Key=integrated_names['zip_filename2'])
 
     return {
         's3Obj': s3_obj,
         'filename': test_filename,
-        'zip_filename': zip_filenames['zip_filename'],
-        'zip_filename2': zip_filenames['zip_filename2'],
+        'zip_filename': integrated_names['zip_filename'],
+        'zip_filename2': integrated_names['zip_filename2'],
     }

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -861,6 +861,7 @@ def make_mocked_search(item_maker=None):
     return mocked_search
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize('url', ['', 'to_become_full_url'])
 def test_search_metadata_unit(integrated_ff, url):
     with mock.patch.object(ff_utils, "authorized_request", make_mocked_search()):


### PR DESCRIPTION
* Fix problem in 1.9.0 with unwanted dependency on
  `pytest.PytestConfigWarning` ([C4-521](https://hms-dbmi.atlassian.net/browse/C4-521)).
* Added some unit tests to run instead of integration tests for
  `s3_utils` in a number of cases.
