### PR TITLE
Fix internal import problems (C4-663)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,23 @@ dcicutils
 Change Log
 ----------
 
+
+1.18.1
+======
+
+**PR 145 Fix internal import problems**
+
+* Make ``lang_utils`` import ``ignored`` from ``misc_utils``, not ``qa_utils``.
+* Make ``deployment_utils`` import ``override_environ`` from ``misc_utils``, not ``qa_utils``.
+
+
 1.18.0
 ======
 
 **PR 141 Port Application Dockerization utils**
 
 * Add additional ECS related APIs needed for orchestration/deployment.
+
 
 1.17.0
 ======
@@ -39,6 +50,7 @@ Change Log
   * ``FixedBugError``
   * ``WrongErrorSeenAfterFix``
   * ``UnexpectedErrorAfterFix``
+
 
 1.16.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 
 * Make ``lang_utils`` import ``ignored`` from ``misc_utils``, not ``qa_utils``.
 * Make ``deployment_utils`` import ``override_environ`` from ``misc_utils``, not ``qa_utils``.
+* Move ``local_attrs`` from ``qa_utils`` to ``misc_utils``
+  so that similar errors can be avoided in other libraries that import it.
 
 
 1.18.0

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -39,8 +39,7 @@ from dcicutils.env_utils import (
     is_fourfront_env, is_cgap_env, is_stg_or_prd_env, is_test_env, is_hotseat_env,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env,
 )
-from dcicutils.misc_utils import PRINT, Retry, apply_dict_overrides
-from dcicutils.qa_utils import override_environ
+from dcicutils.misc_utils import PRINT, Retry, apply_dict_overrides, override_environ
 
 
 # constants associated with EB-related APIs

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -33,13 +33,13 @@ import time
 import boto3
 from git import Repo
 
