### PR TITLE
Add ES cluster resize capability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,25 @@ dcicutils
 Change Log
 ----------
 
+1.14.1
+======
+
+**PR 139: Add ES cluster resize capability
+
+* Adds ElasticSearchServiceClient, a wrapper for boto3.client('es')
+* Implements resize_elasticsearch_cluster, issuing an update to the relevant settings
+* Integrated test was performed on staging
+* Unit tests mock the boto3 API
+
+
+1.14.0
+======
+
+**PR 137: Docker, ECR, ECS Utils
+
+* Adds 3 new modules with basic functionality needed for further development on the alpha stack
+* Deprecates Python 3.4
+
 
 1.13.0
 ======
@@ -87,7 +106,7 @@ Change Log
 1.10.0
 ======
 
-**PR 131: Misc functionality in service of C4-183** 
+**PR 131: Misc functionality in service of C4-183**
 
 * In ``dcicutils.misc_utils``:
 
@@ -151,8 +170,8 @@ Those tests were refactored, and the following additional support was added:
 
 **PR 126: C4-503 Grab Environment API**
 
-* Adds get_beanstalk_environment_variables, which will return information 
-  necessary to simulate any application given the caller has the appropriate 
+* Adds get_beanstalk_environment_variables, which will return information
+  necessary to simulate any application given the caller has the appropriate
   access keys.
 * Removes an obsolete tag from create_db_snapshot, which was set erroneously.
 

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -26,8 +26,8 @@ class ElasticSearchServiceClient:
     DEFAULT_COLD_DATA_NODE_TYPE = 'c5.large.elasticsearch'
     DEFAULT_COLD_DATA_NODE_COUNT = 2
 
-    def __init__(self):
-        self.client = boto3.client('es')
+    def __init__(self, region_name='us-east-1'):
+        self.client = boto3.client('es', region_name=region_name)
 
     def resize_elasticsearch_cluster(self, *, domain_name, master_node_type, master_node_count,
                                      data_node_type, data_node_count=2):

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -18,7 +18,7 @@ class ElasticSearchServiceClient:
      """
     DEFAULT_HOT_MASTER_NODE_TYPE = 'c5.large.elasticsearch'
     DEFAULT_HOT_MASTER_NODE_COUNT = 3
-    DEFAULT_HOT_DATA_NODE_TYPE = 'r5.2xlarge.elasticsearch'
+    DEFAULT_HOT_DATA_NODE_TYPE = 'c5.2xlarge.elasticsearch'
     DEFAULT_HOT_DATA_NODE_COUNT = 2
 
     DEFAULT_COLD_MASTER_NODE_TYPE = 't2.small.elasticsearch'  # does not matter

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -1,4 +1,6 @@
 import logging
+import boto3
+from .misc_utils import PRINT
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
@@ -6,6 +8,64 @@ from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 logging.basicConfig()
 logger = logging.getLogger('logger')
 logger.setLevel(logging.INFO)
+
+
+class ElasticSearchServiceClient:
+    """ Implements utilities for interacting with the Amazon ElasticSearch Service.
+        The idea is, for the production setup, we implement a hot/cold cluster configuration where
+        during the day (say 6 am to 8 pm EST) we run a larger cluster than at night/on
+        weekends. Foursight will implement this mechanism.
+     """
+    DEFAULT_HOT_MASTER_NODE_TYPE = 'c5.large.elasticsearch'
+    DEFAULT_HOT_MASTER_NODE_COUNT = 3
+    DEFAULT_HOT_DATA_NODE_TYPE = 'r5.2xlarge.elasticsearch'
+    DEFAULT_HOT_DATA_NODE_COUNT = 2
+
+    DEFAULT_COLD_MASTER_NODE_TYPE = 't2.small.elasticsearch'  # does not matter
+    DEFAULT_COLD_MASTER_NODE_COUNT = 0
+    DEFAULT_COLD_DATA_NODE_TYPE = 'c5.large.elasticsearch'
+    DEFAULT_COLD_DATA_NODE_COUNT = 2
+
+    def __init__(self):
+        self.client = boto3.client('es')
+
+    def resize_elasticsearch_cluster(self, *, domain_name, master_node_type, master_node_count,
+                                     data_node_type, data_node_count=2):
+        """ Triggers a resizing of the given cluster name (the env name).
+
+        :param domain_name: name of domain we'd like to resize
+        :param master_node_type: instance type we'd like to use for master nodes
+        :param master_node_count: number of master nodes (disabled if 0)
+        :param data_node_type: instance type we'd like to use for data nodes
+        :param data_node_count: # of data nodes, 2 by default
+        :return: True if successful, False otherwise
+        """
+        config = {
+            'InstanceType': data_node_type,
+            'InstanceCount': data_node_count,
+            'DedicatedMasterEnabled': False,
+        }
+        if master_node_count:
+            config.update({
+                'DedicatedMasterEnabled': True,
+                'DedicatedMasterType': master_node_type,
+                'DedicatedMasterCount': master_node_count
+            })
+        try:
+            response = self.client.update_elasticsearch_domain_config(
+                DomainName=domain_name,
+                ElasticsearchClusterConfig=config
+            )['ResponseMetadata']
+            response_is_ok = response['HTTPStatusCode'] == 200
+            if not response_is_ok:
+                PRINT('Could not trigger cluster resize: %s' % response)
+                return False
+            return True
+        except KeyError as e:
+            PRINT('Got unexpected response structure from AWS: %s' % e)
+        except Exception as e:
+            PRINT('Got an unhandled error from boto3: %s' % e)
+        return False
 
 
 def create_es_client(es_url, use_aws_auth=True, **options):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.14.0"
+version = "1.14.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Adds `ElasticSearchServiceClient`, a wrapper for `boto3.client('es')`
- Implements `resize_elasticsearch_cluster`, issuing an update to the relevant settings
- Integrated test was performed on staging
- Unit tests mock the boto3 API