### PR TITLE
Miscellaneous orchestration support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,35 @@
 [flake8]
 max-line-length = 120
+ignore =
+    # ==============================================================
+    # =========  Default list of things Flake8 would ignore ========
+    # ==============================================================
+    # E121: Continuation line under-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E121.html
+    E121,
+    # E123: Closing bracket does not match indentation of opening bracket's line
+    #       https://www.flake8rules.com/rules/E123.html
+    E123,
+    # E126: Continuation line over-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E126.html
+    E126,
+    # E226: Missing whitespace around arithmetic operator
+    #       https://www.flake8rules.com/rules/E226.html
+    E226,
+    # E24: ??? Hard to find doc on why this undocumented code's in default list
+    # E24,
+    # E704: Multiple statements on one line (def)
+    #       https://www.flake8rules.com/rules/E704.html
+    E704,
+    # W503: Line break occurred before a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W503,
+    # W504: Line break occurred after a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W504,
+    # ==============================================================
+    # =====  Other things we think it shouldn't complain about =====
+    # ==============================================================
+    # F541: f-string is missing placeholders
+    #       https://flake8.pycqa.org/en/latest/user/error-codes.html
+    F541

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,57 @@ Change Log
 ----------
 
 
+2.2.0
+=====
+
+* In ``cloudformation_utils``:
+
+  * Add ``hyphenify`` to change underscores to hyphens.
+
+* In ``command_utils``:
+
+  * Add ``shell_script`` context manager and its implementation class ``ShellScript``.
+
+* In ``lang_utils``:
+
+  * Add support for ``string_pluralize`` to pluralize 'nouns' that have attached prepositional phrases, as in::
+
+       string_pluralize('file to load')
+       'files to load`
+
+       string_pluralize('brother-in-law of a proband')
+       'brothers-in-law of probands'
+
+       string_pluralize('brother-in-law of the proband')
+       'brothers-in-law of the proband'
+
+    But, importantly, this also means one can give have arguments to functions that use these do something
+    sophisticated in terms of wording with almost no effort at the point of need, such as::
+
+       [there_are(['foo.json', 'bar.json'][:n], kind='file to load') for n in range(3)]
+       [
+         'There are no files to load.',
+         'There is 1 file to load: foo.json',
+         'There are 2 files to load: foo.json, bar.json'
+       ]
+
+       [n_of(n, 'bucket to delete') for n in range(3)]
+       [
+         '0 buckets to delete',
+         '1 bucket to delete',
+         '2 buckets to delete'
+       ]
+
+* Miscellaneous other changes:
+
+  * In ``docs/source/dcicutils.rst``, add autodoc for various modules that are not getting documented.
+
+  * In ``test/test_misc.py``, add unit test to make sure things don't get omitted from autodoc.
+
+    Specifically, a test will now fail if you make a new file in ``dcicutils`` and do not add a
+    corresponding autodoc entry in ``docs/source/dcicutils.rst``.
+
+
 2.1.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Change Log
 
   * Add ``shell_script`` context manager and its implementation class ``ShellScript``.
 
+  * Add ``module_warnings_as_ordinary_output`` to help work around the problem that S3Utils outputs
+    text we'd sometimes rather see as ordinary output, not log output.
+
 * In ``lang_utils``:
 
   * Add support for ``string_pluralize`` to pluralize 'nouns' that have attached prepositional phrases, as in::

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -240,7 +240,10 @@ def _swap_cname(src, dest):
 
 def _create_foursight_new(dest_env):
     """ Helper function that does what create_foursight_auto used to do but slightly differently """
-    fs = {'dest_env': dest_env, 'bs_url': get_beanstalk_real_url(dest_env)}
+    fs = {  # noQA - PyCharm thinks the way this dictionary is set up could be simplified, but it's fine for now.
+        'dest_env': dest_env,
+        'bs_url': get_beanstalk_real_url(dest_env)
+    }
 
     # Get information, pass to create_foursight
     fs['fs_url'] = get_foursight_env(dest_env, fs['bs_url'])
