### PR TITLE
More s3Utils constants to sync better across services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,35 @@ Change Log
 ----------
 
 
+2.1.0
+=====
+
+* In ``s3_utils``, add various variables that can be used to assure values are synchronized across 4DN/CGAP products:
+
+  * Add new slots on ``s3Utils`` to hold the token at the end of each kind of bucket:
+
+    * ``s3Utils.SYS_BUCKET_SUFFIX == "system"``
+    * ``s3Utils.OUTFILE_BUCKET_SUFFIX == "wfoutput"``
+    * ``s3Utils.RAW_BUCKET_SUFFIX == "files"``
+    * ``s3Utils.BLOB_BUCKET_SUFFIX == "blobs"``
+    * ``s3Utils.METADATA_BUCKET_SUFFIX == "metadata-bundles"``
+    * ``s3Utils.TIBANNA_OUTPUT_BUCKET_SUFFIX == 'tibanna-output'``
+
+  * Add new slots on ``s3Utils`` for various bits of connective glue in setting up the template slots:
+
+    * ``s3Utils.EB_PREFIX == "elasticbeanstalk"``
+    * ``s3Utils.EB_AND_ENV_PREFIX == "elasticbeanstalk-%s-"``
+
+  * Add new slots on ``s3Utils`` for expected keys on a health page corresponding to each kind of bucket:
+
+    * ``s3Utils.SYS_BUCKET_HEALTH_PAGE_KEY == 'system_bucket'``
+    * ``s3Utils.OUTFILE_BUCKET_HEALTH_PAGE_KEY == 'processed_file_bucket'``
+    * ``s3Utils.RAW_BUCKET_HEALTH_PAGE_KEY == 'file_upload_bucket'``
+    * ``s3Utils.BLOB_BUCKET_HEALTH_PAGE_KEY == 'blob_bucket'``
+    * ``s3Utils.METADATA_BUCKET_HEALTH_PAGE_KEY == 'metadata_bundles_bucket'``
+    * ``s3Utils.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY == 'tibanna_output_bucket'``
+
+
 2.0.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Change Log
     * ``s3Utils.METADATA_BUCKET_HEALTH_PAGE_KEY == 'metadata_bundles_bucket'``
     * ``s3Utils.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY == 'tibanna_output_bucket'``
 
+* In ``deployment_utils``, use new variables from ``s3_utils``.
+
 
 2.0.0
 =====

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -40,6 +40,7 @@ from .env_utils import (
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env,
 )
 from .misc_utils import PRINT, Retry, apply_dict_overrides, override_environ
+from .s3_utils import s3Utils
 
 
 # constants associated with EB-related APIs
@@ -515,9 +516,9 @@ class IniFileManager:
 
     AUTO_INDEX_SERVER_TOKEN = "__index_server"
 
-    LEGACY_APPLICATION_BUCKET_ORG = "elasticbeanstalk"
-    LEGACY_APPLICATION_BUCKET_PREFIX = "elasticbeanstalk-"
-    LEGACY_TIBANNA_OUTPUT_BUCKET = "tibanna-output"
+    LEGACY_APPLICATION_BUCKET_ORG = s3Utils.EB_PREFIX                        # = "elasticbeanstalk"
+    LEGACY_APPLICATION_BUCKET_PREFIX = LEGACY_APPLICATION_BUCKET_ORG + "-"   # = "elasticbeanstalk-"
+    LEGACY_TIBANNA_OUTPUT_BUCKET = s3Utils.TIBANNA_OUTPUT_BUCKET_TEMPLATE    # = "tibanna-output"
     LEGACY_FOURSIGHT_BUCKET_PREFIX = "foursight-"
 
     @classmethod
@@ -591,24 +592,36 @@ class IniFileManager:
         sentry_dsn = sentry_dsn or os.environ.get("ENCODED_SENTRY_DSN", "")
         auth0_client = auth0_client or os.environ.get("ENCODED_AUTH0_CLIENT", "")
         auth0_secret = auth0_secret or os.environ.get("ENCODED_AUTH0_SECRET", "")
