### PR TITLE
Miscellaneous support for cgap-portal, and some unit testing (part of C4-601)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,26 @@ Change Log
 ----------
 
 
+1.11.0
+======
+
+**PR 132: Miscellaneous support for cgap-portal, and some unit testing (part of C4-601)**
+
+* For ``jh_utils``:
+
+  * Better unit test for ``find_valid_file_or_extra_file`` (part of fixing C4-601).
+
+* For ``misc_utils``:
+
+  * New function ``ignorable`` which is basically a synonym for ``ignore``, but with the sense that it's OK for the variables given as its arguments to be used elsewhere or not.
+  * New function ``ancestor_classes`` that returns a list of the classes from which a given class inherits.
+  * New function ``is_proper_subclass`` that is like ``issubclass`` but returns ``True`` only if its two arguments _are_ not the same class.
+  * New function ``identity`` that returns its argument.
+  * New functions ``count`` and ``count_if`` for counting things in a sequence.
+  * New function ``find_association`` for finding dictionaries in a list based on specified field criteria.
+  * New ``@decorator`` decorator for defining (what else?) decorators. Specifically, this addresses the ``@foo`` vs ``@foo()`` issue, allowing both syntaxes.
+
+
 1.10.0
 ======
 
@@ -317,3 +337,4 @@ the ``poetry.app`` section of ``pyproject.toml``, as in::
    name = "dcicutils"
    version = "100.200.300"
    ...etc.
+

--- a/dcicutils/jh_utils.py
+++ b/dcicutils/jh_utils.py
@@ -6,11 +6,7 @@ import sys
 from contextlib import contextmanager
 from .ff_utils import *  # NOQA
 from .misc_utils import PRINT
-# urllib is different between python2 and 3
-if sys.version_info[0] == 3:
-    import urllib.request as use_urllib
-else:
-    import urllib2 as use_urllib
+import urllib.request
 
 # do some top level stuff when the module is imported
 if 'FF_ACCESS_KEY' not in os.environ or 'FF_ACCESS_SECRET' not in os.environ:
@@ -42,7 +38,7 @@ HANDLED_FUNCTIONS = [
 ]
 
 
-class HTTPBasic403AuthHandler(use_urllib.HTTPBasicAuthHandler):
+class HTTPBasic403AuthHandler(urllib.request.HTTPBasicAuthHandler):
     """
     See: https://gist.github.com/dnozay/194d816aa6517dc67ca1
     retry with basic auth when facing a 403 forbidden
@@ -65,8 +61,8 @@ def install_auth_opener():
     # create opener / 403 error handler
     auth_handler = HTTPBasic403AuthHandler()
     # install it.
-    opener = use_urllib.build_opener(auth_handler)
-    use_urllib.install_opener(opener)
+    opener = urllib.request.build_opener(auth_handler)
+    urllib.request.install_opener(opener)
     return auth_handler
 
 
@@ -241,7 +237,7 @@ def open_4dn_file(obj_id, format=None, local=True):
     gz = False
     if not local:
         # this seems to handle both binary and non-binary files
-        ff_file = use_urllib.urlopen(file_info['full_href'])
+        ff_file = urllib.request.urlopen(file_info['full_href'])
         if file_info.get('full_href', '').endswith('.gz'):
             gz = True
     else:

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -820,12 +820,6 @@ def check_true(test_value, message, error_class=None):
         raise error_class(message)
 
 
-def reversed(seq):
-    seq_copied = list(seq).copy()
-    seq_copied.reverse()
-    return seq_copied
-
-
 def remove_element(elem, lst, raise_error=True):
     """
     Returns a shallow copy of the given list with the first occurrence of the given element removed.
@@ -929,29 +923,11 @@ def full_object_name(obj):
         return None
 
 
-class _ConstantValuedFunction:
-
-    def __init__(self, value):
-        self._value = value
-
-    def __str__(self):
-        return repr(self)
-
-    def __repr__(self):
-        return "constantly(%r)" % self._value
-
-    def __call__(self, *args, **kwargs):
+def constantly(value):
+    def fn(*args, **kwargs):
         ignored(args, kwargs)
