### PR TITLE
Port Application Dockerization utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,15 @@ dcicutils
 Change Log
 ----------
 
+1.16.1
+======
+
+** PR 141 Port Application Dockerization utils
+
 1.16.0
 ======
 
-**PR 141: Move override_environ and override_dict to misc_utils**
+**PR 142: Move override_environ and override_dict to misc_utils**
 
 * In ``misc_utils``:
 

--- a/dcicutils/cloudformation_utils.py
+++ b/dcicutils/cloudformation_utils.py
@@ -1,0 +1,17 @@
+import boto3
+from .misc_utils import PRINT
+
+
+def get_ecs_real_url(env):
+    """ Grabs the ECS target URL created on orchestration from Cloudformation.
+        NOTE: this is not intended to function with multiple ECS stacks in the
+        same account as of right now.
+    """
+    cfn_client = boto3.client('cloudformation')
+    stacks = cfn_client.describe_stacks().get('Stacks', [])
+    for stack in stacks:
+        for output in stack['Outputs']:
+            if output.get('OutputKey', '') == ('ECSApplicationURL%s' % env.replace('-', '')):
+                return output.get('OutputValue')
+    PRINT('Did not locate the server from Cloudformation! Check ECS Stack metadata.')
+    return ''

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -33,7 +33,7 @@ class ECSUtils:
         try:
             self.client.update_service(cluster=cluster_name, service=service_name,
                                        forceNewDeployment=True)