+
+        # corresponds to s3Utils legacy "elasticbeanstalk-%s-files"
         file_upload_bucket = (file_upload_bucket
                               or os.environ.get("ENCODED_FILE_UPLOAD_BUCKET")
-                              or f"{application_bucket_prefix}{s3_bucket_env}-files")
+                              or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.RAW_BUCKET_SUFFIX}")
+
+        # corresponds to s3Utils legacy "elasticbeanstalk-%s-wfoutput"
         file_wfout_bucket = (file_wfout_bucket
                              or os.environ.get("ENCODED_FILE_WFOUT_BUCKET")
-                             or f"{application_bucket_prefix}{s3_bucket_env}-wfoutput")
+                             or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.OUTFILE_BUCKET_SUFFIX}")
+
+        # corresponds to s3Utils legacy "elasticbeanstalk-%s-blobs"
         blob_bucket = (blob_bucket
                        or os.environ.get("ENCODED_BLOB_BUCKET")
-                       or f"{application_bucket_prefix}{s3_bucket_env}-blobs")
+                       or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.BLOB_BUCKET_SUFFIX}")
+
+        # corresponds to s3Utils legacy "elasticbeanstalk-%s-system"
         system_bucket = (system_bucket
                          or os.environ.get("ENCODED_SYSTEM_BUCKET")
-                         or f"{application_bucket_prefix}{s3_bucket_env}-system")
+                         or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.SYS_BUCKET_SUFFIX}")
+
+        # corresponds to s3Utils legacy "elasticbeanstalk-%s-metadata-bundles"
         metadata_bundles_bucket = (metadata_bundles_bucket
                                    or os.environ.get("ENCODED_METADATA_BUNDLES_BUCKET")
-                                   or f"{application_bucket_prefix}{s3_bucket_env}-metadata-bundles")
+                                   or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.METADATA_BUCKET_SUFFIX}")
+
+        # corresponses to s3Utils legacy "tibanna-output" (no prefix)
         tibanna_output_bucket = (tibanna_output_bucket
                                  or os.environ.get("ENCODED_TIBANNA_OUTPUT_BUCKET")
-                                 or (f"{application_bucket_prefix}tibanna-output"
+                                 or (f"{application_bucket_prefix}{s3Utils.TIBANNA_OUTPUT_BUCKET_SUFFIX}"
                                      if cls.APP_ORCHESTRATED
                                      else cls.LEGACY_TIBANNA_OUTPUT_BUCKET))
         app_kind = cls.APP_KIND or "unknown"

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -1,19 +1,23 @@
 from __future__ import print_function
-import json
+
 import boto3
-import os
-import mimetypes
-import urllib.request
-from zipfile import ZipFile
-from io import BytesIO
+import contextlib
+import json
 import logging
+import mimetypes
+import os
 import requests
+import urllib.request
+
+from dcicutils.misc_utils import override_environ
+from io import BytesIO
+from zipfile import ZipFile
 from .env_utils import is_stg_or_prd_env, prod_bucket_env, full_env_name
-from .misc_utils import PRINT
 from .exceptions import (
     InferredBucketConflict, CannotInferEnvFromNoGlobalEnvs, CannotInferEnvFromManyGlobalEnvs, MissingGlobalEnv,
     GlobalBucketAccessError, SynonymousEnvironmentVariablesMismatched,
 )
+from .misc_utils import PRINT
 
 
 ###########################
@@ -25,14 +29,33 @@ logger = logging.getLogger(__name__)
 
 class s3Utils(object):  # NOQA - This class name violates style rules, but a lot of things might break if we change it.
 
-    SYS_BUCKET_TEMPLATE = "elasticbeanstalk-%s-system"
-    OUTFILE_BUCKET_TEMPLATE = "elasticbeanstalk-%s-wfoutput"
-    RAW_BUCKET_TEMPLATE = "elasticbeanstalk-%s-files"
-    BLOB_BUCKET_TEMPLATE = "elasticbeanstalk-%s-blobs"
-    METADATA_BUCKET_TEMPLATE = "elasticbeanstalk-%s-metadata-bundles"
-    TIBANNA_OUTPUT_BUCKET_TEMPLATE = 'tibanna-output'
+    # Some extra variables used in setup here so that other modules can be consistent with chosen values.
 
-    @staticmethod
+    SYS_BUCKET_SUFFIX = "system"
+    OUTFILE_BUCKET_SUFFIX = "wfoutput"
+    RAW_BUCKET_SUFFIX = "files"
+    BLOB_BUCKET_SUFFIX = "blobs"
+    METADATA_BUCKET_SUFFIX = "metadata-bundles"
+    TIBANNA_OUTPUT_BUCKET_SUFFIX = 'tibanna-output'
+
+    EB_PREFIX = "elasticbeanstalk"
+    EB_AND_ENV_PREFIX = EB_PREFIX + "-%s-"  # = "elasticbeanstalk-%s-"
+
+    SYS_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + SYS_BUCKET_SUFFIX            # = "elasticbeanstalk-%s-system"
+    OUTFILE_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + OUTFILE_BUCKET_SUFFIX    # = "elasticbeanstalk-%s-wfoutput"
+    RAW_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + RAW_BUCKET_SUFFIX            # = "elasticbeanstalk-%s-files"
+    BLOB_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + BLOB_BUCKET_SUFFIX          # = "elasticbeanstalk-%s-blobs"
+    METADATA_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + METADATA_BUCKET_SUFFIX  # = "elasticbeanstalk-%s-metadata-bundles"
+    TIBANNA_OUTPUT_BUCKET_TEMPLATE = TIBANNA_OUTPUT_BUCKET_SUFFIX          # = "tibanna-output" (no prefix)
+
+    SYS_BUCKET_HEALTH_PAGE_KEY = 'system_bucket'
+    OUTFILE_BUCKET_HEALTH_PAGE_KEY = 'processed_file_bucket'
+    RAW_BUCKET_HEALTH_PAGE_KEY = 'file_upload_bucket'
+    BLOB_BUCKET_HEALTH_PAGE_KEY = 'blob_bucket'
+    METADATA_BUCKET_HEALTH_PAGE_KEY = 'metadata_bundles_bucket'
+    TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY = 'tibanna_output_bucket'
+
+    @staticmethod  # backwawrd compatibility in case other repositories are using this
     def verify_and_get_env_config(s3_client, global_bucket: str, env):
         """ Verifies the S3 environment from which the env config is coming from, and returns the S3-based env config
             Throws exceptions if the S3 bucket is unreachable, or an env based on the name of the global S3 bucket
@@ -110,12 +133,14 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
                 health_json_url = '{ff_url}/health?format=json'.format(ff_url=ff_url)
                 logger.warning('health json url: {}'.format(health_json_url))
                 health_json = self.fetch_health_page_json(url=health_json_url, use_urllib=True)
-                sys_bucket_from_health_page = health_json['system_bucket']
-                outfile_bucket_from_health_page = health_json['processed_file_bucket']
-                raw_file_bucket_from_health_page = health_json['file_upload_bucket']
-                blob_bucket_from_health_page = health_json['blob_bucket']
-                metadata_bucket_from_health_page = health_json.get('metadata_bundles_bucket', None)  # N/A for 4DN
-                tibanna_output_bucket_from_health_page = health_json.get('tibanna_output_bucket',
+                sys_bucket_from_health_page = health_json[self.SYS_BUCKET_HEALTH_PAGE_KEY]
+                outfile_bucket_from_health_page = health_json[self.OUTFILE_BUCKET_HEALTH_PAGE_KEY]
+                raw_file_bucket_from_health_page = health_json[self.RAW_BUCKET_HEALTH_PAGE_KEY]
+                blob_bucket_from_health_page = health_json[self.BLOB_BUCKET_HEALTH_PAGE_KEY]
+                metadata_bucket_from_health_page = health_json.get(self.METADATA_BUCKET_HEALTH_PAGE_KEY,
+                                                                   # N/A for 4DN
+                                                                   None)
+                tibanna_output_bucket_from_health_page = health_json.get(self.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY,
                                                                          # new, so it may be missing
                                                                          None)
                 sys_bucket = sys_bucket_from_health_page  # OK to overwrite because we checked it's None above

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.0.0"  # We planned 1.20.0.1b15 to become 1.21.0, but opted for 2.0.0. (Next PR can remove this comment.)
+version = "2.0.0.1b0"  # to become 2.1.0
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -49,6 +49,36 @@ def mocked_s3_integration(integrated_names=None, zip_suffix="", ffenv=None):
         yield s3_connection
 
 
+@pytest.mark.unit
+def test_s3utils_constants():
+
+    # This is a bit concrete, as tests go, but at last it will let us know if something changes. -kmp 22-Aug-2021
+
+    assert s3Utils.SYS_BUCKET_SUFFIX == "system"
+    assert s3Utils.OUTFILE_BUCKET_SUFFIX == "wfoutput"
+    assert s3Utils.RAW_BUCKET_SUFFIX == "files"
+    assert s3Utils.BLOB_BUCKET_SUFFIX == "blobs"
+    assert s3Utils.METADATA_BUCKET_SUFFIX == "metadata-bundles"
+    assert s3Utils.TIBANNA_OUTPUT_BUCKET_SUFFIX == 'tibanna-output'
+
+    assert s3Utils.EB_PREFIX == "elasticbeanstalk"
+    assert s3Utils.EB_AND_ENV_PREFIX == "elasticbeanstalk-%s-"
+
+    assert s3Utils.SYS_BUCKET_TEMPLATE == "elasticbeanstalk-%s-system"
+    assert s3Utils.OUTFILE_BUCKET_TEMPLATE == "elasticbeanstalk-%s-wfoutput"
+    assert s3Utils.RAW_BUCKET_TEMPLATE == "elasticbeanstalk-%s-files"
+    assert s3Utils.BLOB_BUCKET_TEMPLATE == "elasticbeanstalk-%s-blobs"
+    assert s3Utils.METADATA_BUCKET_TEMPLATE == "elasticbeanstalk-%s-metadata-bundles"
+    assert s3Utils.TIBANNA_OUTPUT_BUCKET_TEMPLATE == "tibanna-output"
+
+    assert s3Utils.SYS_BUCKET_HEALTH_PAGE_KEY == 'system_bucket'
+    assert s3Utils.OUTFILE_BUCKET_HEALTH_PAGE_KEY == 'processed_file_bucket'
+    assert s3Utils.RAW_BUCKET_HEALTH_PAGE_KEY == 'file_upload_bucket'
+    assert s3Utils.BLOB_BUCKET_HEALTH_PAGE_KEY == 'blob_bucket'
+    assert s3Utils.METADATA_BUCKET_HEALTH_PAGE_KEY == 'metadata_bundles_bucket'
+    assert s3Utils.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY == 'tibanna_output_bucket'
+
+
 @pytest.mark.integrated
 @pytest.mark.parametrize('ff_ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev', 'fourfront-hotseat'])
 def test_s3utils_creation_ff_ordinary(ff_ordinary_envname):
@@ -189,7 +219,7 @@ def test_s3utils_get_keys_for_staging():
 
 
 @pytest.mark.integrated
-def test_s3utils_get_jupyterhub_key(basestring):
+def test_s3utils_get_jupyterhub_key():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'data' implies the GA test environment has overbroad privilege.
     #   We should make this work without access to 'data'.


### PR DESCRIPTION
* In `s3_utils`, add various variables that can be used to assure values are synchronized across 4DN/CGAP products:

  * Add new slots on `s3Utils` to hold the token at the end of each kind of bucket:

    * `s3Utils.SYS_BUCKET_SUFFIX == "system"`
    * `s3Utils.OUTFILE_BUCKET_SUFFIX == "wfoutput"`
    * `s3Utils.RAW_BUCKET_SUFFIX == "files"`
    * `s3Utils.BLOB_BUCKET_SUFFIX == "blobs"`
    * `s3Utils.METADATA_BUCKET_SUFFIX == "metadata-bundles"`
    * `s3Utils.TIBANNA_OUTPUT_BUCKET_SUFFIX == 'tibanna-output'`

  * Add new slots on `s3Utils` for various bits of connective glue in setting up the template slots:

    * `s3Utils.EB_PREFIX == "elasticbeanstalk"`
    * `s3Utils.EB_AND_ENV_PREFIX == "elasticbeanstalk-%s-"`

  * Add new slots on `s3Utils` for expected keys on a health page corresponding to each kind of bucket:

    * `s3Utils.SYS_BUCKET_HEALTH_PAGE_KEY == 'system_bucket'`
    * `s3Utils.OUTFILE_BUCKET_HEALTH_PAGE_KEY == 'processed_file_bucket'`
    * `s3Utils.RAW_BUCKET_HEALTH_PAGE_KEY == 'file_upload_bucket'`
    * `s3Utils.BLOB_BUCKET_HEALTH_PAGE_KEY == 'blob_bucket'`
    * `s3Utils.METADATA_BUCKET_HEALTH_PAGE_KEY == 'metadata_bundles_bucket'`
    * `s3Utils.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY == 'tibanna_output_bucket'`

* In `deployment_utils`, use new variables from `s3_utils`