### PR TITLE
Misc functionality in service of C4-183

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ Change Log
 ----------
 
 
+1.10.0
+======
+
+**PR 131: Misc functionality in service of C4-183** 
+
+* In ``dcicutils.misc_utils``:
+
+  * New function ``remove_element`` to remove an element from a list.
+  * New class ``TestApp`` which is a synonym for ``webtest.TestApp``
+    but declared not to be a test case.
+  * Make ``_VirtualAppHelper`` use new ``TestApp``.
+
+
 1.9.2
 =====
 **PR 130: Fix bug that sometimes results in duplicated search results (C4-336)**

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -69,7 +69,23 @@ class VirtualAppError(Exception):
         return self.__repr__()
 
 
-class _VirtualAppHelper(webtest.TestApp):  # effectively disguises 'TestApp'
+class TestApp(webtest.TestApp):
+    """
+    Equivalent to webtest.TestApp, but pytest will not let the name confuse into thinking it's a test case.
+
+    A test case in PyTest is something that contains "test" in its name. We didn't pick the name TestApp,
+    but there may be tools that want to use TestApp for testing, and so this is a better place to inherit from,
+    since we've added an appropriate declaration to keep PyTest from confusing it with a TestCase.
+    """
+
+    __test__ = False  # This declaration asserts to PyTest that this is not a test case.
+
+
+class _VirtualAppHelper(TestApp):
+    """
+    A helper class equivalent to webtest.TestApp, except that it isn't intended for test use.
+    """
+
     pass
 
 
@@ -783,6 +799,27 @@ def check_true(test_value, message, error_class=None):
         error_class = RuntimeError
     if not test_value:
         raise error_class(message)
