### PR TITLE
Fix ControlledTime.utcnow on AWS (C4-623)

### DIFF
--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -129,7 +129,7 @@ LOCAL_TIMEZONE_MAPPINGS = {
 }
 
 
-def guess_local_timezone_for_testing():
+def guess_local_timezone_for_testing() -> pytz.tzinfo:
     # Figuring out the actual local timezone from Python is much discussed on Stackoverflow and elsehwere
     # and there are no perfect solutions. It's a complicated topic. But mostly we need to be able to distinguish
     # local testing at HMS and remote testing on AWS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.11.0.1b0"
+version = "1.11.0.2b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.11.0.2b0"
+version = "1.11.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.11.0"
+version = "1.11.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -11,7 +11,7 @@ import time
 import uuid
 
 from dcicutils import qa_utils
-from dcicutils.misc_utils import Retry, PRINT, file_contents
+from dcicutils.misc_utils import Retry, PRINT, file_contents, REF_TZ
 from dcicutils.qa_utils import (
     mock_not_called, local_attrs, override_environ, override_dict, show_elapsed_time, timed,
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom, MockUUIDModule,
@@ -281,7 +281,7 @@ def test_override_environ():
     assert unique_prop3 not in os.environ
 
 
-class MockLocalTimezone:
+class MockLocalTimezone:  # Technically should return pytz.tzinfo but doesn't
 
     def __init__(self, summer_tz, winter_tz):
         self._summer_tz = summer_tz
@@ -295,6 +295,14 @@ class MockLocalTimezone:
             return self._summer_tz
         else:
             return self._winter_tz
+
+
+def test_guess_local_timezone_for_testing_contextually():
+
+    if platform.system() == 'Darwin':
+        assert guess_local_timezone_for_testing() == REF_TZ
+    else:
+        assert guess_local_timezone_for_testing() == pytz.UTC
 
 
 def test_guess_local_timezone_for_testing():

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -385,8 +385,6 @@ def test_controlled_time_utcnow_with_tz():
 
 def test_controlled_time_utcnow():
 
-    hour = 60 * 60  # 60 seconds * 60 minutes
-
     # This doesn't test that we resolve the timezone correclty, just that if we use a given timezone, it works.
     # We've picked a timezone where daylight time is not likely to be in play.
     local_time = guess_local_timezone_for_testing()
@@ -396,8 +394,7 @@ def test_controlled_time_utcnow():
     t1 = t.now()     # initial time + 1 second
     t.set_datetime(t0)
     t2 = t.utcnow()  # initial time UTC + 1 second
-    # US/Eastern on 2020-01-01 is not daylight time, so EST (-0500) not EDT (-0400).
-    assert (t2 - t1).total_seconds() == 5 * hour
+    # This might be 5 hours in US/Eastern at HMS or it might be 0 hours in UTC on AWS or GitHub Actions.
     assert (t2 - t1).total_seconds() == abs(local_time.utcoffset(t0).total_seconds())
 
 

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -1,11 +1,11 @@
-import boto3
 import contextlib
 import datetime
 import io
 import pytest
 
 from dcicutils import s3_utils as s3_utils_module
-from dcicutils.qa_utils import ignored, override_environ, MockBoto3, MockFileSystem
+from dcicutils.misc_utils import ignored, ignorable
+from dcicutils.qa_utils import override_environ, MockBoto3
 from dcicutils.s3_utils import s3Utils
 from dcicutils.beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env, compute_cgap_stg_env
 from dcicutils.env_utils import get_standard_mirror_env, FF_PUBLIC_URL_STG, FF_PUBLIC_URL_PRD, CGAP_PUBLIC_URL_PRD
@@ -394,6 +394,7 @@ def test_get_file_size_integrated(integrated_s3_info):
         integrated_s3_info['s3Obj'].get_file_size('not_a_file')
     assert 'not found' in str(exec_info.value)
 
+
 @pytest.mark.unit
 def test_get_file_size_unit(integrated_names):
 
@@ -436,6 +437,7 @@ def test_size_unit(integrated_names):
 
         # When bucket doesn't exist, we expect an error
         with pytest.raises(Exception, match='.*NoSuchBucket.*') as exec_info:
+            ignorable(exec_info)
             s3_connection.size('not_a_bucket')
 
 


### PR DESCRIPTION
Per [C4-623](https://hms-dbmi.atlassian.net/browse/C4-623), `ControlledTime.utcnow()` was broken on AWS because it presumed that the local time was Eastern time, rather than checking, so it was unconditionally subtracting 4 or 5 hours rather than doing the right math. (This resulted in some failures in CGAP tests I was trying to write.)

In this fix, we change `ControlledTime.utcnow()` to guess the local timezone better.

There are PEP8-only changes to `ff_utils` here, too. (They were the only syntax errors in the repo that `flake8` was calling out.)