@@ -577,6 +580,7 @@ def create_db_from_snapshot(db_identifier, snapshot_name, delete_db_if_present=T
     Args:
         db_identifier (str): RDS instance identifier
         snapshot_name (str): identifier/ARN of RDS snapshot to restore from
+        delete_db_if_present(bool): whether to drop the database on unwind
 
     Returns:
         str: resource ARN if successful, otherwise "Deleting"
@@ -909,7 +913,9 @@ def create_foursight_auto(dest_env):
     Returns:
         dict: response from Foursight PUT /api/environments
     """
-    fs = {'dest_env': dest_env}
+    fs = {  # noQA - PyCharm thinks the way this dictionary is set up could be simplified, but it's fine for now.
+        'dest_env': dest_env
+    }
 
     # automatically determine info for FS environ creation
     fs['bs_url'] = get_beanstalk_real_url(dest_env)
@@ -989,7 +995,7 @@ def create_foursight(dest_env, bs_url, es_url, fs_url=None):
         fs_url = fs_url[len('fourfront-'):]
 
     foursight_url = FOURSIGHT_URL + 'environments/' + fs_url
-    payload = {'fourfront': bs_url,  'es': es_url, 'ff_env': dest_env}
+    payload = {'fourfront': bs_url, 'es': es_url, 'ff_env': dest_env}
 
     ff_auth = os.environ.get('FS_AUTH')
     headers = {'content-type': 'application/json', 'Authorization': ff_auth}

--- a/dcicutils/cloudformation_utils.py
+++ b/dcicutils/cloudformation_utils.py
@@ -19,6 +19,11 @@ def dehyphenate(s):
     return s.replace('-', '')
 
 
+def hyphenify(s):
+    """Turns the underscore form of snake_case into the hyphenated form."""
+    return s.replace('_', '-')
+
+
 def make_required_key_for_ecs_application_url(env_name):
     """
     This pattern needs to remain fixed for various things to connect up.

--- a/dcicutils/command_utils.py
+++ b/dcicutils/command_utils.py
@@ -1,6 +1,4 @@
 import contextlib
-import glob
-import os
 import subprocess
 
 from typing import Optional

--- a/dcicutils/es_utils.py
+++ b/dcicutils/es_utils.py
@@ -115,7 +115,7 @@ def get_index_list(client, name, days_old=0, timestring='%Y.%m.%d', ilo=None):
     # return ilo
 
 
-def create_snapshot_repo(client, repo_name,  s3_bucket):
+def create_snapshot_repo(client, repo_name, s3_bucket):
     """
     Creates a repo to store ES snapshots on
 

--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -68,9 +68,7 @@ class EnglishUtils:
 
     _NOUN_WITH_PREPOSITIONAL_ATTACHMENT = re.compile(
         # Note use of *? to get minimal match in group1, so that we'll find the first preposition, not a later one
-        # f"^(?:([a-z]*?)([-])+({'|'.join(COMMON_PREPOSITIONS)})([-]+)([a-z-]*)|([a-z- ]*?[a-z-]?)([ ]+)({'|'.join(COMMON_PREPOSITIONS)})([ ]+)(.*))$",
-
-        # The use of "*?" makes us treat multiple prepositions like a-of-b-of-c by recursing as
+        # Specifically, the use of "*?" makes us treat multiple prepositions like a-of-b-of-c by recursing as
         # (a)(-)(of)(-)(b-of-c). If we used "*" instead of "*?", we would get (a-of-b)(-)(of)(-)(c).
         # If we were only doing hyphenated items, it wouldn't matter a whole lot.
         # But in the words part, it matters a great deal because with spaces and hyphens interleaved, there is a
@@ -81,7 +79,7 @@ class EnglishUtils:
                  # to ONLY match a hyphenated compound word like son-in-law as (son)(-)(in)(-)(law)
                  ([a-z][a-z-]*?)  # shortest possible (i.e., first) block of hyphenated words preceding "-<prep>-"
                  ([-])            # pre-preposition-hyphen to make sure it's part of the same compound.
-                 ({'|'.join(_COMPOUND_PLURAL_PREPOSITIONS).replace(' ', '[ ]')}) # matches the prep, as (about|at|...)  
+                 ({'|'.join(_COMPOUND_PLURAL_PREPOSITIONS).replace(' ', '[ ]')}) # matches the prep, as (about|at|...)
                  ([-])            # hyphen on the other side of prep
                  ([a-z-]*)        # we're less fussy about this. It could contain more preps, for example.
               |
@@ -91,13 +89,13 @@ class EnglishUtils:
                  ([a-z]        # first token starts with an alphabetic,
                   [a-z- ]*?    # matches any number of words, which may be hyphenated,
                   [a-z])       # and ends in an alphabetic
-                 ([ ]+)        # unlike with hyphenation, any number of pre-<prep> spaces is ok        
+                 ([ ]+)        # unlike with hyphenation, any number of pre-<prep> spaces is ok
                  ({'|'.join(_COMPOUND_PLURAL_PREPOSITIONS).replace(' ', '[ ]')}) # matches the prep, as (about|at|...)
                  ([ ]+)        # any amount of whitespace on the other side
                  (.*)          # anything else that follows first space-delimeted preposition
              )$""",
 
-       re.IGNORECASE | re.VERBOSE)
+        re.IGNORECASE | re.VERBOSE)
     _INDEFINITE_NOUN_REF = re.compile(
         f"^an?[ -]+([^ -].*)$",
         re.IGNORECASE)