-            PRINT('Successfully updated ECS cluster %s service %s' % cluster_name, service_name)
+            PRINT('Successfully updated ECS cluster %s service %s' % (cluster_name, service_name))
         except Exception as e:
             PRINT('Error encountered triggering cluster update: %s' % e)
             raise

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -9,11 +9,11 @@ class ECSUtils:
     """
 
     def __init__(self):
-        """ Cluster name in this case is the env name """
+        """ Creates a boto3 client for 'ecs'. """
         self.client = boto3.client('ecs', region_name=CGAP_ECS_REGION)  # same as ECR
 
     def list_ecs_clusters(self):
-        """ Returns a list of ECS clusters + some metadata. """
+        """ Returns a list of ECS clusters ARNs. """
         return self.client.list_clusters().get('clusterArns', [])
 
     def list_ecs_services(self, *, cluster_name):

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -7,39 +7,39 @@ class ECSUtils:
     """ Utility class for interacting with ECS - mostly stubs at this point, but will likely
         expand a lot.
     """
-    WSGI = 'wsgi'  # XXX: might want to be joined with an identifier?
-    INDEXER = 'indexer'
-    INGESTER = 'ingester'
-    SERVICES = [
-        WSGI, INDEXER, INGESTER
-    ]
 
-    def __init__(self, *, cluster_name):
+    def __init__(self):
         """ Cluster name in this case is the env name """
-        self.cluster_name = cluster_name
         self.client = boto3.client('ecs', region_name=CGAP_ECS_REGION)  # same as ECR
 
-    def update_ecs_service(self, *, service_name=WSGI):
+    def list_ecs_clusters(self):
+        """ Returns a list of ECS clusters + some metadata. """
+        return self.client.list_clusters().get('clusterArns', [])
+
+    def list_ecs_services(self, *, cluster_name):
+        """ Returns a list of ECS Service names under the given cluster. There should be 4 of them as of right now -
+            adding more is considered a compatible change.
+        """
+        services = self.client.list_services(cluster=cluster_name).get('serviceArns', [])
+        if len(services) < 4:
+            raise Exception('Environment error! Expected at least 4 services - check that ECS finished orchestrating.')
+        return services
+
+    def update_ecs_service(self, *, cluster_name, service_name):
         """ Forces an update of this cluster's service, by default WSGI (for now)
             It is highly likely we want some variants of this - but will start here.
             Note that this just updates a particular service.
         """
-        if service_name not in self.SERVICES:
-            raise NotImplementedError('Specified service %s is an invalid service!' % service_name)
         try:
-            self.client.update_service(cluster=self.cluster_name, service=service_name,
+            self.client.update_service(cluster=cluster_name, service=service_name,
                                        forceNewDeployment=True)
+            PRINT('Successfully updated ECS cluster %s service %s' % cluster_name, service_name)
         except Exception as e:
             PRINT('Error encountered triggering cluster update: %s' % e)
             raise
 
-    def update_all_services(self):
+    def update_all_services(self, *, cluster_name):
         """ Forces an update of all services on this cluster. """
-        for service_name in self.SERVICES:
-            try:
-                self.client.update_service(cluster=self.cluster_name, service=service_name,
-                                           forceNewDeployment=True)
-                PRINT('Successfully updated ECS cluster %s service %s' % self.cluster_name, service_name)
-            except Exception as e:
-                PRINT('Error encountered triggering cluster update: %s' % e)
-                raise  # abort update right away
+        for service_name in self.list_ecs_services(cluster_name=cluster_name):
+            self.update_ecs_service(cluster_name=cluster_name, service_name=service_name)
+        return True

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -468,3 +468,11 @@ def classify_server_url(url, raise_error=True):
         'environment': environment,
         'is_stg_or_prd': is_stg_or_prd
     }
+
+
+def make_env_name_cfn_compatible(env_name: str) -> str:
+    """ Common IDs in Cloudformation forbid the use of '-', and we don't want to change
+        our environment name formatting so this simple method is provided to document this
+        behavior. ex: cgap-mastertest -> cgapmastertest
+    """
+    return env_name.replace('-', '')

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -1,0 +1,53 @@
+import os
+import boto3
+import json
+from botocore.exceptions import ClientError
+from dcicutils.ecr_utils import CGAP_ECR_REGION
+
+
+def assume_identity():
+    """ Grabs application identity from the secrets manager.
+        Looks for environment variable IDENTITY, which should contain the name of
+        a secret in secretsmanager that is a JSON blob of core configuration information.
+        Default value is current value in the test account. This name should be the
+        name of the environment.
+    """
+    secret_name = os.environ.get('IDENTITY', 'dev/beanstalk/cgap-dev')
+    region_name = CGAP_ECR_REGION  # us-east-1, must match ECR/ECS Region
+    session = boto3.session.Session(region_name=region_name)
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:  # leaving some useful debug info to help narrow issues
+        if e.response['Error']['Code'] == 'DecryptionFailureException':
+            # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+            raise e
+        elif e.response['Error']['Code'] == 'InternalServiceErrorException':
+            # An error occurred on the server side.
+            raise e
+        elif e.response['Error']['Code'] == 'InvalidParameterException':
+            # You provided an invalid value for a parameter.
+            raise e
+        elif e.response['Error']['Code'] == 'InvalidRequestException':
+            # You provided a parameter value that is not valid for the current state of the resource.
+            raise e
+        elif e.response['Error']['Code'] == 'ResourceNotFoundException':
+            raise e
+        else:
+            raise e
+    else:
+        # Decrypts secret using the associated KMS CMK.
+        # Depending on whether the secret is a string or binary, one of these fields will be populated.
+        if 'SecretString' in get_secret_value_response:
+            identity = json.loads(get_secret_value_response['SecretString'])
+        else:
+            raise Exception('Got unexpected response structure from boto3')
+    if not identity:
+        raise Exception('Identity could not be found! Check the secret name.')
+    return identity

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -3,6 +3,15 @@ import boto3
 import json
 from botocore.exceptions import ClientError
 from dcicutils.ecr_utils import CGAP_ECR_REGION
+from dcicutils.misc_utils import PRINT
+
+
+# Environment variable whose value is the name of a secret
+# stored in AWS Secrets Manager that contains the global
+# application configuration. This secret JSON is acquired
+# and returned to the caller. Note that this API can behave differently
+# across AWS Accounts.
+GLOBAL_APPLICATION_CONFIGURATION = 'IDENTITY'
 
 
 def assume_identity():
@@ -12,7 +21,7 @@ def assume_identity():
         Default value is current value in the test account. This name should be the
         name of the environment.
     """
-    secret_name = os.environ.get('IDENTITY', 'dev/beanstalk/cgap-dev')
+    secret_name = os.environ.get(GLOBAL_APPLICATION_CONFIGURATION, 'dev/beanstalk/cgap-dev')
     region_name = CGAP_ECR_REGION  # us-east-1, must match ECR/ECS Region
     session = boto3.session.Session(region_name=region_name)
     client = session.client(
@@ -25,22 +34,15 @@ def assume_identity():
             SecretId=secret_name
         )
     except ClientError as e:  # leaving some useful debug info to help narrow issues