-        return self._value
-
-    @property
-    def __doc__(self):
-        return "A function that always returns a constant value: %r" % self._value
-
-
-def constantly(x):
-    """Given any constant x, returns a function that always returns the constant x."""
-    return _ConstantValuedFunction(x)
+        return value
+    return fn
 
 
 def identity(x):

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -5,6 +5,7 @@ This file contains functions that might be generally useful.
 import contextlib
 import datetime
 import functools
+import inspect
 import math
 import io
 import os
@@ -198,6 +199,24 @@ def ignored(*args, **kwargs):
     return args, kwargs
 
 
+def ignorable(*args, **kwargs):
+    """
+    This is useful for defeating flake warnings.
+    Call this function to use values that really might be ignored.
+    This is intended as a declaration that variables are or might be intentionally ignored,
+    but no enforcement of that is done. Some sample uses:
+
+    def foo(x, y):
+        ignorable(x, y)  # so flake8 won't complain about unused vars, whether or not next line is commented out.
+        # print(x, y)
+        return 3
+
+    foo_synonym = foo
+    ignorable(foo_synonym)  # We might or might not use foo_synonym, but we don't want it reported as unused
+    """
+    return args, kwargs
+
+
 def get_setting_from_context(settings, ini_var, env_var=None, default=None):
     """
     This gets a value from either an environment variable or a config file.
@@ -330,7 +349,7 @@ class Retry:
             wait_multiplier: A multiplier by which the number of wait_seconds is adjusted on each retry.
         """
 
