### PR TITLE
Add known_bug_expected and related support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,25 @@ dcicutils
 Change Log
 ----------
 
+
+1.17.0
+======
+
+**PR 142: Add known_bug_accepted and related support**
+
+* In ``misc_utils``:
+
+  * Add ``capitalize1`` to uppercase the first letter of something,
+    leaving other case alone (rather than forcing it lower).
+
+* In ``qa_utils``:
+
+  * Add ``known_bug_expected`` to mark situations in testing where
+    a named bug is expected (one for which there is a JIRA ticket),
+    allowing managing of the error handling by setting the bug's status
+    as ``fixed=False`` (the default) or ``fixed=True``.
+
+
 1.16.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,15 @@ Change Log
     allowing managing of the error handling by setting the bug's status
     as ``fixed=False`` (the default) or ``fixed=True``.
 
+* In (new module) ``exceptions``:
+
+  * ``KnownBugError``
+  * ``UnfixedBugError``
+  * ``WrongErrorSeen``
+  * ``ExpectedErrorNotSeen``
+  * ``FixedBugError``
+  * ``WrongErrorSeenAfterFix``
+  * ``UnexpectedErrorAfterFix``
 
 1.16.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 1.17.0
 ======
 
-**PR 142: Add known_bug_accepted and related support**
+**PR 144: Add known_bug_accepted and related support**
 
 * In ``misc_utils``:
 
@@ -28,7 +28,7 @@ Change Log
 1.16.0
 ======
 
-**PR 141: Move override_environ and override_dict to misc_utils**
+**PR 143: Move override_environ and override_dict to misc_utils**
 
 * In ``misc_utils``:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 1.17.0
 ======
 
-**PR 144: Add known_bug_accepted and related support**
+**PR 144: Add known_bug_expected and related support**
 
 * In ``misc_utils``:
 

--- a/dcicutils/exceptions.py
+++ b/dcicutils/exceptions.py
@@ -1,0 +1,68 @@
+# Exceptions can be put here to get them out of the way of the main flow of things,
+# and because once in a while we may want them to be shared or to have shared parents.
+
+from dcicutils.diff_utils import DiffManager
+from dcicutils.misc_utils import ignored, full_object_name, full_class_name, capitalize1
+
+
+class KnownBugError(AssertionError):
+
+    def set_jira_ticket(self, jira_ticket):
+        self.jira_ticket = jira_ticket
+        self.bug_name = "a bug" if jira_ticket is None else "Bug %s" % jira_ticket
+
+
+class UnfixedBugError(KnownBugError):
+    pass
+
+
+class WrongErrorSeen(UnfixedBugError):
+
+    def __init__(self, *, expected_class, error_seen, jira_ticket=None):
+        self.set_jira_ticket(jira_ticket)
+        self.expected_class = expected_class
+        self.error_seen = error_seen
+        super().__init__("%s did not occur where expected."
+                         " An error of class %s was thrown where one of class %s was expected."
+                         " The bug may have been fixed or it may be manifesting in an unexpected way: %s"
+                         % (capitalize1(self.bug_name),
+                            full_class_name(error_seen),
+                            full_object_name(expected_class),
+                            error_seen))
+
+
+class ExpectedErrorNotSeen(UnfixedBugError):
+
+    def __init__(self, *, jira_ticket=None):
+        self.set_jira_ticket(jira_ticket)
+        super().__init__("%s did not occur where expected. It may have been fixed." % capitalize1(self.bug_name))
+
+
+class FixedBugError(KnownBugError):
+    pass
+
+
+class WrongErrorSeenAfterFix(FixedBugError):
+
+    def __init__(self, *, expected_class, error_seen, jira_ticket=None):
+        self.set_jira_ticket(jira_ticket)
+        self.expected_class = expected_class
+        self.error_seen = error_seen
+        super().__init__("%s did not occur,"
+                         " but an error of class %s was thrown where one of class %s was expected to be fixed."
+                         " This may be another bug showing through or a regression of some sort: %s"
+                         % (capitalize1(self.bug_name),
+                            full_class_name(error_seen),
+                            full_object_name(expected_class),
+                            error_seen))
+
+
+class UnexpectedErrorAfterFix(FixedBugError):
+
+    def __init__(self, *, expected_class, error_seen, jira_ticket=None):
+        self.set_jira_ticket(jira_ticket)
+        self.expected_class = expected_class
+        self.error_seen = error_seen
+        super().__init__("An error of class %s was thrown where we expected one of class %s was fixed."
+                         " This may be a regression in the fix for %s: %s"
+                         % (full_class_name(error_seen), full_object_name(expected_class), self.bug_name, error_seen))