-        if e.response['Error']['Code'] == 'DecryptionFailureException':
-            # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
-            raise e
-        elif e.response['Error']['Code'] == 'InternalServiceErrorException':
-            # An error occurred on the server side.
-            raise e
-        elif e.response['Error']['Code'] == 'InvalidParameterException':
-            # You provided an invalid value for a parameter.
-            raise e
-        elif e.response['Error']['Code'] == 'InvalidRequestException':
-            # You provided a parameter value that is not valid for the current state of the resource.
-            raise e
-        elif e.response['Error']['Code'] == 'ResourceNotFoundException':
-            raise e
-        else:
-            raise e
+        if e.response['Error']['Code'] in [
+            'DecryptionFailureException'  # SM can't decrypt the protected secret text using the provided KMS key.
+            'InternalServiceErrorException',  # An error occurred on the server side.
+            'InvalidParameterException',  # You provided an invalid value for a parameter.
+            'InvalidRequestException',  # Invalid parameter value for the current state of the resource.
+            'ResourceNotFoundException',
+        ]:
+            PRINT('Encountered a known exception trying to acquire secrets.')
+        raise e
     else:
         # Decrypts secret using the associated KMS CMK.
         # Depending on whether the secret is a string or binary, one of these fields will be populated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.15.1"
+version = "1.16.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.16.0"
+version = "1.16.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_cfn_utils.py
+++ b/test/test_cfn_utils.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest import mock
+from dcicutils.cloudformation_utils import get_ecs_real_url
+
+
+class MockedCfnClient():
+    """ Mocks boto3.client('cloudformation').describe_stacks """
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def describe_stacks():
+        return {
+            'Stacks': [
+                {
+                    'Outputs': [
+                        {
+                            'OutputKey': 'Blah1',
+                            'OutputValue': 'Blah1'
+                        },
+                        {
+                            'OutputKey': 'ECSApplicationURLcgaphotseat',
+                            'OutputValue': 'http://dummy-url2.org'
+                        }
+                    ]
+                },
+                {
+                    'Outputs': [
+                        {
+                            'OutputKey': 'Blah2',
+                            'OutputValue': 'Blah2'
+                        },
+                        {
+                            'OutputKey': 'ECSApplicationURLcgapmastertest',
+                            'OutputValue': 'http://dummy-url.org'
+                        }
+                    ]
+                },
+            ]
+        }
+
+
+def test_cfn_utils_get_ecs_real_url():
+    """ Tests get_ecs_real_url using the mocked response above. """
+    with mock.patch('boto3.client', return_value=MockedCfnClient()):
+        real_url = get_ecs_real_url('cgap-mastertest')
+        assert real_url == 'http://dummy-url.org'
+        real_url = get_ecs_real_url('cgapmastertest')
+        assert real_url == 'http://dummy-url.org'
+        real_url = get_ecs_real_url('cgap-hotseat')
+        assert real_url == 'http://dummy-url2.org'
+        real_url = get_ecs_real_url('cgaphotseat')
+        assert real_url == 'http://dummy-url2.org'

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -15,6 +15,7 @@ from dcicutils.env_utils import (
     FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env, classify_server_url,
     full_env_name, full_cgap_env_name, full_fourfront_env_name, is_cgap_server, is_fourfront_server,
+    make_env_name_cfn_compatible,
 )
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
@@ -765,3 +766,13 @@ def test_classify_server_url_other():
         'environment': 'unknown',
         'is_stg_or_prd': False,
     }
+
+
+@pytest.mark.parametrize('env_name, cfn_id', [
+    ('cgap-mastertest', 'cgapmastertest'),
+    ('fourfront-cgap', 'fourfrontcgap'),
+    ('cgap-msa', 'cgapmsa'),
+    ('fourfrontmastertest', 'fourfrontmastertest')
+])
+def test_make_env_name_cfn_compatible(env_name, cfn_id):
+    assert make_env_name_cfn_compatible(env_name) == cfn_id


### PR DESCRIPTION
Adds some additional APIs needed for the ECS setup, including:
- `get_ecs_real_url`, which will extract the URL of the ECS WSGI Service
- `assume_identity`, used by the cgap-portal directly currently to pull environment configuration (see c4_519)