-        def decorator(function):
+        def _decorator(function):
             function_name = name_key or function.__name__
             function_profile = cls.RetryOptions(
                 retries_allowed=cls._defaulted(retries_allowed, cls.DEFAULT_RETRIES_ALLOWED),
@@ -368,7 +387,7 @@ class Retry:
 
             return wrapped_function
 
-        return decorator
+        return _decorator
 
     @classmethod
     def retrying(cls, fn, retries_allowed=None, wait_seconds=None, wait_increment=None, wait_multiplier=None):
@@ -801,6 +820,12 @@ def check_true(test_value, message, error_class=None):
         raise error_class(message)
 
 
+def reversed(seq):
+    seq_copied = list(seq).copy()
+    seq_copied.reverse()
+    return seq_copied
+
+
 def remove_element(elem, lst, raise_error=True):
     """
     Returns a shallow copy of the given list with the first occurrence of the given element removed.
@@ -858,6 +883,21 @@ def obsolete(func, fail=True):
     return inner
 
 
+def ancestor_classes(cls, reverse=False):
+    result = list(cls.__mro__[1:])
+    if reverse:
+        result.reverse()
+    return result
+
+
+def is_proper_subclass(cls, maybe_proper_superclass):
+    """
+    Returns true of its first argument is a subclass of the second argument, but is not that class itself.
+    (Every class is a subclass of itself, but no class is a 'proper subclass' of itself.)
+    """
+    return cls is not maybe_proper_superclass and issubclass(cls, maybe_proper_superclass)
+
+
 def full_class_name(obj):
     """
     Returns the fully-qualified name of the class of the given obj (an object).
@@ -889,11 +929,53 @@ def full_object_name(obj):
         return None
 
 
-def constantly(value):
-    def fn(*args, **kwargs):
+class _ConstantValuedFunction:
+
+    def __init__(self, value):
+        self._value = value
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        return "constantly(%r)" % self._value
+
+    def __call__(self, *args, **kwargs):
         ignored(args, kwargs)
-        return value
-    return fn
+        return self._value
+
+    @property
+    def __doc__(self):
+        return "A function that always returns a constant value: %r" % self._value
+
+
+def constantly(x):
+    """Given any constant x, returns a function that always returns the constant x."""
+    return _ConstantValuedFunction(x)
+
+
+def identity(x):
+    """Returns its argument."""
+    return x
+
+
+def count_if(filter, seq):
+    return sum(1 for x in seq if filter(x))
+
+
+def count(seq, filter=None):
+    return count_if(filter or identity, seq)
+
+
+def find_association(data, **kwargs):
+    for datum in data:
+        mismatch = False
+        for k, v in kwargs.items():
+            if k in datum and datum[k] != v:
+                mismatch = True
+        if not mismatch:
+            return datum
+    return None
 
 
 def keyword_as_title(keyword):
@@ -1113,6 +1195,77 @@ def url_path_join(*fragments):
     for thing in fragments[1:]:
         result = result.rstrip("/") + "/" + thing.lstrip("/")
     return result
+
+
+def _is_function_of_exactly_one_required_arg(x):
+    if not callable(x):
+        return False
+    argspec = inspect.getfullargspec(x)
+    return len(argspec.args) == 1 and not argspec.varargs and not argspec.defaults and not argspec.kwonlyargs
+
+
+def _apply_decorator(fn, *args, **kwargs):
+    """
+    This implements a fix to the decorator syntax where it gets fussy about whether @foo and @foo() are synonyms.
+    The price to be paid is you can't use it for decorators that take positional arguments.
+    """
+    if args and (kwargs or len(args) > 1):
+        # If both args and kwargs are in play, they have to have been passed explicitly like @foo(a1, k2=v2).
+        # If more than one positional is given, that has to be something like @foo(a1, a2, ...)
+        # Decorators using this function need to agree to only accept keyword arguments, so those cases can't happen.
+        # They can do this by using an optional first positional argument, as in 'def foo(x=3):',
+        # or they can do it by using a * as in 'def foo(*, x)' or if no arguments are desired, obviously, 'def foo():'.
+        raise SyntaxError("Positional arguments to decorator (@%s) not allowed here." % fn.__name__)
+    elif args:
+        arg0 = args[0]  # At this point, we know there is a single positional argument.
+        #
+        # Here there are two cases.
+        #
+        # (a) The user may have done @foo, in which case we will have a fn which is the value of foo,
+        #     but not the result of applying it.
+        #
+        # (b) Otherwise, the user has done @foo(), in which case what we'll have the function of one
+        #     argument that does the wrapping of the subsequent function or class.
+        #
+        # So since case (a) expects fn to be a function that tolerates zero arguments
+        # while case (b) expects fn to be a function that rejects positional arguments,
+        # we can call fn with the positional argument, arg0. If that argument is rejected with a TypeError,
+        # we know that it's really case (a) and that we need to call fn once with no arguments
+        # before retrying on arg0.
+        if _is_function_of_exactly_one_required_arg(fn):
+            # We are ready to wrap the function or class in arg0
+            return fn(arg0)
+        else:
+            # We are ALMOST ready to wrap the function or class in arg0,
+            # but first we have to call ourselves with no arguments as in case (a) described above.
+            return fn()(arg0)
+    else:
+        # Here we have kwargs = {...} from @foo(x=3, y=4, ...) or maybe no kwargs either @foo().
+        # Either way, we've already evaluated the foo(...) call, so all that remains is to call on our kwargs.
+        # (There are no args to call it on because we tested that above.)
+        return fn(**kwargs)
+
+
+def _decorator(decorator_function):
+    """See documentation for decorator."""
+    @functools.wraps(decorator_function)
+    def _wrap_decorator(*args, **kwargs):
+        return _apply_decorator(decorator_function, *args, **kwargs)
+    return _wrap_decorator
+
+
+@_decorator
+def decorator():
+    """
+    This defines a decorator, such that is can be used as either @foo or @foo()
+    PROVIDED THAT the function doing the decorating is not a function a single required argument,
+    since that would create an ambiguity that would inhibit the auto-correction this will do.
+
+    @decorator
+    def foo(...):
+        ...
+    """
+    return _decorator
 
 
 # Deprecated names, still supported for a while.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.10.0"
+version = "1.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_jh_utils.py
+++ b/test/test_jh_utils.py
@@ -3,8 +3,11 @@
 import os
 import datetime
 import pytest
-from dcicutils import s3_utils
-from dcicutils.qa_utils import override_environ
+import re
+
+from dcicutils import s3_utils, ff_utils
+from dcicutils.qa_utils import override_environ, MockFileSystem
+from unittest import mock
 
 pytestmark = pytest.mark.working
 
@@ -63,8 +66,224 @@ def test_some_decorated_methods_work(integrated_ff):
     assert len(faceted_search_res) == 8
 
 
-@pytest.mark.integrated
-def test_jh_open_4dn_file(integrated_ff):
+NOT_AN_ID = 'not_an_id'
+NOT_AN_ID_ERROR_MESSAGE = "Could not open file: not_an_id"
+NOT_VALID_FILE_ERROR_MESSAGE = 'not a valid file object'
+
+BIOSAMPLE_SEARCH_STRING = 'search/?type=Biosample'
+BIOSAMPLE_SEARCH_RESULT = [
+    {  # This is actually only a subset of the fields we'd find.
+        "modifications_summary": "None",
+        "@type": ["Biosample", "Item"],
+        "display_title": "4DNBS1235556",
+        "description": "H1 test prep",
+        "biosample_type": "in vitro differentiated cells",
+        "accession": "4DNBS1235556",
+        "uuid": "111112bc-1111-4448-903e-854af460b123",
+        "schema_version": "2",
+        "@id": "/biosamples/4DNBS1235556/"
+    }
+]
+BIOSAMPLE_ITEM_0 = BIOSAMPLE_SEARCH_RESULT[0]
+BIOSAMPLE_ITEM_0_UUID = BIOSAMPLE_ITEM_0['uuid']
+
+FILE_SEARCH_RESULT = [
+    {  # This is actually only a subset of the fields we'd find.
+        "display_title": "4DNFIIEB6GJB.bed.gz",
+        "title": "4DNFIIEB6GJB",
+        "@type": ["FileProcessed", "File", "Item"],
+        "uuid": "09d6427d-c253-47d1-8535-f9345b3f7771",
+        "@id": "/files-processed/4DNFIIEB6GJB/",
+        "status": "uploaded",
+        "href": "/files-processed/4DNFIIEB6GJB/@@download/4DNFIIEB6GJB.bed.gz",
+        "upload_key": "09d6427d-c253-47d1-8535-f9345b3f7771/4DNFIIEB6GJB.bed.gz",
+        "md5sum": "146e3b87f0eac872280c9e2c7c684d43",
+        "file_type": "domain calls",
+        "file_format": {
+            "uuid": "69f6d609-f2ac-4c82-9472-1a13331b5ce9",
+            "@id": "/file-formats/bed/",
+            "display_title": "bed",
+            "file_format": "bed",
+            "@type": ["FileFormat", "Item"],
+            "principals_allowed": {"view": [], "edit": []}
+        },
+        "schema_version": "3",
+        "extra_files": [
+            {
+                "filename": "4DNFIIEB6GJB",
+                "md5sum": "ad348286f605c227c55b5741c292e967",
+                "upload_key": "09d6427d-c253-47d1-8535-f9345b3f7771/4DNFIIEB6GJB.beddb",
+                "href": "/files-processed/4DNFIIEB6GJB/@@download/4DNFIIEB6GJB.beddb",
+                "filesize": 37888,
+                "accession": "4DNFIIEB6GJB",
+                "uuid": "09d6427d-c253-47d1-8535-f9345b3f7771",
+                "file_format": {
+                    "principals_allowed": {},
+                    "@type": [],
+                    "display_title": "beddb",
+                    "@id": "/file-formats/beddb/",
+                    "uuid": "76dc8c06-67d8-487b-8fc8-d841752a0b60"
+                },
+                "status": "uploaded"
+            }
+        ]
+    }
+]
+FILE_ITEM_0 = FILE_SEARCH_RESULT[0]
+FILE_ITEM_0_UUID = FILE_ITEM_0['uuid']
+[FILE_ITEM_0_EXTRA_FILE] = FILE_ITEM_0['extra_files']
+
+
+class MockResponse:
+    def __init__(self, status_code, json):
+        self.status_code = status_code
+        self._json = json
+
+    def json(self):
+        return self._json
+
+
+@pytest.mark.unit
+def test_find_valid_file_or_extra_file(integrated_ff):
+
+    # This setup isn't good for a unit test, but right now we can't load jh_utils otherwise. -kmp 15-Feb-2021
+    test_server = integrated_ff['ff_key']['server']
+    initialize_jh_env(test_server)
+    from dcicutils import jh_utils
+
+    def mocked_get_metadata(obj_id):
+        if obj_id == NOT_AN_ID:
+            raise Exception(NOT_AN_ID_ERROR_MESSAGE)
+        elif obj_id == BIOSAMPLE_ITEM_0_UUID:
+            return BIOSAMPLE_ITEM_0
+        elif obj_id == FILE_ITEM_0_UUID:
+            return FILE_ITEM_0
+        else:
+            raise NotImplementedError("mocked_authorized_request mock shortfall.")
+
+    def mocked_search_metadata(*args, **kwargs):
+        raise NotImplementedError()
+
+    def mocked_authorized_request(url, *args, **kwargs):
+        if url.endswith("/" + NOT_AN_ID):
+            return MockResponse(404, json={'message': NOT_AN_ID_ERROR_MESSAGE})
+        elif url.endswith("/" + BIOSAMPLE_ITEM_0_UUID):
+            return MockResponse(200, json=BIOSAMPLE_ITEM_0)
+        elif url.endswith("/" + FILE_ITEM_0_UUID):
+            return MockResponse(200, json=FILE_ITEM_0)
+        else:
+            raise NotImplementedError("mocked_authorized_request mock shortfall.")
+
+    mfs = MockFileSystem()
+    with mock.patch("builtins.open", mfs.open):
+        with mock.patch("os.path.exists", mfs.exists):
+            with mock.patch.object(ff_utils, "get_metadata") as mock_get_metadata:
+                with mock.patch.object(ff_utils, "authorized_request") as mock_authorized_request:
+                    with mock.patch.object(jh_utils, "search_metadata") as mock_search_metadata:
+
+                        mock_get_metadata.side_effect = mocked_get_metadata
+                        mock_authorized_request.side_effect = mocked_authorized_request
+                        mock_search_metadata.side_effect = mocked_search_metadata
+
+                        with pytest.raises(Exception, match=re.escape(NOT_AN_ID_ERROR_MESSAGE)):
+                            jh_utils.find_valid_file_or_extra_file(NOT_AN_ID, None)
+
+                        with pytest.raises(Exception, match=re.escape(NOT_VALID_FILE_ERROR_MESSAGE)):
+                            jh_utils.find_valid_file_or_extra_file(BIOSAMPLE_ITEM_0_UUID, None)
+
+                        result = jh_utils.find_valid_file_or_extra_file(FILE_ITEM_0_UUID, None)
+                        assert sorted(result.keys()) == ['full_href', 'full_path', 'metadata']
+                        assert result['metadata'] == FILE_ITEM_0
+                        assert result['full_href'].startswith('http')  # either http or https, depending...
+                        assert result['full_href'].endswith(FILE_ITEM_0['href'])
+                        assert result['full_path'].startswith('/home')  # the dirname is a wired constant of jh_utils :(
+                        assert result['full_href'].endswith(FILE_ITEM_0['href'])
+
+                        extra_format = FILE_ITEM_0_EXTRA_FILE['file_format']['display_title']
+                        result = jh_utils.find_valid_file_or_extra_file(FILE_ITEM_0_UUID, format=extra_format)
+                        assert sorted(result.keys()) == ['full_href', 'full_path', 'metadata']
+                        assert result['metadata'] == FILE_ITEM_0
+                        assert sorted(result.keys()) == ['full_href', 'full_path', 'metadata']
+                        assert result['metadata'] == FILE_ITEM_0
+                        assert result['full_href'].startswith('http')  # either http or https, depending...
+                        assert result['full_href'].endswith(FILE_ITEM_0_EXTRA_FILE['href'])
+                        assert result['full_path'].startswith('/home')  # the dirname is a wired constant of jh_utils :(
+                        assert result['full_href'].endswith(FILE_ITEM_0_EXTRA_FILE['href'])
+
+                        with pytest.raises(Exception, match="invalid file format"):
+                            jh_utils.find_valid_file_or_extra_file(FILE_ITEM_0_UUID, 'not_a_format')
+
+
+@pytest.mark.unit
+def test_jh_open_4dn_file_unit(integrated_ff):
+
+    # This setup isn't good for a unit test, but right now we can't load jh_utils otherwise. -kmp 15-Feb-2021
+    test_server = integrated_ff['ff_key']['server']
+    initialize_jh_env(test_server)
+    from dcicutils import jh_utils
+
+    def mocked_get_metadata(obj_id):
+        if obj_id == NOT_AN_ID:
+            raise Exception(NOT_AN_ID_ERROR_MESSAGE)
+        elif obj_id == BIOSAMPLE_ITEM_0_UUID:
+            return BIOSAMPLE_ITEM_0
+        elif obj_id == FILE_ITEM_0_UUID:
+            return FILE_ITEM_0
+        else:
+            raise NotImplementedError("mocked_authorized_request mock shortfall.")
+
+    def mocked_search_metadata(*args, **kwargs):
+        raise NotImplementedError()
+
+    def mocked_authorized_request(url, *args, **kwargs):
+        if url.endswith("/" + NOT_AN_ID):
+            return MockResponse(404, json={'message': NOT_AN_ID_ERROR_MESSAGE})
+        elif url.endswith("/" + BIOSAMPLE_ITEM_0_UUID):
+            return MockResponse(200, json=BIOSAMPLE_ITEM_0)
+        elif url.endswith("/" + FILE_ITEM_0_UUID):
+            return MockResponse(200, json=FILE_ITEM_0)
+        else:
+            raise NotImplementedError("mocked_authorized_request mock shortfall.")
+
+    mfs = MockFileSystem()
+    with mock.patch("builtins.open", mfs.open):
+        with mock.patch("os.path.exists", mfs.exists):
+            with mock.patch.object(ff_utils, "get_metadata") as mock_get_metadata:
+                with mock.patch.object(ff_utils, "authorized_request") as mock_authorized_request:
+                    with mock.patch.object(jh_utils, "search_metadata") as mock_search_metadata:
+
+                        mock_get_metadata.side_effect = mocked_get_metadata
+                        mock_authorized_request.side_effect = mocked_authorized_request
+                        mock_search_metadata.side_effect = mocked_search_metadata
+
+                        with pytest.raises(Exception, match=re.escape(NOT_AN_ID_ERROR_MESSAGE)):
+                            with jh_utils.open_4dn_file(NOT_AN_ID):
+                                pass
+
+                        with pytest.raises(Exception, match=re.escape(NOT_VALID_FILE_ERROR_MESSAGE)):
+                            with jh_utils.open_4dn_file(BIOSAMPLE_ITEM_0_UUID):
+                                pass
+
+                        with pytest.raises(Exception, match="404: Not Found"):
+                            with jh_utils.open_4dn_file(FILE_ITEM_0_UUID, local=False):
+                                pass
+
+                        with pytest.raises(Exception, match="404: Not Found"):
+                            extra_format = FILE_ITEM_0_EXTRA_FILE['file_format']['display_title']
+                            with jh_utils.open_4dn_file(FILE_ITEM_0_UUID, format=extra_format, local=False):
+                                pass
+
+                        with pytest.raises(Exception, match="invalid file format"):
+                            with jh_utils.open_4dn_file(FILE_ITEM_0_UUID, format='not_a_format', local=False):
+                                pass
+
+                        with pytest.raises(Exception, match="No such file or directory"):
+                            with jh_utils.open_4dn_file(FILE_ITEM_0_UUID, local=True):
+                                pass
+
+
+@pytest.mark.integratedx
+def test_jh_open_4dn_file_integrated(integrated_ff):
     # this is tough because uploaded files don't actually exist on mastertest s3
     # so, this test pretty much assumes urllib will work for actually present
     # files and will just test the exceptions for now
@@ -72,16 +291,16 @@ def test_jh_open_4dn_file(integrated_ff):
     initialize_jh_env(test_server)
     from dcicutils import jh_utils
     with pytest.raises(Exception) as exec_info:
-        with jh_utils.open_4dn_file('not_an_id', local=False) as f:  # NOQA
+        with jh_utils.open_4dn_file(NOT_AN_ID, local=False) as f:  # NOQA
             pass
-    assert 'Could not open file: not_an_id' in str(exec_info.value)
+    assert NOT_AN_ID_ERROR_MESSAGE in str(exec_info.value)
     # use non-file metadata
     search_bios_res = jh_utils.search_metadata('search/?type=Biosample')
     assert len(search_bios_res) > 0
     with pytest.raises(Exception) as exec_info2:
         with jh_utils.open_4dn_file(search_bios_res[0]['uuid'], local=False) as f:  # NOQA
             pass
-    assert 'not a valid file object' in str(exec_info2.value)
+    assert NOT_VALID_FILE_ERROR_MESSAGE in str(exec_info2.value)
     # get real file metadata
     search_file_res = jh_utils.search_metadata('search/?status=uploaded&type=File&extra_files.href!=No+value')
     assert len(search_file_res) > 0

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -20,7 +20,7 @@ from dcicutils.misc_utils import (
     keyword_as_title, file_contents, CachedField, camel_case_to_snake_case, snake_case_to_camel_case, make_counter,
     CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json, url_path_join,
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
-    DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, reversed,
+    DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association,
     ancestor_classes, is_proper_subclass, decorator
 )
 from dcicutils.qa_utils import (
@@ -1310,22 +1310,6 @@ def test_check_true():
     assert msg in str(e)
 
 
-def test_reversed():
-
-    x = [10, 20, 30]
-    y = reversed(x)
-
-    assert x is not y
-    assert x == [10, 20, 30]
-    assert y == [30, 20, 10]
-
-    y = reversed(y)
-    assert x is not y
-    assert x == y
-    assert x == [10, 20, 30]
-    assert y == [10, 20, 30]
-
-
 def test_remove_element():
 
     old = ['a', 'b', 'c', 'a', 'b', 'c']
@@ -1443,10 +1427,6 @@ def test_constantly():
     assert five(13) == 5
     assert five(nobody='cares') == 5
     assert five(0, 1, 2, fourth=3, fifth=4) == 5
-
-    assert str(five) == "constantly(5)"
-    assert repr(five) == "constantly(5)"
-    assert five.__doc__ == "A function that always returns a constant value: 5"
 
     assert five() + five() == 10
 


### PR DESCRIPTION
For `jh_utils`:

* I wrote a unit test for `open_4dn_file` that can replace the integration test (which I've marked `integrationx` so it won't run normally among the unit tests). This fixes one of the several failing tests mentioned in [Several unit tests in dcicutils are failing when nothing has changed (C4-601)](https://hms-dbmi.atlassian.net/browse/C4-601).
* I wrote a new unit test for `find_valid_file_or_extra_file`.

For `misc_utils`:

* New function `ignorable` which is basically a synonym for `ignore`, but with the sense that it's OK for the variables given as its arguments to be used elsewhere or not.
* New function `ancestor_classes` that returns a list of the classes from which a given class inherits.
* New function `is_proper_subclass` which is like `issubclass` but returns true only if its two arguments are not the same.
* New function `identity` that returns its argument.
* New functions `count` and `count_if` for counting things in a sequence.
* New function `find_association` for finding 
* New `@decorator` decorator for defining--what else?--decorators, specifically addressing the `@foo` vs `@foo()` issue.