--- a/dcicutils/exceptions.py
+++ b/dcicutils/exceptions.py
@@ -1,8 +1,7 @@
 # Exceptions can be put here to get them out of the way of the main flow of things,
 # and because once in a while we may want them to be shared or to have shared parents.
 
-from dcicutils.diff_utils import DiffManager
-from dcicutils.misc_utils import ignored, full_object_name, full_class_name, capitalize1
+from dcicutils.misc_utils import full_object_name, full_class_name, capitalize1
 
 
 class KnownBugError(AssertionError):

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -1032,6 +1032,11 @@ def snake_case_to_camel_case(s):
     return s.title().replace('_', '')
 
 
+def capitalize1(s):
+    """ Capitalizes the first letter of a string and leaves the others alone. """
+    return s[:1].upper() + s[1:]
+
+
 class CachedField:
     def __init__(self, name, update_function, timeout=600):
         """ Provides a named field that is cached for a certain period of time. The value is computed

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -1130,7 +1130,10 @@ def snake_case_to_camel_case(s):
 
 
 def capitalize1(s):
-    """ Capitalizes the first letter of a string and leaves the others alone. """
+    """
+    Capitalizes the first letter of a string and leaves the others alone.
+    This is in contrast to the string's .capitalize() method, which would force the rest of the string to lowercase.
+    """
     return s[:1].upper() + s[1:]
 
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1090,6 +1090,36 @@ def check_duplicated_items_by_key(key, items, url=None, formatter=str):
 
 @contextlib.contextmanager
 def known_bug_expected(jira_ticket=None, fixed=False, error_class=None):
+    """
+    A context manager for provisionally catching errors due to known bugs.
+
+    For a bug that has a ticket filed against it, a use of the functionality in testing can be wrapped by
+    an expression such as:
+
+        with known_bug_expected(jira_ticket="TST-00001", error_class=RuntimeError):
+            ... stuff that fails ...
+
+    If the expected error does not occur, an error will result so that it's easy to notice that it may have changed
+    or been fixed.
+
+    Later, when the bug is fixed, just add fixed=True, as in:
+
+        with known_bug_expected(jira_ticket="TST-00001", error_class=RuntimeError, fixed=True):
+            ... stuff that fails ...
+
+    If the previously-expected error (now thought to be fixed) happens, an error will result so it's easy to tell
+    if there's been a regression.
+
+    Parameters:
+
+        jira_ticket:  a string identifying the bug, or None. There is no syntax checking or validation.
+        fixed: a boolean that says whether the bug is expected to be fixed.
+        error_class: the class of error that would result if the bug were not fixed.
+
+    Returns:
+
+        N/A - This is intended for use as a context manager.
+    """
     error_class = error_class or Exception
     if fixed is False:
         try:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -22,7 +22,6 @@ from unittest import mock
 from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix
 from .misc_utils import (
     PRINT, ignored, Retry, CustomizableProperty, getattr_customized, remove_prefix, REF_TZ,
-    full_class_name, full_object_name, capitalize1,
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.16.0"
+version = "1.17.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,0 +1,93 @@
+from dcicutils.exceptions import (
+    ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix,
+)
+
+
+def test_expected_error_not_seen():
+
+    e = ExpectedErrorNotSeen()
+    assert e.bug_name == "a bug"
+    assert str(e) == "A bug did not occur where expected. It may have been fixed."
+
+    e = ExpectedErrorNotSeen(jira_ticket="ABC-001")
+    assert e.bug_name == "Bug ABC-001"
+    assert str(e) == "Bug ABC-001 did not occur where expected. It may have been fixed."
+
+
+def test_wrong_error_seen():
+
+    error_seen = ValueError("Not an integer.")
+
+    e = WrongErrorSeen(expected_class=RuntimeError, error_seen=error_seen)
+    assert e.bug_name == "a bug"
+    assert e.jira_ticket is None
+    assert e.error_seen == error_seen
+    assert e.expected_class == RuntimeError
+    assert str(e) == (
+        'A bug did not occur where expected. An error of class ValueError was thrown'
+        ' where one of class RuntimeError was expected. The bug may have been fixed'
+        ' or it may be manifesting in an unexpected way: Not an integer.'
+    )
+
+    e = WrongErrorSeen(jira_ticket="ABC-001", expected_class=RuntimeError, error_seen=error_seen)
+    assert e.bug_name == "Bug ABC-001"
+    assert e.jira_ticket == "ABC-001"
+    assert e.error_seen == error_seen
+    assert e.expected_class == RuntimeError
+    assert str(e) == (
+        'Bug ABC-001 did not occur where expected. An error of class ValueError was thrown'
+        ' where one of class RuntimeError was expected. The bug may have been fixed'
+        ' or it may be manifesting in an unexpected way: Not an integer.'
+    )
+
+
+def test_unexpected_error_after_fix():
+
+    error_seen = RuntimeError("Something went wrong.")
+
+    e = UnexpectedErrorAfterFix(expected_class=RuntimeError, error_seen=error_seen)
+    assert e.bug_name == "a bug"
+    assert e.jira_ticket is None
+    assert e.error_seen == error_seen
+    assert e.expected_class == RuntimeError
+    assert str(e) == (
+        'An error of class RuntimeError was thrown where we expected one of class RuntimeError was fixed.'
+        ' This may be a regression in the fix for a bug: Something went wrong.'
+    )
+
+    e = UnexpectedErrorAfterFix(jira_ticket="ABC-001", expected_class=RuntimeError, error_seen=error_seen)
+    assert e.bug_name == "Bug ABC-001"
+    assert e.jira_ticket == "ABC-001"
+    assert e.error_seen == error_seen
+    assert e.expected_class == RuntimeError
+    assert str(e) == (
+        'An error of class RuntimeError was thrown where we expected one of class RuntimeError was fixed.'
+        ' This may be a regression in the fix for Bug ABC-001: Something went wrong.'
+    )
+
+
+def test_wrong_error_seen_after_fix():
+
+    error_seen = ValueError("Not an integer.")
+
+    e = WrongErrorSeenAfterFix(expected_class=RuntimeError, error_seen=error_seen)
+    assert e.bug_name == "a bug"
+    assert e.jira_ticket is None
+    assert e.error_seen == error_seen
+    assert e.expected_class == RuntimeError
+    assert str(e) == (
+        'A bug did not occur, but an error of class ValueError was thrown'
+        ' where one of class RuntimeError was expected to be fixed.'
+        ' This may be another bug showing through or a regression of some sort: Not an integer.'
+    )
+
+    e = WrongErrorSeenAfterFix(jira_ticket="ABC-001", expected_class=RuntimeError, error_seen=error_seen)
+    assert e.bug_name == "Bug ABC-001"
+    assert e.jira_ticket == "ABC-001"
+    assert e.error_seen == error_seen
+    assert e.expected_class == RuntimeError
+    assert str(e) == (
+        'Bug ABC-001 did not occur, but an error of class ValueError was thrown'
+        ' where one of class RuntimeError was expected to be fixed.'
+        ' This may be another bug showing through or a regression of some sort: Not an integer.'
+    )

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -21,7 +21,7 @@ from dcicutils.misc_utils import (
     CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json, url_path_join,
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
-    ancestor_classes, is_proper_subclass, decorator
+    ancestor_classes, is_proper_subclass, decorator, capitalize1,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ, MockFileSystem, printed_output, raises_regexp
@@ -1718,6 +1718,18 @@ class TestCachedField:
 ])
 def test_camel_case_to_snake_case(token, expected):
     assert camel_case_to_snake_case(token) == expected
+
+
+@pytest.mark.parametrize('token, expected', [
+    ('', ''),
+    ('x', 'X'),
+    ('foo', 'Foo'),
+    ('FOO', 'FOO'),
+    ('Foo', 'Foo'),
+    ('fooBar', 'FooBar'),
+])
+def test_capitalize1(token, expected):
+    assert capitalize1(token) == expected
 
 
 @pytest.mark.parametrize('token, expected', [

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -22,7 +22,8 @@ from dcicutils.misc_utils import (
     CustomizableProperty, UncustomizedInstance, getattr_customized, copy_json, url_path_join,
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
-    ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict, capitalize1,
+    ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
+    capitalize1,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -13,7 +13,7 @@ import uuid
 
 from dcicutils import qa_utils
 from dcicutils.exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix
-from dcicutils.misc_utils import Retry, PRINT, file_contents, REF_TZ, capitalize1
+from dcicutils.misc_utils import Retry, PRINT, file_contents, REF_TZ
 from dcicutils.qa_utils import (
     mock_not_called, local_attrs, override_environ, override_dict, show_elapsed_time, timed,
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom, MockUUIDModule,


### PR DESCRIPTION
Some stuff I had laying around in a sandbox I'm trying to clear out...

* In `dcicutils.qa_utils`:

  * Add `known_bug_expected` to mark situations in testing where a named bug is expected (one for which there is a JIRA ticket), allowing managing of the error handling by setting the bug's status as `fixed=False` (the default) or `fixed=True`.

* In `dcicutils.misc_utils`:

  * Add `capitalize1` to uppercase the first letter of something, leaving other case alone (rather than forcing it lower).

* In new `dcicutils.exceptions` to hold onto exception classes, with error classes used by `known_bug_expected`:
  * `KnownBugError`
  * `UnfixedBugError`
  * `WrongErrorSeen`
  * `ExpectedErrorNotSeen`
  * `FixedBugError`
  * `WrongErrorSeenAfterFix`
  * `UnexpectedErrorAfterFix`