### PR TITLE
Fixes to env_utils.data_set_for_env for CGAP (C4-634)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,24 @@ Change Log
 ----------
 
 
+1.11.2
+======
+
+**PR 134: Fixes to env_utils.data_set_for_env for CGAP**
+
+* Fix ``env_utils.data_set_for_env`` which were returning ``'test'``
+  for ``fourfront-cgapwolf`` and ``fourfront-cgaptest``.
+  Oddly, the proper value is ``'prod'``.
+
+
+1.11.1
+======
+
+**PR 133: Fix ControlledTime.utcnow on AWS (C4-623)**
+
+* Fix ``qa_utils.ControlledTime.utcnow`` on AWS (C4-623).
+
+
 1.11.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 1.11.2
 ======
 
-**PR 134: Fixes to env_utils.data_set_for_env for CGAP**
+**PR 134: Fixes to env_utils.data_set_for_env for CGAP (C4-634)**
 
 * Fix ``env_utils.data_set_for_env`` which were returning ``'test'``
   for ``fourfront-cgapwolf`` and ``fourfront-cgaptest``.

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -141,12 +141,12 @@ BEANSTALK_DEV_DATA_SETS = {
     'fourfront-webdev': 'prod',
 
     'fourfront-cgapdev': 'test',
-    'fourfront-cgaptest': 'test',
-    'fourfront-cgapwolf': 'test',
+    'fourfront-cgaptest': 'prod',
+    'fourfront-cgapwolf': 'prod',
 
     'cgap-dev': 'test',
-    'cgap-test': 'test',
-    'cgap-wolf': 'test',
+    'cgap-test': 'prod',
+    'cgap-wolf': 'prod',
 
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.11.1"
+version = "1.11.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/ini_files/cgaptest.ini
+++ b/test/ini_files/cgaptest.ini
@@ -21,7 +21,7 @@ indexer.namespace = fourfront-cgaptest
 index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
-load_test_data = encoded.loadxl:load_test_data
+load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 
 [composite:indexer]

--- a/test/ini_files/cgapwolf.ini
+++ b/test/ini_files/cgapwolf.ini
@@ -21,7 +21,7 @@ indexer.namespace = fourfront-cgapwolf
 index_server = ${INDEX_SERVER}
 elasticsearch.aws_auth = true
 production = true
-load_test_data = encoded.loadxl:load_test_data
+load_test_data = encoded.loadxl:load_prod_data
 sqlalchemy.url = postgresql://${RDS_USERNAME}:${RDS_PASSWORD}@${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 
 [composite:indexer]

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -676,37 +676,51 @@ def test_deployment_utils_transitional_equivalence():
                     # Fourfront uses data_set='prod' for everything but 'fourfront-mastertest',
                     # which uses data_set='test'
 
-                    tester(ref_ini="blue.ini", bs_env="fourfront-blue", data_set="prod",
+                    bs_env = "fourfront-blue"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="blue.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.%s" % us_east,
                            line_checker=FFProdChecker(expect_indexer=index_default,
                                                       expect_index_server=index_server_default))
 
-                    tester(ref_ini="green.ini", bs_env="fourfront-green", data_set="prod",
+                    bs_env = "fourfront-green"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="green.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-green-cghpezl64x4uma3etijfknh7ja.%s" % us_east,
                            line_checker=FFProdChecker(expect_indexer=index_default,
                                                       expect_index_server=index_server_default))
 
-                    tester(ref_ini="hotseat.ini", bs_env="fourfront-hotseat", data_set="prod",
+                    bs_env = "fourfront-hotseat"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="hotseat.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-hotseat-f3oxd2wjxw3h2wsxxbcmzhhd4i.%s" % us_east,
                            line_checker=Checker(expect_indexer=index_default,
                                                 expect_index_server=index_server_default))
 
-                    tester(ref_ini="mastertest.ini", bs_env="fourfront-mastertest", data_set="test",
+                    bs_env = "fourfront-mastertest"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="mastertest.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.%s" % us_east,
                            line_checker=Checker(expect_indexer=index_default,
                                                 expect_index_server=index_server_default))
 
-                    tester(ref_ini="webdev.ini", bs_env="fourfront-webdev", data_set="prod",
+                    bs_env = "fourfront-webdev"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="webdev.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.%s" % us_east,
                            line_checker=Checker(expect_indexer=index_default,
                                                 expect_index_server=index_server_default))
 
-                    tester(ref_ini="webprod.ini", bs_env="fourfront-webprod", data_set="prod",
+                    bs_env = "fourfront-webprod"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="webprod.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.%s" % us_east,
                            line_checker=FFProdChecker(expect_indexer=index_default,
                                                       expect_index_server=index_server_default))
 
-                    tester(ref_ini="webprod2.ini", bs_env="fourfront-webprod2", data_set="prod",
+                    bs_env = "fourfront-webprod2"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="webprod2.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.%s" % us_east,
                            line_checker=FFProdChecker(expect_indexer=index_default,
                                                       expect_index_server=index_server_default))

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -14,7 +14,7 @@ from dcicutils.deployment_utils import (
     # TODO: This isn't yet tested.
     # EBDeployer,
 )
-from dcicutils.env_utils import is_cgap_env
+from dcicutils.env_utils import is_cgap_env, data_set_for_env
 from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ
 
@@ -638,28 +638,37 @@ def test_deployment_utils_transitional_equivalence():
                                     return "'%s' missing in '%s'" % (fragment, line)
                             self.check_any(line)
 
-                    # CGAP uses data_set='prod' for 'fourfront-cgap' and data_set='test' for all others.
+                    # CGAP uses data_set='prod' for everything but 'fourfront-cgapdev', which uses 'test'.
+                    # But that logic is hidden in data_set_for_env, in case it changes.
 
                     us_east = "us-east-1.es.amazonaws.com:80"
                     index_default = "true"
                     index_server_default = None
 
-                    tester(ref_ini="cgap.ini", bs_env="fourfront-cgap", data_set="prod",
+                    bs_env = "fourfront-cgap"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="cgap.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
                            line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                         expect_index_server=index_server_default))
 
