### PR TITLE
Move override_environ and override_dict to misc_utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,37 @@ dcicutils
 Change Log
 ----------
 
+1.16.0
+======
+
+**PR 141: Move override_environ and override_dict to misc_utils**
+
+* In ``misc_utils``:
+
+  * Adds ``override_environ`` and ``override_dict``
+    which were previously defined in ``qa_utils``.
+
+  * Adds new function ``exported`` which is really a synonym
+    for ``ignored`` but highlights the reason for the presence
+    of the named variable is so that other files can still
+    import it.
+
+* In ``qa_utils``:
+
+  * Leaves legacy support for ``override_environ``
+    and ``override_dict``, which are now defined in ``misc_utils``.
+
+
+1.15.1
+======
+
+**PR 138: JH Docker Mount Update**
+
+* In ``jh_utils.find_valid_file_or_extra_file``,
+  account for file metadata containing an
+  ``"open_data_url"``.
+
+
 1.15.0
 ======
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -235,6 +235,33 @@ class VirtualApp:
         return self.wrapped_app.app
 
 
+def exported(*variables):
+    """
+    This function does nothing but is used for declaration purposes.
+    It is useful for the situation where one module imports names from another module merely to allow
+    functions in another module to import them, usually for legacy compatibility.
+    Otherwise, the import might look unnecessary.
+    e.g.,
+
+    ---file1.py---
+    def identity(x):
+        return x
+
+    ---file2.py---
+    from .file1 import identity
+    from dcicutils.misc_utils import exported
+
+    # This function used to be defined here, but now is defined in file1.py
+    exported(identity)
+
+    ---file3.py---
+    # This file has not been updated to realize that file1.py is the new home of identity.
+    from .file2 import identity
+    print("one=", identity(1))
+    """
+    ignored(variables)
+
+
 def ignored(*args, **kwargs):
     """
     This is useful for defeating flake warnings.
@@ -856,6 +883,48 @@ def environ_bool(var, default=False):
         return default
     else:
         return os.environ[var].lower() == "true"
+
+
+@contextlib.contextmanager
+def override_environ(**overrides):
+    """
+    Overrides os.environ for the dynamic extent of the call, using the specified values.
+    A value of None means to delete the property temporarily.
+    (This uses override_dict to do the actual overriding. See notes for that function about lack of thread safety.)
+    """
+    with override_dict(os.environ, **overrides):
+        yield
+
+
+@contextlib.contextmanager
+def override_dict(d, **overrides):
+    """
+    Overrides the given dictionary for the dynamic extent of the call, using the specified values.
+    A value of None means to delete the property temporarily.
+
+    This function is not threadsafe because it dynamically assigns and de-assigns parts of a dictionary.
+    It should be reserved for use in test functions or command line tools or other contexts that are known
+    to be single-threaded, or at least not competing for the resource of the dictionary. (It would be threadsafe
+    to use a dictionary that is only owned by the current process.)
+    """
+    to_delete = []
+    to_restore = {}
+    try:
+        for k, v in overrides.items():
+            if k in d:
+                to_restore[k] = d[k]
+            else:
+                to_delete.append(k)
+            if v is None:
+                d.pop(k, None)  # Delete key k, tolerating it being already gone
+            else:
+                d[k] = v
+        yield
+    finally:
+        for k in to_delete:
+            d.pop(k, None)  # Delete key k, tolerating it being already gone
+        for k, v in to_restore.items():
+            d[k] = v
 
 
 def check_true(test_value, message, error_class=None):

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -16,7 +16,7 @@ import toml
 import uuid
 import warnings
 
-from dcicutils.misc_utils import environ_bool
+from dcicutils.misc_utils import environ_bool, exported, override_environ, override_dict
 from json import dumps as json_dumps, loads as json_loads
 from unittest import mock
 from .misc_utils import PRINT, ignored, Retry, CustomizableProperty, getattr_customized, remove_prefix, REF_TZ
@@ -95,32 +95,7 @@ def local_attrs(obj, **kwargs):
             setattr(obj, key, saved[key])
 
 
-@contextlib.contextmanager
-def override_environ(**overrides):
-    with override_dict(os.environ, **overrides):
-        yield
-
-
-@contextlib.contextmanager
-def override_dict(d, **overrides):
-    to_delete = []
-    to_restore = {}
-    try:
-        for k, v in overrides.items():
-            if k in d:
-                to_restore[k] = d[k]
-            else:
-                to_delete.append(k)
-            if v is None:
-                d.pop(k, None)  # Delete key k, tolerating it being already gone
-            else:
-                d[k] = v
-        yield
-    finally:
-        for k in to_delete:
-            d.pop(k, None)  # Delete key k, tolerating it being already gone
-        for k, v in to_restore.items():
-            d[k] = v
+exported(override_environ, override_dict)
 
 
 LOCAL_TIMEZONE_MAPPINGS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.15.1"
+version = "1.16.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -1,7 +1,7 @@
-import pytest
 from unittest import mock
 from dcicutils.ecr_utils import ECRUtils
 from dcicutils.docker_utils import DockerUtils
+from dcicutils.misc_utils import ignored
 
 
 REPO_URL = '123456789.dkr.ecr.us-east-2.amazonaws.com/cgap-mastertest'  # dummy URL
@@ -15,6 +15,7 @@ def mocked_describe_respositories():
 
 
 def mocked_ecr_login(*, username, password, registry):
+    ignored(username, password, registry)
     return
 
 

--- a/test/test_ecs_utils.py
+++ b/test/test_ecs_utils.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest import mock
 from dcicutils.ecs_utils import ECSUtils
+from dcicutils.misc_utils import ignored
 
 
 @pytest.fixture(scope='module')
@@ -8,10 +9,11 @@ def ecs_utils():
     return ECSUtils(cluster_name='dummy-cluster')
 
 
-def mock_update_service(*, cluster, service, forceNewDeployment):
+def mock_update_service(*, cluster, service, forceNewDeployment):  # noQA - AWS chose mixed case argument name
     """ Mock matching the relevant API signature for below (we don't actually want
         to trigger an ECS deploy in unit testing.
     """
+    ignored(cluster, service, forceNewDeployment)
     return
 
 
@@ -29,4 +31,3 @@ def test_ecs_utils_basic_should_proceed(ecs_utils, service_name):
 def test_ecs_utils_basic_should_fail(ecs_utils, service_name):
     with pytest.raises(Exception):
         ecs_utils.update_ecs_service(service_name=service_name)
-

--- a/test/test_es_utils.py
+++ b/test/test_es_utils.py
@@ -2,7 +2,9 @@ import pytest
 from unittest import mock
 from dcicutils.qa_utils import timed
 from dcicutils.ff_utils import get_es_metadata
-from dcicutils.es_utils import create_es_client, execute_lucene_query_on_es, get_bulk_uuids_embedded, ElasticSearchServiceClient
+from dcicutils.es_utils import (
+    create_es_client, execute_lucene_query_on_es, get_bulk_uuids_embedded, ElasticSearchServiceClient,
+)
 
 
 class TestElasticSearchServiceClient:

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -9,6 +9,7 @@ import pytz
 import random
 import re
 import time
+import uuid
 import warnings
 import webtest
 
@@ -21,10 +22,10 @@ from dcicutils.misc_utils import (
     CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json, url_path_join,
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
-    ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri
+    ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict
 )
 from dcicutils.qa_utils import (
-    Occasionally, ControlledTime, override_environ, MockFileSystem, printed_output, raises_regexp
+    Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp
 )
 from unittest import mock
 
@@ -1350,32 +1351,32 @@ def test_rate_manager():
 
 def test_environ_bool():
 
-    with override_environ(FOO=None):
+    with qa_override_environ(FOO=None):
         assert environ_bool("FOO") is False
         assert environ_bool("FOO", default=None) is None
         assert environ_bool("FOO", None) is None
 
-    with override_environ(FOO="TRUE"):
+    with qa_override_environ(FOO="TRUE"):
         assert environ_bool("FOO") is True
         assert environ_bool("FOO", default=None) is True
         assert environ_bool("FOO", None) is True
 
-    with override_environ(FOO="TrUe"):  # Actually, any case should work
+    with qa_override_environ(FOO="TrUe"):  # Actually, any case should work
         assert environ_bool("FOO") is True
         assert environ_bool("FOO", default=None) is True
         assert environ_bool("FOO", None) is True
 
-    with override_environ(FOO="FALSE"):
+    with qa_override_environ(FOO="FALSE"):
         assert environ_bool("FOO") is False
         assert environ_bool("FOO", default=None) is False
         assert environ_bool("FOO", None) is False
 
-    with override_environ(FOO="anything"):
+    with qa_override_environ(FOO="anything"):
         assert environ_bool("FOO") is False
         assert environ_bool("FOO", default=None) is False
         assert environ_bool("FOO", None) is False
 
-    with override_environ(FOO=""):
+    with qa_override_environ(FOO=""):
         assert environ_bool("FOO") is False
         assert environ_bool("FOO", default=None) is False
         assert environ_bool("FOO", None) is False
@@ -2131,7 +2132,8 @@ def test_is_valid_absolute_uri():
 
     assert is_valid_absolute_uri("//somehost/?alpha=1&beta=2") is False
 
-    assert is_valid_absolute_uri("//somehost/?alpha=1&beta=2&colon=:") is False  # Used to wrongly yield True due to ':' in URI
+    # Used to wrongly yield True due to ':' in URI
+    assert is_valid_absolute_uri("//somehost/?alpha=1&beta=2&colon=:") is False
 
     # Scheme provided, but no host. We want absolute URIs.
     #
@@ -2182,8 +2184,134 @@ def test_is_valid_absolute_uri():
 
     # TODO: In the rfc3987 implementation, we allowed tags, but do we really want that? -kmp 20-Apr-2021
 
-    assert is_valid_absolute_uri("foo#alpha") is False  # Used to be False, but only due to lack of ':' in URI, not due to tag
+    # Used to be False, but only due to lack of ':' in URI, not due to tag
+    assert is_valid_absolute_uri("foo#alpha") is False
     assert is_valid_absolute_uri("foo#alpha:beta") is False  # Used to wrongly be True due to ':' in URI
 
     assert is_valid_absolute_uri("http://abc.def/foo#alpha") is True  # TODO: Reconsider tags
     assert is_valid_absolute_uri("http://abc.def/foo#alpha:beta") is True  # TODO: Reconsider tags
+
+
+def test_override_dict():
+
+    d = {'foo': 'bar'}
+    d_copy = d.copy()
+
+    unique_prop1 = str(uuid.uuid4())
+    unique_prop2 = str(uuid.uuid4())
+    unique_prop3 = str(uuid.uuid4())
+
+    assert unique_prop1 not in d
+    assert unique_prop2 not in d
+    assert unique_prop3 not in d
+
+    with override_dict(d, **{unique_prop1: "something", unique_prop2: "anything"}):
+
+        assert unique_prop1 in d  # added
+        value1a = d.get(unique_prop1)
+        assert value1a == "something"
+
+        assert unique_prop2 in d  # added
+        value2a = d.get(unique_prop2)
+        assert value2a == "anything"
+
+        assert unique_prop3 not in d
+
+        with override_dict(d, **{unique_prop1: "something_else", unique_prop3: "stuff"}):
+
+            assert unique_prop1 in d  # updated
+            value1b = d.get(unique_prop1)
+            assert value1b == "something_else"
+
+            assert unique_prop2 in d  # unchanged
+            assert d.get(unique_prop2) == value2a
+
+            assert unique_prop3 in d  # added
+            assert d.get(unique_prop3) == "stuff"
+
+            with override_dict(d, **{unique_prop1: None}):
+
+                assert unique_prop1 not in d  # removed
+
+                with override_dict(d, **{unique_prop1: None}):
+
+                    assert unique_prop1 not in d  # re-removed
+
+                assert unique_prop1 not in d  # un-re-removed, but still removed
+
+            assert unique_prop1 in d  # restored after double removal
+            assert d.get(unique_prop1) == value1b
+
+        assert unique_prop1 in d
+        assert d.get(unique_prop1) == value1a
+
+        assert unique_prop2 in d
+        assert d.get(unique_prop2) == value2a
+
+        assert unique_prop3 not in d
+
+    assert unique_prop1 not in d
+    assert unique_prop2 not in d
+    assert unique_prop3 not in d
+
+    assert d == d_copy
+
+
+def test_override_environ():
+
+    unique_prop1 = str(uuid.uuid4())
+    unique_prop2 = str(uuid.uuid4())
+    unique_prop3 = str(uuid.uuid4())
+
+    assert unique_prop1 not in os.environ
+    assert unique_prop2 not in os.environ
+    assert unique_prop3 not in os.environ
+
+    with override_environ(**{unique_prop1: "something", unique_prop2: "anything"}):
+
+        assert unique_prop1 in os.environ  # added
+        value1a = os.environ.get(unique_prop1)
+        assert value1a == "something"
+
+        assert unique_prop2 in os.environ  # added
+        value2a = os.environ.get(unique_prop2)
+        assert value2a == "anything"
+
+        assert unique_prop3 not in os.environ
+
+        with override_environ(**{unique_prop1: "something_else", unique_prop3: "stuff"}):
+
+            assert unique_prop1 in os.environ  # updated
+            value1b = os.environ.get(unique_prop1)
+            assert value1b == "something_else"
+
+            assert unique_prop2 in os.environ  # unchanged
+            assert os.environ.get(unique_prop2) == value2a
+
+            assert unique_prop3 in os.environ  # added
+            assert os.environ.get(unique_prop3) == "stuff"
+
+            with override_environ(**{unique_prop1: None}):
+
+                assert unique_prop1 not in os.environ  # removed
+
+                with override_environ(**{unique_prop1: None}):
+
+                    assert unique_prop1 not in os.environ  # re-removed
+
+                assert unique_prop1 not in os.environ  # un-re-removed, but still removed
+
+            assert unique_prop1 in os.environ  # restored after double removal
+            assert os.environ.get(unique_prop1) == value1b
+
+        assert unique_prop1 in os.environ
+        assert os.environ.get(unique_prop1) == value1a
+
+        assert unique_prop2 in os.environ
+        assert os.environ.get(unique_prop2) == value2a
+
+        assert unique_prop3 not in os.environ
+
+    assert unique_prop1 not in os.environ
+    assert unique_prop2 not in os.environ
+    assert unique_prop3 not in os.environ


### PR DESCRIPTION
* Move `override_environ` and `override_dict` to `misc_utils`.
* Add exported to `misc_utils`.
* Leave behind placeholders in `qa_utils`.
* Fix some PEP8 for PyCharm and flake8.