-from dcicutils.beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env
-from dcicutils.env_utils import (
+from .beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env
+from .env_utils import (
     get_standard_mirror_env, data_set_for_env, get_bucket_env, INDEXER_ENVS,
     is_fourfront_env, is_cgap_env, is_stg_or_prd_env, is_test_env, is_hotseat_env,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env,
 )
-from dcicutils.misc_utils import PRINT, Retry, apply_dict_overrides, override_environ
+from .misc_utils import PRINT, Retry, apply_dict_overrides, override_environ
 
 
 # constants associated with EB-related APIs

--- a/dcicutils/exceptions.py
+++ b/dcicutils/exceptions.py
@@ -1,7 +1,7 @@
 # Exceptions can be put here to get them out of the way of the main flow of things,
 # and because once in a while we may want them to be shared or to have shared parents.
 
-from dcicutils.misc_utils import full_object_name, full_class_name, capitalize1
+from .misc_utils import full_object_name, full_class_name, capitalize1
 
 
 class KnownBugError(AssertionError):

--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 
-from .qa_utils import ignored
+from .misc_utils import ignored
 
 
 class EnglishUtils:

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -927,6 +927,38 @@ def override_dict(d, **overrides):
             d[k] = v
 
 
+@contextlib.contextmanager
+def local_attrs(obj, **kwargs):
+    """
+    This binds the named attributes of the given object.
+    This is only allowed for an object that directly owns the indicated attributes.
+
+    """
+    keys = kwargs.keys()
+    for key in keys:
+        if key not in obj.__dict__:
+            # This works only for objects that directly have the indicated property.
+            # That happens for
+            #  (a) an instance where its instance variables are in keys.
+            #  (b) an uninstantiated class where its class variables (but not inherited class variables) are in keys.
+            # So the error happens for these cases:
+            #  (c) an instance where any of the keys come from its class instead of the instance itself
+            #  (d) an uninstantiated class being used for keys that are inherited rather than direct class variables
+            raise ValueError("%s inherits property %s. Treating it as dynamic could affect other objects."
+                             % (obj, key))
+    saved = {
+        key: getattr(obj, key)
+        for key in keys
+    }
+    try:
+        for key in keys:
+            setattr(obj, key, kwargs[key])
+        yield
+    finally:
+        for key in keys:
+            setattr(obj, key, saved[key])
+
+
 def check_true(test_value, message, error_class=None):
     """
     If the first argument does not evaluate to a true value, an error is raised.

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -2,8 +2,8 @@ import os
 import boto3
 import json
 from botocore.exceptions import ClientError
-from dcicutils.ecr_utils import CGAP_ECR_REGION
-from dcicutils.misc_utils import PRINT
+from .ecr_utils import CGAP_ECR_REGION
+from .misc_utils import PRINT
 
 
 # Environment variable whose value is the name of a secret

--- a/dcicutils/snapshot_utils.py
+++ b/dcicutils/snapshot_utils.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 
 from elasticsearch.exceptions import NotFoundError
-from dcicutils.misc_utils import (
+from .misc_utils import (
     environ_bool, PRINT, camel_case_to_snake_case, full_object_name,
     ignorable, ancestor_classes, decorator, ignored,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.18.0.1b0"
+version = "1.18.0.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.18.0.1b1"
+version = "1.18.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "1.18.0"
+version = "1.18.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -23,7 +23,7 @@ from dcicutils.misc_utils import (
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ, hms_now, HMS_TZ,
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
-    capitalize1,
+    capitalize1, local_attrs,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp
@@ -2328,3 +2328,120 @@ def test_override_environ():
     assert unique_prop1 not in os.environ
     assert unique_prop2 not in os.environ
     assert unique_prop3 not in os.environ
+
+
+NORMAL_ATTR0 = 16
+NORMAL_ATTR1 = 17
+NORMAL_ATTR2 = 'foo'
+NORMAL_ATTR3 = 'bar'
+
+OVERRIDDEN_ATTR0 = 61
+OVERRIDDEN_ATTR1 = 71
+OVERRIDDEN_ATTR2 = 'oof'
+OVERRIDDEN_ATTR3 = 'rab'
+
+
+def test_dynamic_properties():
+
+    def test_thing(test_obj):
+
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        # attrs = ['attr0', 'attr1', 'attr2', 'attr3']
+
+        # If this were done wrong, we'd bind an inherited attribute
+        # and then when we put things back it would become an instance
+        # attribute, so we remember what things were originally
+        # instance attributes so that we can check later.
+        old_attr_dict = test_obj.__dict__.copy()
+
+        # Test of the ordinary case.
+        with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr2=OVERRIDDEN_ATTR2):
+            assert test_obj.attr0 == OVERRIDDEN_ATTR0
+            assert test_obj.attr1 == NORMAL_ATTR1
+            assert test_obj.attr2 == OVERRIDDEN_ATTR2
+            assert test_obj.attr3 == NORMAL_ATTR3
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        assert test_obj.__dict__ == old_attr_dict
+
+        # Another test of the ordinary case.
+        with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr1=OVERRIDDEN_ATTR1,
+                         attr2=OVERRIDDEN_ATTR2, attr3=OVERRIDDEN_ATTR3):
+            assert test_obj.attr0 == OVERRIDDEN_ATTR0
+            assert test_obj.attr1 == OVERRIDDEN_ATTR1
+            assert test_obj.attr2 == OVERRIDDEN_ATTR2
+            assert test_obj.attr3 == OVERRIDDEN_ATTR3
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        # Test case of raising an error and assuring things are still set to normal
+        try:
+            with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr2=OVERRIDDEN_ATTR2):
+                assert test_obj.attr0 == NORMAL_ATTR0
+                assert test_obj.attr1 == NORMAL_ATTR1
+                assert test_obj.attr2 == NORMAL_ATTR2
+                assert test_obj.attr3 == NORMAL_ATTR3
+                raise Exception("This is expected to be caught.")
+        except Exception:
+            pass
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+        # Test case of no attributes set at all
+        with local_attrs(object):
+            assert test_obj.attr0 == NORMAL_ATTR0
+            assert test_obj.attr1 == NORMAL_ATTR1
+            assert test_obj.attr2 == NORMAL_ATTR2
+            assert test_obj.attr3 == NORMAL_ATTR3
+        assert test_obj.attr0 == NORMAL_ATTR0
+        assert test_obj.attr1 == NORMAL_ATTR1
+        assert test_obj.attr2 == NORMAL_ATTR2
+        assert test_obj.attr3 == NORMAL_ATTR3
+
+    class Foo:
+        attr0 = NORMAL_ATTR0
+        attr1 = NORMAL_ATTR1
+
+        def __init__(self):
+            self.attr2 = NORMAL_ATTR2
+            self.attr3 = NORMAL_ATTR3
+
+    with pytest.raises(ValueError):
+        # Binding attr1 would affect other instances.
+        test_thing(Foo())
+
+    class Bar:
+        def __init__(self):
+            self.attr0 = NORMAL_ATTR0
+            self.attr1 = NORMAL_ATTR1
+            self.attr2 = NORMAL_ATTR2
+            self.attr3 = NORMAL_ATTR3
+
+    test_thing(Bar())
+
+    class Baz:
+        attr0 = NORMAL_ATTR0
+        attr1 = NORMAL_ATTR1
+        attr2 = NORMAL_ATTR2
+        attr3 = NORMAL_ATTR3
+
+    test_thing(Baz)
+
+    with pytest.raises(ValueError):
+        # Binding attr1 would affect other instances.
+        test_thing(Baz())
+
+    for thing in [3, "foo", None]:
+        with local_attrs(thing):
+            pass  # Just make sure no error occurs when no attributes given

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -15,7 +15,7 @@ from dcicutils import qa_utils
 from dcicutils.exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix
 from dcicutils.misc_utils import Retry, PRINT, file_contents, REF_TZ
 from dcicutils.qa_utils import (
-    mock_not_called, local_attrs, override_environ, override_dict, show_elapsed_time, timed,
+    mock_not_called, override_environ, override_dict, show_elapsed_time, timed,
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom, MockUUIDModule,
     MockResponse, printed_output, MockBotoS3Client, MockKeysNotImplemented, MockBoto3, known_bug_expected,
     raises_regexp, VersionChecker, check_duplicated_items_by_key, guess_local_timezone_for_testing,
@@ -39,123 +39,6 @@ def test_mock_not_called():
         assert m, "Expected assertion text did not appear."
     else:
         raise AssertionError("An AssertionError was not raised.")
-
-
-NORMAL_ATTR0 = 16
-NORMAL_ATTR1 = 17
-NORMAL_ATTR2 = 'foo'
-NORMAL_ATTR3 = 'bar'
-
-OVERRIDDEN_ATTR0 = 61
-OVERRIDDEN_ATTR1 = 71
-OVERRIDDEN_ATTR2 = 'oof'
-OVERRIDDEN_ATTR3 = 'rab'
-
-
-def test_dynamic_properties():
-
-    def test_thing(test_obj):
-
-        assert test_obj.attr0 == NORMAL_ATTR0
-        assert test_obj.attr1 == NORMAL_ATTR1
-        assert test_obj.attr2 == NORMAL_ATTR2
-        assert test_obj.attr3 == NORMAL_ATTR3
-
-        # attrs = ['attr0', 'attr1', 'attr2', 'attr3']
-
-        # If this were done wrong, we'd bind an inherited attribute
-        # and then when we put things back it would become an instance
-        # attribute, so we remember what things were originally
-        # instance attributes so that we can check later.
-        old_attr_dict = test_obj.__dict__.copy()
-
-        # Test of the ordinary case.
-        with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr2=OVERRIDDEN_ATTR2):
-            assert test_obj.attr0 == OVERRIDDEN_ATTR0
-            assert test_obj.attr1 == NORMAL_ATTR1
-            assert test_obj.attr2 == OVERRIDDEN_ATTR2
-            assert test_obj.attr3 == NORMAL_ATTR3
-        assert test_obj.attr0 == NORMAL_ATTR0
-        assert test_obj.attr1 == NORMAL_ATTR1
-        assert test_obj.attr2 == NORMAL_ATTR2
-        assert test_obj.attr3 == NORMAL_ATTR3
-
-        assert test_obj.__dict__ == old_attr_dict
-
-        # Another test of the ordinary case.
-        with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr1=OVERRIDDEN_ATTR1,
-                         attr2=OVERRIDDEN_ATTR2, attr3=OVERRIDDEN_ATTR3):
-            assert test_obj.attr0 == OVERRIDDEN_ATTR0
-            assert test_obj.attr1 == OVERRIDDEN_ATTR1
-            assert test_obj.attr2 == OVERRIDDEN_ATTR2
-            assert test_obj.attr3 == OVERRIDDEN_ATTR3
-        assert test_obj.attr0 == NORMAL_ATTR0
-        assert test_obj.attr1 == NORMAL_ATTR1
-        assert test_obj.attr2 == NORMAL_ATTR2
-        assert test_obj.attr3 == NORMAL_ATTR3
-
-        # Test case of raising an error and assuring things are still set to normal
-        try:
-            with local_attrs(test_obj, attr0=OVERRIDDEN_ATTR0, attr2=OVERRIDDEN_ATTR2):
-                assert test_obj.attr0 == NORMAL_ATTR0
-                assert test_obj.attr1 == NORMAL_ATTR1
-                assert test_obj.attr2 == NORMAL_ATTR2
-                assert test_obj.attr3 == NORMAL_ATTR3
-                raise Exception("This is expected to be caught.")
-        except Exception:
-            pass
-        assert test_obj.attr0 == NORMAL_ATTR0
-        assert test_obj.attr1 == NORMAL_ATTR1
-        assert test_obj.attr2 == NORMAL_ATTR2
-        assert test_obj.attr3 == NORMAL_ATTR3
-
-        # Test case of no attributes set at all
-        with local_attrs(object):
-            assert test_obj.attr0 == NORMAL_ATTR0
-            assert test_obj.attr1 == NORMAL_ATTR1
-            assert test_obj.attr2 == NORMAL_ATTR2
-            assert test_obj.attr3 == NORMAL_ATTR3
-        assert test_obj.attr0 == NORMAL_ATTR0
-        assert test_obj.attr1 == NORMAL_ATTR1
-        assert test_obj.attr2 == NORMAL_ATTR2
-        assert test_obj.attr3 == NORMAL_ATTR3
-
-    class Foo:
-        attr0 = NORMAL_ATTR0
-        attr1 = NORMAL_ATTR1
-
-        def __init__(self):
-            self.attr2 = NORMAL_ATTR2
-            self.attr3 = NORMAL_ATTR3
-
-    with pytest.raises(ValueError):
-        # Binding attr1 would affect other instances.
-        test_thing(Foo())
-
-    class Bar:
-        def __init__(self):
-            self.attr0 = NORMAL_ATTR0
-            self.attr1 = NORMAL_ATTR1
-            self.attr2 = NORMAL_ATTR2
-            self.attr3 = NORMAL_ATTR3
-
-    test_thing(Bar())
-
-    class Baz:
-        attr0 = NORMAL_ATTR0
-        attr1 = NORMAL_ATTR1
-        attr2 = NORMAL_ATTR2
-        attr3 = NORMAL_ATTR3
-
-    test_thing(Baz)
-
-    with pytest.raises(ValueError):
-        # Binding attr1 would affect other instances.
-        test_thing(Baz())
-
-    for thing in [3, "foo", None]:
-        with local_attrs(thing):
-            pass  # Just make sure no error occurs when no attributes given
 
 
 def test_override_dict():


### PR DESCRIPTION
This fixes some internal import problems that create an unwanted dependency on pytest.

It also moves `local_attrs` into the `misc_utils` so it can be used by other libraries without a `pytest` dependency.