-                    tester(ref_ini="cgapdev.ini", bs_env="fourfront-cgapdev", data_set="test",
+                    bs_env = "fourfront-cgapdev"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="cgapdev.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.%s" % us_east,
                            line_checker=Checker(expect_indexer=index_default,
                                                 expect_index_server=index_server_default))
 
-                    tester(ref_ini="cgaptest.ini", bs_env="fourfront-cgaptest", data_set="test",
+                    bs_env = "fourfront-cgaptest"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="cgaptest.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.%s" % us_east,
                            line_checker=Checker(expect_indexer=index_default,
                                                 expect_index_server=index_server_default))
 
-                    tester(ref_ini="cgapwolf.ini", bs_env="fourfront-cgapwolf", data_set="test",
+                    bs_env = "fourfront-cgapwolf"
+                    data_set = data_set_for_env(bs_env)
+                    tester(ref_ini="cgapwolf.ini", bs_env=bs_env, data_set=data_set,
                            es_server="search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.%s" % us_east,
                            line_checker=Checker(expect_indexer=index_default,
                                                 expect_index_server=index_server_default))

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -80,14 +80,14 @@ def test_data_set_for_env():
 
     assert data_set_for_env('fourfront-cgap') == 'prod'
     assert data_set_for_env('fourfront-cgapdev') == 'test'
-    assert data_set_for_env('fourfront-cgaptest') == 'test'
-    assert data_set_for_env('fourfront-cgapwolf') == 'test'
+    assert data_set_for_env('fourfront-cgaptest') == 'prod'  # oddly, yes, not a typo
+    assert data_set_for_env('fourfront-cgapwolf') == 'prod'  # same
 
     assert data_set_for_env('cgap-blue') == 'prod'
     assert data_set_for_env('cgap-green') == 'prod'
     assert data_set_for_env('cgap-dev') == 'test'
-    assert data_set_for_env('cgap-test') == 'test'
-    assert data_set_for_env('cgap-wolf') == 'test'
+    assert data_set_for_env('cgap-test') == 'prod'  # see above
+    assert data_set_for_env('cgap-wolf') == 'prod'  # see above
 
 
 def test_public_url_mappings():


### PR DESCRIPTION
Per [dcicutils.env_utils.data_set_for_env returns some wrong values on cgap (C4-634)](https://hms-dbmi.atlassian.net/browse/C4-634), this fixes the function `dcicutils.env_utils.data_set_for_env ` to return what I _think_ are the right values for the `fourfront-cgaptest` and `fourfront-cgapwolf` environments.

@willronchetti, please confirm the choice of values--changed to `prod` instead of `test` to affect what gets loaded by default in `any.ini` after processing by the ini file generator. (To me they seems somewhat arbitrary, which is why this function exists. But it makes it hard for me to know what's right. It's more a property of what people are used to, it seems, than of any principled correspondence. The rationale for why I did what I did is on [the ticket](https://hms-dbmi.atlassian.net/browse/C4-634).