--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -120,6 +120,21 @@ class EnglishUtils:
         return "%s %s" % (article, word)
 
     @classmethod
+    def maybe_pluralize(cls, n, thing):
+        """
+        Given a number and a noun, returns the singular or plural of the noun as appropriate.
+
+        The number may simply be a collection (list, tuple, etc.), in which case len is used.
+
+        NOTE: The number itself does not appear in the return value.
+              It is used only to determine if pluralization is needed.
+        """
+
+        if isinstance(n, (list, tuple, set, dict)):
+            n = len(n)
+        return thing if n == 1 else cls.string_pluralize(thing)
+
+    @classmethod
     def n_of(cls, n, thing, num_format=None):
         """
         Given a number and a noun, returns the name for that many of that noun.
@@ -397,6 +412,8 @@ class EnglishUtils:
 # Export specific useful functions
 
 a_or_an = EnglishUtils.a_or_an
+
+maybe_pluralize = EnglishUtils.maybe_pluralize
 
 n_of = EnglishUtils.n_of
 

--- a/docs/source/dcicutils.rst
+++ b/docs/source/dcicutils.rst
@@ -4,23 +4,6 @@ API Documentation
 
 Note that JH utils is excluded due to side-effects of importing the module. See the source file for details.
 
-ff_utils
-^^^^^^^^
-
-.. automodule:: dcicutils.ff_utils
-   :members:
-
-s3_utils
-^^^^^^^^
-
-.. automodule:: dcicutils.s3_utils
-  :members:
-
-es_utils
-^^^^^^^^
-
-.. automodule:: dcicutils.es_utils
-  :members:
 
 beanstalk_utils
 ^^^^^^^^^^^^^^^
@@ -28,8 +11,135 @@ beanstalk_utils
 .. automodule:: dcicutils.beanstalk_utils
    :members:
 
+
+command_utils
+^^^^^^^^^^^^^
+
+.. automodule:: dcicutils.command_utils
+   :members:
+
+
+cloudformation_utils
+^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: dcicutils.cloudformation_utils
+   :members:
+
+
+data_utils
+^^^^^^^^^^
+
+.. automodule:: dcicutils.data_utils
+   :members:
+
+
+deployment_utils
+^^^^^^^^^^^^^^^^
+
+.. automodule:: dcicutils.deployment_utils
+   :members:
+
+
+diff_utils
+^^^^^^^^^^
+
+.. automodule:: dcicutils.diff_utils
+   :members:
+
+
+docker_utils
+^^^^^^^^^^^^
+
+.. automodule:: dcicutils.docker_utils
+   :members:
+
+
+ecr_utils
+^^^^^^^^^
+
+.. automodule:: dcicutils.ecr_utils
+  :members:
+
+
+ecs_utils
+^^^^^^^^^
+
+.. automodule:: dcicutils.ecs_utils
+  :members:
+
+
+env_utils
+^^^^^^^^^
+
+.. automodule:: dcicutils.env_utils
+  :members:
+
+
+es_utils
+^^^^^^^^
+
+.. automodule:: dcicutils.es_utils
+  :members:
+
+
+exceptions
+^^^^^^^^^^
+
+.. automodule:: dcicutils.exceptions
+  :members:
+
+
+ff_utils
+^^^^^^^^
+
+.. automodule:: dcicutils.ff_utils
+   :members:
+
+
+lang_utils
+^^^^^^^^^^
+
+.. automodule:: dcicutils.lang_utils
+   :members:
+
+
 log_utils
 ^^^^^^^^^
 
 .. automodule:: dcicutils.log_utils
    :members:
+
+
+misc_utils
+^^^^^^^^^^
+
+.. automodule:: dcicutils.misc_utils
+   :members:
+
+
+qa_utils
+^^^^^^^^
+
+.. automodule:: dcicutils.qa_utils
+   :members:
+
+
+s3_utils
+^^^^^^^^
+
+.. automodule:: dcicutils.s3_utils
+  :members:
+
+
+secrets_utils
+^^^^^^^^^^^^^
+
+.. automodule:: dcicutils.secrets_utils
+  :members:
+
+
+snapshot_utils
+^^^^^^^^^^^^^^
+
+.. automodule:: dcicutils.snapshot_utils
+  :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.2.0"
+version = "2.1.01.b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.1.0.1b2"
+version = "2.1.0.1b3"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.1.0.1b1"
+version = "2.1.0.1b2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.1.0.1b3"
+version = "2.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.1.0.1b0"
+version = "2.1.0.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.1.01.b0"
+version = "2.1.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.1.0"
+version = "2.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_cloudformation_utils.py
+++ b/test/test_cloudformation_utils.py
@@ -21,8 +21,18 @@ def test_dehyphenate():
 
     assert cloudformation_utils.dehyphenate('foo') == 'foo'
     assert cloudformation_utils.dehyphenate('foo-bar') == 'foobar'
+    assert cloudformation_utils.dehyphenate('foo_bar') == 'foo_bar'
     assert cloudformation_utils.dehyphenate('-foo-bar--baz----') == 'foobarbaz'
     assert cloudformation_utils.dehyphenate('-foo123-bar7baz--quux----') == 'foo123bar7bazquux'
+
+
+def test_hyphenify():
+
+    assert cloudformation_utils.hyphenify('foo') == 'foo'
+    assert cloudformation_utils.hyphenify('foo-bar') == 'foo-bar'
+    assert cloudformation_utils.hyphenify('foo_bar') == 'foo-bar'
+    assert cloudformation_utils.hyphenify('_foo_bar__baz____') == '-foo-bar--baz----'
+    assert cloudformation_utils.hyphenify('_foo123-bar7baz__quux----') == '-foo123-bar7baz--quux----'
 
 
 def test_make_key_for_ecs_application_url():

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -1264,7 +1264,7 @@ def test_expand_es_metadata(integrated_ff):
     for pos_case in ['file_processed', 'user', 'file_format', 'award', 'lab']:
         assert pos_case in store
     for neg_case in ['workflow_run_awsem', 'workflow', 'file_reference', 'software', 'workflow_run_sbg',
-                     'quality_metric_pairsqc',  'quality_metric_fastqc']:
+                     'quality_metric_pairsqc', 'quality_metric_fastqc']:
         assert neg_case not in store
     # make sure the frame is raw (default)
     test_item = store['file_processed'][0]
@@ -1537,7 +1537,7 @@ def test_expand_es_metadata_add_wfrs(integrated_ff):
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
     store, uuids = ff_utils.expand_es_metadata(test_list, add_pc_wfr=True, key=key, ff_env=ff_env)
     for pos_case in ['workflow_run_awsem', 'workflow', 'file_reference', 'software', 'workflow_run_sbg',
-                     'quality_metric_pairsqc',  'quality_metric_fastqc']:
+                     'quality_metric_pairsqc', 'quality_metric_fastqc']:
         assert pos_case in store
 
 
@@ -1562,7 +1562,7 @@ def test_expand_es_metadata_ignore_fields(integrated_ff):
                                                key=key, ff_env=ff_env)
     for pos_case in ['workflow_run_awsem', 'workflow', 'file_reference', 'software', 'workflow_run_sbg']:
         assert pos_case in store
-    for neg_case in ['quality_metric_pairsqc',  'quality_metric_fastqc']:
+    for neg_case in ['quality_metric_pairsqc', 'quality_metric_fastqc']:
         assert neg_case not in store
 
 

--- a/test/test_lang_utils.py
+++ b/test/test_lang_utils.py
@@ -2,7 +2,8 @@ import datetime
 import pytest
 
 from dcicutils.lang_utils import (
-    EnglishUtils, a_or_an, select_a_or_an, string_pluralize, conjoined_list, disjoined_list, there_are, must_be_one_of
+    EnglishUtils, a_or_an, select_a_or_an, string_pluralize, conjoined_list, disjoined_list,
+    there_are, must_be_one_of, maybe_pluralize,
 )
 
 
@@ -356,3 +357,17 @@ def test_must_be():
     assert must_be_one_of(['A'], possible='valid', kind='argument') == "The only valid argument is A."
     assert must_be_one_of(['A', 'B'], possible='valid', kind='argument') == "Valid arguments are A and B."
     assert must_be_one_of(['A', 'B', 'C'], possible='valid', kind='argument') == "Valid arguments are A, B and C."
+
+
+def test_maybe_pluralize():
+
+    assert maybe_pluralize(0, 'gene') == 'genes'
+    assert maybe_pluralize(1, 'gene') == 'gene'
+    assert maybe_pluralize(2, 'gene') == 'genes'
+    assert maybe_pluralize(3, 'gene') == 'genes'
+
+    assert maybe_pluralize([], 'gene') == 'genes'
+    assert maybe_pluralize(['a'], 'gene') == 'gene'
+    assert maybe_pluralize(['a', 'b'], 'gene') == 'genes'
+    assert maybe_pluralize(['a', 'b', 'c'], 'gene') == 'genes'
+

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -4,7 +4,7 @@ import os
 import re
 
 from dcicutils.misc_utils import PRINT, remove_suffix
-from dcicutils.lang_utils import maybe_pluralize, there_are
+from dcicutils.lang_utils import there_are
 
 
 _MY_DIR = os.path.dirname(__file__)
@@ -31,19 +31,19 @@ def test_documentation():
 
     with io.open(_DCICUTILS_DOC_FILE) as fp:
 
-        LINE_NUMBER = 0
+        line_number = 0
         current_module = None
         automodules_seen = 0
         prev_line = None
         problems = []
-        expected_modules = {remove_suffix(".py", os.path.basename(file)) for file in _DCICUTILS_FILES} -  SKIP_MODULES
+        expected_modules = {remove_suffix(".py", os.path.basename(file)) for file in _DCICUTILS_FILES} - SKIP_MODULES
         documented_modules = set()
         for line in fp:
-            LINE_NUMBER += 1  # We count the first line as line 1
+            line_number += 1  # We count the first line as line 1
             line = line.strip()
             if _SUBSUBSECTION_LINE.match(line):
                 if current_module and automodules_seen == 0:
-                    problems.append(f"Line {LINE_NUMBER}: Missing automodule declaration for section {current_module}.")
+                    problems.append(f"Line {line_number}: Missing automodule declaration for section {current_module}.")
                 current_module = prev_line
                 automodules_seen = 0
             elif _SECTION_OR_SUBSECTION_LINE.match(line):
@@ -54,15 +54,18 @@ def test_documentation():
                 if matched:
                     automodule_module = matched.group(1)
                     if not current_module:
-                        problems.append(f"Line {LINE_NUMBER}: Unexpected automodule declaration"
+                        problems.append(f"Line {line_number}: Unexpected automodule declaration"
                                         f" outside of module section.")
                     else:
                         documented_modules.add(automodule_module)
-                        if automodules_seen == 1:  # Below that, no issue. Above that, we already warned, so don't duplicate.
-                            problems.append(f"Line {LINE_NUMBER}: More than one automodule"
+                        if automodules_seen == 1:
+                            # If fewer than 1 seen, no issue.
+                            # If more than 1 seen, we already warned, so don't duplicate.
+                            # So really only the n == 1 case matters to us.
+                            problems.append(f"Line {line_number}: More than one automodule"
                                             f" in section {current_module}?")
                         if automodule_module != current_module:
-                            problems.append(f"Line {LINE_NUMBER}: Unexpected automodule declaration"
+                            problems.append(f"Line {line_number}: Unexpected automodule declaration"
                                             f" for section {current_module}: {automodule_module}.")
                     automodules_seen += 1
             prev_line = line

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,0 +1,77 @@
+import glob
+import io
+import os
+import re
+
+from dcicutils.misc_utils import PRINT, remove_suffix
+from dcicutils.lang_utils import maybe_pluralize, there_are
+
+
+_MY_DIR = os.path.dirname(__file__)
+
+_ROOT_DIR = os.path.dirname(_MY_DIR)
+
+_DCICUTILS_DIR = os.path.join(_ROOT_DIR, "dcicutils")
+
+_DCICUTILS_DOC_FILE = os.path.join(_ROOT_DIR, "docs/source/dcicutils.rst")
+
+_DCICUTILS_FILES = glob.glob(os.path.join(_DCICUTILS_DIR, "*.py"))
+
+_SECTION_OR_SUBSECTION_LINE = re.compile(r"^([=]+|[-]+)$")
+
+_SUBSUBSECTION_LINE = re.compile(r"^[\^]+$")
+
+_AUTOMODULE_LINE = re.compile(r"^[.][.][ ]+automodule::[ ]+dcicutils[.](.*)$")
+
+
+SKIP_MODULES = {'jh_utils', '__init__'}
+
+
+def test_documentation():
+
+    with io.open(_DCICUTILS_DOC_FILE) as fp:
+
+        LINE_NUMBER = 0
+        current_module = None
+        automodules_seen = 0
+        prev_line = None
+        problems = []
+        expected_modules = {remove_suffix(".py", os.path.basename(file)) for file in _DCICUTILS_FILES} -  SKIP_MODULES
+        documented_modules = set()
+        for line in fp:
+            LINE_NUMBER += 1  # We count the first line as line 1
+            line = line.strip()
+            if _SUBSUBSECTION_LINE.match(line):
+                if current_module and automodules_seen == 0:
+                    problems.append(f"Line {LINE_NUMBER}: Missing automodule declaration for section {current_module}.")
+                current_module = prev_line
+                automodules_seen = 0
+            elif _SECTION_OR_SUBSECTION_LINE.match(line):
+                current_module = None
+                automodules_seen = 0
+            else:
+                matched = _AUTOMODULE_LINE.match(line)
+                if matched:
+                    automodule_module = matched.group(1)
+                    if not current_module:
+                        problems.append(f"Line {LINE_NUMBER}: Unexpected automodule declaration"
+                                        f" outside of module section.")
+                    else:
+                        documented_modules.add(automodule_module)
+                        if automodules_seen == 1:  # Below that, no issue. Above that, we already warned, so don't duplicate.
+                            problems.append(f"Line {LINE_NUMBER}: More than one automodule"
+                                            f" in section {current_module}?")
+                        if automodule_module != current_module:
+                            problems.append(f"Line {LINE_NUMBER}: Unexpected automodule declaration"
+                                            f" for section {current_module}: {automodule_module}.")
+                    automodules_seen += 1
+            prev_line = line
+        undocumented_modules = expected_modules - documented_modules
+        if undocumented_modules:
+            problems.append(there_are(sorted(undocumented_modules), kind="undocumented module", punctuate=True))
+        if problems:
+            for n, problem in enumerate(problems, start=1):
+                PRINT(f"PROBLEM {n}: {problem}")
+            message = there_are(problems, kind="problem", tense='past', show=False,
+                                context=f"found in the readthedocs declaration file, {_DCICUTILS_DOC_FILE!r}")
+            raise AssertionError(message)


### PR DESCRIPTION
This PR does three main things, each quite different, but each supporting some aspect of orchestration.

* Adds support for dynamically writing shell scripts that is useful for scripts used in the tibanna setup of 4dn-cloud-infra.
* Adds support for more modules to get auto-doc at ReadTheDocs, and adds unit tests that try to help that stay up-to-date. The desire to refer people to the `env_utils` and `s3_utils` documentation made this an issue. Only a handful of the `dcicutils` modules are autodoc'd right now.
* Adds some enhanced pluralization support for multi-word combinations (like "file to load" becoming "files to load")  so that various  other high-level operations like `n_of` and `there_are` can takes such expressions as noun form arguments and do the right thing.

See the `CHANGELOG.rst` for a more detailed summary of changes.

There are a number of small changes due to `flake8` fussing at me. I set up a `.flake8` rule to ignore `F541`, which fusses uselessly about using `f"..."` with no expression placeholders. I don't see any reason to care about that. Weird thing about `flake8` is that doing so overrides their default list of options, so the list has to specifically enumerate the options you think they are defaulting and won't pick up new ones later. :(