+
+
+def remove_element(elem, lst, raise_error=True):
+    """
+    Returns a copy of the given list with the first occurrence of the given element removed.
+
+    If the element doesn't occur in the list, an error is raised unless given raise_error=False,
+    in which case a copy of the original list is returned.
+
+    :param elem: an object
+    :param lst: a list
+    :param raise_error: a boolean (default True)
+    """
+
+    result = lst.copy()
+    try:
+        result.remove(elem)
+    except ValueError:
+        if raise_error:
+            raise
+    return result
 
 
 def remove_prefix(prefix, text, required=False):

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -803,10 +803,10 @@ def check_true(test_value, message, error_class=None):
 
 def remove_element(elem, lst, raise_error=True):
     """
-    Returns a copy of the given list with the first occurrence of the given element removed.
+    Returns a shallow copy of the given list with the first occurrence of the given element removed.
 
     If the element doesn't occur in the list, an error is raised unless given raise_error=False,
-    in which case a copy of the original list is returned.
+    in which case a shallow copy of the original list is returned (with no elements removed).
 
     :param elem: an object
     :param lst: a list

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -716,10 +716,10 @@ class MockBotoS3Client:
     def _content_etag(content):
         return hashlib.md5(content).hexdigest()
 
-    def Bucket(self, name):
+    def Bucket(self, name):  # noQA - AWS function naming style
         return MockBotoS3Bucket(s3=self, name=name)
 
-    def head_object(self, Bucket, Key, **kwargs):
+    def head_object(self, Bucket, Key, **kwargs):  # noQA - AWS argument naming style
         if kwargs != self.other_required_arguments:
             raise MockKeysNotImplemented("get_object", kwargs.keys())
 
@@ -740,7 +740,7 @@ class MockBotoS3Client:
             # For now, just fail in any way since maybe our code doesn't care.
             raise Exception("Mock File Not Found")
 
-    def list_objects(self, Bucket, Prefix=None):
+    def list_objects(self, Bucket, Prefix=None):  # noQA - AWS argument naming style
         # Ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects
         bucket_prefix = Bucket + "/"
         bucket_prefix_length = len(bucket_prefix)
@@ -831,10 +831,10 @@ class MockBotoS3BucketObjects:
         self.bucket = bucket
 
     def all(self):
-        return self.bucket._all()
+        return self.bucket._all()  # noQA - we are effectively a friend of this instance and are intended to call this.
 
     def delete(self):
-        return self.bucket._delete(delete_bucket_too=False)
+        return self.bucket._delete(delete_bucket_too=False)  # noQA - we are effectively a friend of this instance
 
 
 class MockBotoSQSClient:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.9.2"
+version = "1.10.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -12,14 +12,14 @@ import warnings
 import webtest
 
 from dcicutils.misc_utils import (
-    PRINT, ignored, filtered_warnings, get_setting_from_context, VirtualApp, VirtualAppError,
+    PRINT, ignored, filtered_warnings, get_setting_from_context, TestApp, VirtualApp, VirtualAppError,
     _VirtualAppHelper,  # noqa - yes, this is a protected member, but we still want to test it
     Retry, apply_dict_overrides, utc_today_str, RateManager, environ_bool,
     LockoutManager, check_true, remove_prefix, remove_suffix, full_class_name, full_object_name, constantly,
     keyword_as_title, file_contents, CachedField, camel_case_to_snake_case, snake_case_to_camel_case, make_counter,
     CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json, url_path_join,
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
-    DatetimeCoercionFailure,
+    DatetimeCoercionFailure, remove_element,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ, MockFileSystem, printed_output, raises_regexp
@@ -136,6 +136,12 @@ class FakeTestApp:
 
 class FakeApp:
     pass
+
+
+def test_test_app():
+    test_app = TestApp(FakeApp(), {})
+    assert isinstance(test_app, webtest.TestApp)
+    assert not test_app.__test__
 
 
 def test_virtual_app_creation():
@@ -1280,6 +1286,16 @@ def test_check_true():
     with pytest.raises(RuntimeError) as e:
         check_true(x == [4, 5, 6], msg)
     assert msg in str(e)
+
+
+def test_remove_element():
+
+    assert remove_element('b', ['a', 'b', 'c', 'a', 'b', 'c']) == ['a', 'c', 'a', 'b', 'c']
+
+    with pytest.raises(ValueError):
+        assert remove_element('z', ['a', 'b', 'c', 'a', 'b', 'c'])
+
+    assert remove_element('z', ['a', 'b', 'c', 'a', 'b', 'c'], raise_error=False) == ['a', 'b', 'c', 'a', 'b', 'c']
 
 
 def test_remove_prefix():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -1290,12 +1290,20 @@ def test_check_true():
 
 def test_remove_element():
 
-    assert remove_element('b', ['a', 'b', 'c', 'a', 'b', 'c']) == ['a', 'c', 'a', 'b', 'c']
+    old = ['a', 'b', 'c', 'a', 'b', 'c']
+    new = remove_element('b', old)
+    assert old is not new
+    assert old == ['a', 'b', 'c', 'a', 'b', 'c']
+    assert new == ['a', 'c', 'a', 'b', 'c']
+
+    new = remove_element('z', old, raise_error=False)
+    assert old is not new
+    assert new == ['a', 'b', 'c', 'a', 'b', 'c']
+    assert old == ['a', 'b', 'c', 'a', 'b', 'c']
 
     with pytest.raises(ValueError):
-        assert remove_element('z', ['a', 'b', 'c', 'a', 'b', 'c'])
-
-    assert remove_element('z', ['a', 'b', 'c', 'a', 'b', 'c'], raise_error=False) == ['a', 'b', 'c', 'a', 'b', 'c']
+        remove_element('z', old)
+    assert old == ['a', 'b', 'c', 'a', 'b', 'c']
 
 
 def test_remove_prefix():


### PR DESCRIPTION
In `dcicutils.misc_utils`:

* New function `remove_element` to remove an element from a list (functionally rather than by side-effect).
* New class `TestApp` which is a synonym for `webtest.TestApp` but declared not to be a test case. (Classes with names that have "test" in their name are possible to confuse with test cases under `pytest`, so this has the necessary declaration to suppress that confusion.)
* Make `_VirtualAppHelper` use new `TestApp`.