### PR TITLE
Make s3Utils always have an EnvUtils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,13 @@ Change Log
 
   * Add a class ``HealthPageKey`` that holds names of keys expected in health page json.
     This was ported from ``cgap-portal``, which can now start importing from here.
+    Also:
+
+    * Add ``HealthPageKey.TIBANNA_CWLS_BUCKET``.
+
+  * In ``s3Utils``:
+
+    * Add ``TIBANNA_CWLS_BUCKET_SUFFIX``.
 
   * Add an ``EnvManager`` object to manage obtaining and parsing contents of the data in global env bucket.
     Specific capabilities include:
@@ -52,6 +59,12 @@ Change Log
     * When an ``env`` argument is given in creation of ``s3Utils``, an ``EnvManager`` object will be placed in
       the ``.env_manager`` property of the resulting ``s3Utils`` instance. (If no ``env`` argument is given, no
       such object can usefully be created since there is insufficient information.)
+
+* In ``deployment_utils``:
+
+  * Support ``ENCODED_TIBANNA_CWLS_BUCKET`` and a ``--tibanna-cwls-bucket`` command line argument that get merged
+    into ``TIBANNA_CWLS_BUCKET`` for use in ``.ini`` templates.  These default similarly to how the
+    Tibanna output bucket does.
 
 
 2.2.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,14 @@ Change Log
       such object can usefully be created since there is insufficient information.)
 
 
+2.2.1
+=====
+
+* In ``env_utils``:
+
+  * Add ``fourfront-cgap`` to the table of ``CGAP_PUBLIC_URLS``.
+
+
 2.2.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,14 +12,25 @@ Change Log
 
 * In ``qa_utils`` add some support for testing new functionality:
 
+  * In ``MockBoto3``, create a different way to register client classes.
+
   * In ``MockBotoS3Client``:
 
     * Add minimal support for ``head_bucket``.
     * Add minimal support for ``list_objects_v2``.
     * Make ``list_objects`` and ``list_objects_v2``, return a ``KeyCount`` in the result.
 
+  * New class ``MockBotoElasticBeanstalkClient`` for mocking beanstalk behavior.
+
+    * New subclasses ``MockBoto4DNLegacyElasticBeanstalkClient`` and ``MockBotoFooBarElasticBeanstalkClient``
+      that mock behavior of our standard legacy setup and a setup with just a ``fourfront-foo`` and ``fourfront-bar``,
+      respectively.
+
 
 * In ``s3_utils``:
+
+  * Add a class ``HealthPageKey`` that holds names of keys expected in health page json.
+    This was ported from ``cgap-portal``, which can now start importing from here.
 
   * Add an ``EnvManager`` object to manage obtaining and parsing contents of the data in global env bucket.
     Specific capabilities include:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,6 @@ Change Log
       that mock behavior of our standard legacy setup and a setup with just a ``fourfront-foo`` and ``fourfront-bar``,
       respectively.
 
-
 * In ``s3_utils``:
 
   * Add a class ``HealthPageKey`` that holds names of keys expected in health page json.
@@ -49,6 +48,11 @@ Change Log
     * This class also creates suitable abstraction to allow for a future in which the contents of this dictionary
       might include keys ``portal_url``, ``es_url``, and ``env_name`` in lieu of what are now
       ``fourfront``, ``es``, and ``ff_env``, respectively.
+
+    * When an ``env`` argument is given in creation of ``s3Utils``, an ``EnvManager`` object will be placed in
+      the ``.env_manager`` property of the resulting ``s3Utils`` instance. (If no ``env`` argument is given, no
+      such object can usefully be created since there is insufficient information.)
+
 
 2.2.0
 =====

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -332,7 +332,12 @@ def beanstalk_info(env):
     """
     client = boto3.client('elasticbeanstalk', region_name=REGION)
     res = describe_beanstalk_environments(client, EnvironmentNames=[env])
-    return res['Environments'][0]
+    envs = res['Environments']
+    if not envs:
+        raise ClientError({"Error": {"Code": 404, "Message": f"Environment does not exist: {env}"}},
+                          operation_name="beanstalk_info")
+    else:
+        return envs[0]
 
 
 def get_beanstalk_real_url(env):

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -334,7 +334,10 @@ def beanstalk_info(env):
     res = describe_beanstalk_environments(client, EnvironmentNames=[env])
     envs = res['Environments']
     if not envs:
+        # Raise an error that will be meaningful to the caller, rather than just getting an index out of range error.
         raise ClientError({"Error": {"Code": 404, "Message": f"Environment does not exist: {env}"}},
+                          # Properly speaking, this error does not come from .describe_environments(), so we kind of
+                          # have to make up an operation that's failing, even though it's not a boto3 operation.
                           operation_name="beanstalk_info")
     else:
         return envs[0]

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -75,6 +75,7 @@ CGAP_PUBLIC_URL_PRD = 'https://cgap.hms.harvard.edu'
 
 CGAP_PUBLIC_URLS = {
     'cgap': CGAP_PUBLIC_URL_PRD,
+    'fourfront-cgap': CGAP_PUBLIC_URL_PRD,
     'data': CGAP_PUBLIC_URL_PRD,
     'staging': CGAP_PUBLIC_URL_STG,
 }

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2,7 +2,9 @@
 qa_utils: Tools for use in quality assurance testing.
 """
 
+
 import contextlib
+import copy
 import datetime
 import dateutil.tz as dateutil_tz
 import hashlib
@@ -23,6 +25,7 @@ from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAft
 from .misc_utils import (
     PRINT, ignored, Retry, CustomizableProperty, getattr_customized, remove_prefix, REF_TZ,
     environ_bool, exported, override_environ, override_dict, local_attrs, full_class_name,
+    find_associations,
 )
 
 
@@ -854,7 +857,7 @@ class MockBotoS3Client:
             # For now, just fail in any way since maybe our code doesn't care.
             raise Exception("Mock File Not Found")
 
-    def head_bucket(self, Bucket):
+    def head_bucket(self, Bucket):  # noQA - AWS argument naming style
         bucket_prefix = Bucket + "/"
         for filename, content in self.s3_files.files.items():
             if filename.startswith(bucket_prefix):
@@ -1221,3 +1224,169 @@ def known_bug_expected(jira_ticket=None, fixed=False, error_class=None):
         else:
             # If no error occurs, that's probably the fix in play.
             pass
+
+
+def client_failer(operation_name, code=400):
+    def fail(message, code=code):
+        raise ClientError({"Error": {"Message": message, "Code": code}}, operation_name=operation_name)
+    return fail
+
+
+@MockBoto3.register_client(kind='elasticbeanstalk')
+class MockBotoElasticBeanstalkClient:
+
+    DEFAULT_MOCKED_BEANSTALKS = []
+    DEFAULT_MOCKED_CONFIGURATION_SETTINGS = []
+
+    def _default_mocked_beanstalks(self, mocked_beanstalks):
+        return mocked_beanstalks or self.DEFAULT_MOCKED_BEANSTALKS
+
+    def _default_mocked_configuration_settings(self, mocked_configuration_settings):
+        return mocked_configuration_settings or self.DEFAULT_MOCKED_CONFIGURATION_SETTINGS
+
+    def __init__(self, mocked_beanstalks=None, mocked_configuration_settings=None, boto3=None, region_name=None):
+        self.boto3 = boto3 or MockBoto3()
+        self.region_name = region_name
+        self.mocked_beanstalks = self._default_mocked_beanstalks(mocked_beanstalks)
+        self.mocked_configuration_settings = self._default_mocked_configuration_settings(mocked_configuration_settings)
+
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elasticbeanstalk.html#ElasticBeanstalk.Client.describe_environments  # noQA
+    def describe_environments(self, ApplicationName=None, EnvironmentNames=None):  # noQA - AWS picks these names
+        criteria = {}
+        if ApplicationName:
+            criteria['ApplicationName'] = ApplicationName
+        if EnvironmentNames:
+            criteria['EnvironmentName'] = lambda name: name in EnvironmentNames
+        result = find_associations(self.mocked_beanstalks, **criteria)
+        return {
+            "Environments": copy.deepcopy(result),
+            "ResponseMetadata": {
+                "HTTPStatusCode": 200,
+            },
+        }
+
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elasticbeanstalk.html#ElasticBeanstalk.Client.describe_configuration_settings  # noQA
+    def describe_configuration_settings(self, ApplicationName=None, EnvironmentName=None):  # noQA - AWS picks these names
+        criteria = {}
+        if ApplicationName:
+            criteria['ApplicationName'] = ApplicationName
+        if EnvironmentName:
+            criteria['EnvironmentName'] = EnvironmentName
+        result = find_associations(self.mocked_configuration_settings, **criteria)
+        return {
+            "ConfigurationSettings": copy.deepcopy(result),
+            "ResponseMetadata": {
+                "HTTPStatusCode": 200,
+            },
+        }
+
+    def swap_environment_cnames(self, SourceEnvironmentName, DestinationEnvironmentName):  # noQA - AWS picks these names
+        fail = client_failer("SwapEnvironmentCNAMEs", code=404)
+        source_beanstalk = find_associations(self.mocked_beanstalks, EnvironmentName=SourceEnvironmentName)
+        if not source_beanstalk:
+            fail(f"SourceEnvironmentName {SourceEnvironmentName} not found.")
+        destination_beanstalk = find_associations(self.mocked_beanstalks, EnvironmentName=DestinationEnvironmentName)
+        if not destination_beanstalk:
+            fail(f"DestinationEnvironmentName {DestinationEnvironmentName} not found.")
+        old_source_cname = source_beanstalk['CNAME']
+        source_beanstalk['CNAME'] = destination_beanstalk['CNAME']
+        destination_beanstalk['CNAME'] = old_source_cname
+
+    def restart_app_server(self, EnvironmentName):  # noQA - AWS picks these names
+        fail = client_failer("RestartAppServer", code=404)
+        beanstalk = find_associations(self.mocked_beanstalks, EnvironmentName=EnvironmentName)
+        if not beanstalk:
+            fail(f"EnvironmentName {EnvironmentName} not found.")
+        beanstalk['_restarted_count'] = beanstalk.get('_restarted_count', 0) + 1  # a way to tell it happened.
+
+    def create_environment(self, ApplicationName, EnvironmentName, TemplateName, OptionSettings):  # noQA - AWS picks these names
+        raise NotImplementedError("create_environment")
+
+    def update_environment(self, EnvironmentName, TemplateName=None, OptionSettings=None):  # noQA - AWS picks these names
+        raise NotImplementedError("update_environment")
+
+
+def make_mock_beanstalk_cname(env_name):
+    return f"{env_name}.9wzadzju3p.us-east-1.elasticbeanstalk.com"
+
+def make_mock_beanstalk(env_name, cname=None):
+    return {
+        "EnvironmentName": env_name,
+        "ApplicationName": "4dn-web",
+        "CNAME": cname or make_mock_beanstalk_cname(env_name),
+    }
+
+
+_NAMESPACE_AUTOSCALING_LAUNCHCONFIG = "aws:autoscaling:launchconfiguration"
+_NAMESPACE_CLOUDFORMATION_PARAMETER = "aws:cloudformation:template:parameter"
+_NAMESPACE_ENVIRONMENT_VARIABLE = "aws:elasticbeanstalk:application:environment"
+
+
+def make_mock_beanstalk_environment_variables(var_str):
+    # An extra option just as a decoy
+    spec0 = [{"Namespace": _NAMESPACE_AUTOSCALING_LAUNCHCONFIG, "OptionName": "InstanceType", "Value": "c5.xlarge"}]
+    # The string form of the environment variables, as given to CloudFormation
+    spec1 = [{"Namespace": _NAMESPACE_CLOUDFORMATION_PARAMETER, "OptionName": "EnvironmentVariables", "Value": var_str}]
+    # The individually parsed form of the environment variables, like beanstalks use.
+    spec2 = [{"Namespace": _NAMESPACE_ENVIRONMENT_VARIABLE, "OptionName": name, "Value": value}
+             for name, value in [spec.split("=") for spec in var_str.split(",")]]
+    return spec0 + spec1 + spec2
+
+
+_MOCK_APPLICATION_NAME = "4dn-web"
+_MOCK_SERVICE_USERNAME = 'service-accout-name'
+_MOCK_SERVICE_PASSWORD = 'service-accout-pw'
+_MOCK_APPLICATION_OPTIONS_PARTIAL = (
+    f"MOCK_USERNAME={_MOCK_SERVICE_USERNAME},MOCK_PASSWORD={_MOCK_SERVICE_PASSWORD},ENV_NAME="
+)
+
+
+class MockBoto4DNLegacyElasticBeanstalkClient(MockBotoElasticBeanstalkClient):
+
+    DEFAULT_MOCKED_BEANSTALKS = [
+        make_mock_beanstalk("fourfront-cgapdev"),
+        make_mock_beanstalk("fourfront-cgapwolf"),
+        make_mock_beanstalk("fourfront-cgap"),
+        make_mock_beanstalk("fourfront-cgaptest"),
+        make_mock_beanstalk("fourfront-webdev"),
+        make_mock_beanstalk("fourfront-hotseat"),
+        make_mock_beanstalk("fourfront-mastertest"),
+        make_mock_beanstalk("fourfront-green", cname="fourfront-green.us-east-1.elasticbeanstalk.com"),
+        make_mock_beanstalk("fourfront-blue"),
+    ]
+
+    MOCK_APPLICATION_NAME = _MOCK_APPLICATION_NAME
+    MOCK_SERVICE_USERNAME = _MOCK_SERVICE_USERNAME
+    MOCK_SERVICE_PASSWORD = _MOCK_SERVICE_PASSWORD
+
+    DEFAULT_MOCKED_CONFIGURATION_SETTINGS = [
+        {
+            "ApplicationName": _MOCK_APPLICATION_NAME,
+            "EnvironmentName": env_name,
+            "DeploymentStatus": "deployed",
+            "OptionSettings": make_mock_beanstalk_environment_variables(_MOCK_APPLICATION_OPTIONS_PARTIAL + env_name),
+        }
+        for env_name in [beanstalk["EnvironmentName"] for beanstalk in DEFAULT_MOCKED_BEANSTALKS]
+    ]
+
+    @classmethod
+    def all_legacy_beanstalk_names(cls):
+        return [beanstalk["EnvironmentName"] for beanstalk in cls.DEFAULT_MOCKED_BEANSTALKS]
+
+
+class MockBotoFooBarElasticBeanstalkClient(MockBotoElasticBeanstalkClient):
+
+    DEFAULT_MOCKED_BEANSTALKS = [
+        make_mock_beanstalk("fourfront-foo"),
+        make_mock_beanstalk("fourfront-bar"),
+    ]
+
+    DEFAULT_MOCKED_CONFIGURATION_SETTINGS = [
+        {
+            "ApplicationName": _MOCK_APPLICATION_NAME,
+            "EnvironmentName": env_name,
+            "DeploymentStatus": "deployed",
+            "OptionSettings": make_mock_beanstalk_environment_variables(_MOCK_APPLICATION_OPTIONS_PARTIAL + env_name),
+        }
+        for env_name in [beanstalk["EnvironmentName"] for beanstalk in DEFAULT_MOCKED_BEANSTALKS]
+    ]

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1316,6 +1316,7 @@ class MockBotoElasticBeanstalkClient:
 def make_mock_beanstalk_cname(env_name):
     return f"{env_name}.9wzadzju3p.us-east-1.elasticbeanstalk.com"
 
+
 def make_mock_beanstalk(env_name, cname=None):
     return {
         "EnvironmentName": env_name,

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -622,6 +622,13 @@ class MockBoto3:
 
     @classmethod
     def register_client(cls, *, kind):
+        """
+        A decorator for defining classes of mocked clients. Intended use:
+
+            @MockBoto3.register_client(kind='cloudformation')
+            class MockBotoCloudFormationClient:
+                ...etc.
+        """
         def _wrap(cls_to_wrap):
             if cls._CLIENTS.get(kind):
                 raise ValueError(f"A MockBoto3 client for {kind} is already defined.")

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -493,7 +493,6 @@ class EnvManager:
             raise ValueError(f"Missing {self.LEGACY_ES_URL_KEY!r} or {self.ES_URL_KEY!r}"
                              f" key in global_env {env_description}.")
 
-
     @property
     def portal_url(self):
         """

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -428,9 +428,9 @@ class EnvManager:
         that would be needed to create an EnvManager with an env_description argument. The s3 argument is not part
         of that description, but is still needed if available. In other words:
 
-            EnvManager(s3=s3, portal_url=p, es_url=e, env_name=n)
+            EnvManager.compose(s3=s3, portal_url=portal_url, es_url=es_url, env_name=env_name)
             ==
-            EnvManager(s3=s3, env_description={'fourfront': p, 'es': e, 'ff_env': n})
+            EnvManager(s3=s3, env_description={'fourfront': portal_url, 'es': es_url, 'ff_env': env_name})
         """
         # TODO: At some future time, use the non-LEGACY versions of keys.
         description = {

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -27,7 +27,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class HealthPageKey:
+class HealthPageKey:  # This is moving here from cgap-portal.
     APPLICATION_BUCKET_PREFIX = 'application_bucket_prefix'
     BEANSTALK_APP_VERSION = 'beanstalk_app_version'
     BEANSTALK_ENV = 'beanstalk_env'
@@ -81,8 +81,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
     BLOB_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.BLOB_BUCKET                      # = 'blob_bucket'
     METADATA_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.METADATA_BUNDLES_BUCKET      # = 'metadata_bundles_bucket'
     TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.TIBANNA_OUTPUT_BUCKET  # = 'tibanna_output_bucket'
-
-    # NOTE: This is also deprecated, even though not a bucket name. Use HealthPageKey.ELASTICSEARCH.
+    # This is also deprecated, even though not a bucket name. Use HealthPageKey.ELASTICSEARCH.
     ELASTICSEARCH_HEALTH_PAGE_KEY = HealthPageKey.ELASTICSEARCH                  # = 'elasticsearch'
 
     @staticmethod  # backward compatibility in case other repositories are using this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.2.0.1b0"
+version = "2.2.1.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.2.1.1b0"
+version = "2.2.1.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.2.1.1b1"
+version = "2.3.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -77,13 +77,13 @@ INTEGRATED_ENV = 'fourfront-mastertest'
 # but it changes too much, so now we discover it from the 'elasticsearch' and 'namespace' parts of health page...
 INTEGRATED_ES = _discover_es_url_from_boto3_eb_metadata(INTEGRATED_ENV)
 
-@pytest.fixture(scope='session')
-def basestring():
-    try:
-        basestring = basestring  # noQA - PyCharm static analysis doesn't understand this Python 2.7 compatibility issue
-    except NameError:
-        basestring = str
-    return basestring
+# @pytest.fixture(scope='session')
+# def basestring():
+#     try:
+#         basestring = basestring  # noQA - PyCharm static analysis doesn't understand this Python 2.7 compatibility issue
+#     except NameError:
+#         basestring = str
+#     return basestring
 
 
 @pytest.fixture(scope='session')

--- a/test/ini_files/cg_any.ini
+++ b/test/ini_files/cg_any.ini
@@ -10,6 +10,7 @@ system_bucket = ${SYSTEM_BUCKET}
 metadata_bundles_bucket = ${METADATA_BUNDLES_BUCKET}
 sentry_dsn = ${SENTRY_DSN}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = tibanna-cwls
 tibanna_output_bucket = tibanna-output
 app_kind = ${APP_KIND}
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/ini_files/cg_any_alpha.ini
+++ b/test/ini_files/cg_any_alpha.ini
@@ -11,6 +11,7 @@ metadata_bundles_bucket = ${METADATA_BUNDLES_BUCKET}
 sentry_dsn = ${SENTRY_DSN}
 s3_bucket_org = ${S3_BUCKET_ORG}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = ${TIBANNA_CWLS_BUCKET}
 tibanna_output_bucket = ${TIBANNA_OUTPUT_BUCKET}
 app_kind = ${APP_KIND}
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/ini_files/cgap.ini
+++ b/test/ini_files/cgap.ini
@@ -10,6 +10,7 @@ system_bucket = elasticbeanstalk-fourfront-cgap-system
 metadata_bundles_bucket = elasticbeanstalk-fourfront-cgap-metadata-bundles
 sentry_dsn = ${SENTRY_DSN}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = tibanna-cwls
 tibanna_output_bucket = tibanna-output
 app_kind = unknown
 app_deployment = beanstalk

--- a/test/ini_files/cgap_alfa.ini
+++ b/test/ini_files/cgap_alfa.ini
@@ -11,6 +11,7 @@ metadata_bundles_bucket = md-bucket
 sentry_dsn = ${SENTRY_DSN}
 s3_bucket_org = ${S3_BUCKET_ORG}
 identity = ThisIsMyIdentity
+tibanna_cwls_bucket = cwls-bucket
 tibanna_output_bucket = tb-bucket
 app_kind = cgap
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/ini_files/cgap_alpha.ini
+++ b/test/ini_files/cgap_alpha.ini
@@ -11,6 +11,7 @@ metadata_bundles_bucket = ${METADATA_BUNDLES_BUCKET}
 sentry_dsn = ${SENTRY_DSN}
 s3_bucket_org = ${S3_BUCKET_ORG}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = ${TIBANNA_CWLS_BUCKET}
 tibanna_output_bucket = ${TIBANNA_OUTPUT_BUCKET}
 app_kind = cgap
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/ini_files/cgapdev.ini
+++ b/test/ini_files/cgapdev.ini
@@ -10,6 +10,7 @@ system_bucket = elasticbeanstalk-fourfront-cgapdev-system
 metadata_bundles_bucket = elasticbeanstalk-fourfront-cgapdev-metadata-bundles
 sentry_dsn = ${SENTRY_DSN}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = tibanna-cwls
 tibanna_output_bucket = tibanna-output
 app_kind = unknown
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/ini_files/cgaptest.ini
+++ b/test/ini_files/cgaptest.ini
@@ -10,6 +10,7 @@ system_bucket = elasticbeanstalk-fourfront-cgaptest-system
 metadata_bundles_bucket = elasticbeanstalk-fourfront-cgaptest-metadata-bundles
 sentry_dsn = ${SENTRY_DSN}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = tibanna-cwls
 tibanna_output_bucket = tibanna-output
 app_kind = unknown
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/ini_files/cgapwolf.ini
+++ b/test/ini_files/cgapwolf.ini
@@ -10,6 +10,7 @@ system_bucket = elasticbeanstalk-fourfront-cgapwolf-system
 metadata_bundles_bucket = elasticbeanstalk-fourfront-cgapwolf-metadata-bundles
 sentry_dsn = ${SENTRY_DSN}
 identity = ${IDENTITY}
+tibanna_cwls_bucket = tibanna-cwls
 tibanna_output_bucket = tibanna-output
 app_kind = cgap
 app_deployment = ${APP_DEPLOYMENT}

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -788,6 +788,7 @@ def test_deployment_utils_transitional_equivalence():
                                                             "system_bucket": "s-bucket",
                                                             "metadata_bundles_bucket": "md-bucket",
                                                             "identity": "ThisIsMyIdentity",
+                                                            "tibanna_cwls_bucket": "cwls-bucket",
                                                             "tibanna_output_bucket": "tb-bucket",
                                                         }),
                            s3_bucket_env=bs_env,
@@ -801,6 +802,7 @@ def test_deployment_utils_transitional_equivalence():
                            identity='ThisIsMyIdentity',
                            auth0_client="31415926535",
                            auth0_secret="piepipiepipiepi",
+                           tibanna_cwls_bucket="cwls-bucket",
                            tibanna_output_bucket="tb-bucket",
                            )
 
@@ -810,7 +812,8 @@ def test_deployment_utils_transitional_equivalence():
                                           ENCODED_SYSTEM_BUCKET='decoy4',
                                           ENCODED_METADATA_BUNDLES_BUCKET='decoy5',
                                           ENCODED_S3_BUCKET_ORG='decoy6',
-                                          ENCODED_TIBANNA_OUTPUT_BUCKET='decoy7'):
+                                          ENCODED_TIBANNA_OUTPUT_BUCKET='decoy7',
+                                          ENCODED_TIBANNA_CWLS_BUCKET='decoy8'):
                         # The decoy values in the environment variables don't matter because we'll be passing
                         # explicit values for these to the builder that will take precedence.
                         tester(ref_ini="cgap_alfa.ini", any_ini="cg_any_alpha.ini", bs_env=bs_env, data_set=data_set,
@@ -824,6 +827,7 @@ def test_deployment_utils_transitional_equivalence():
                                                                 "blob_bucket": "b-bucket",
                                                                 "system_bucket": "s-bucket",
                                                                 "metadata_bundles_bucket": "md-bucket",
+                                                                "tibanna_cwls_bucket": "cwls-bucket",
                                                                 "tibanna_output_bucket": "tb-bucket",
                                                                 "identity": "ThisIsMyIdentity",
                                                             }),
@@ -834,6 +838,7 @@ def test_deployment_utils_transitional_equivalence():
                                blob_bucket='b-bucket',
                                system_bucket='s-bucket',
                                metadata_bundles_bucket='md-bucket',
+                               tibanna_cwls_bucket="cwls-bucket",
                                tibanna_output_bucket="tb-bucket",
                                identity='ThisIsMyIdentity',
                                )
@@ -845,6 +850,7 @@ def test_deployment_utils_transitional_equivalence():
                                           ENCODED_METADATA_BUNDLES_BUCKET='md-bucket',
                                           ENCODED_S3_BUCKET_ORG=test_alpha_org,
                                           ENCODED_TIBANNA_OUTPUT_BUCKET='tb-bucket',
+                                          ENCODED_TIBANNA_CWLS_BUCKET='cwls-bucket',
                                           ENCODED_IDENTITY='ThisIsMyIdentity'):
                         # If no explicit args are passed to the builder, the ENCODED_xxx arguments DO matter.
                         tester(ref_ini="cgap_alfa.ini", any_ini="cg_any_alpha.ini", bs_env=bs_env, data_set=data_set,
@@ -858,6 +864,7 @@ def test_deployment_utils_transitional_equivalence():
                                                                 "blob_bucket": "b-bucket",
                                                                 "system_bucket": "s-bucket",
                                                                 "metadata_bundles_bucket": "md-bucket",
+                                                                "tibanna_cwls_bucket": "cwls-bucket",
                                                                 "tibanna_output_bucket": "tb-bucket",
                                                                 "identity": "ThisIsMyIdentity",
                                                             }),
@@ -1088,6 +1095,7 @@ def test_deployment_utils_main():
                             'blob_bucket': None,
                             'system_bucket': None,
                             'metadata_bundles_bucket': None,
+                            'tibanna_cwls_bucket': None,
                             'tibanna_output_bucket': None,
                             'application_bucket_prefix': None,
                             'foursight_bucket_prefix': None,
@@ -1116,6 +1124,7 @@ def test_deployment_utils_main():
                             'blob_bucket': None,
                             'system_bucket': None,
                             'metadata_bundles_bucket': None,
+                            'tibanna_cwls_bucket': None,
                             'tibanna_output_bucket': None,
                             'application_bucket_prefix': None,
                             'foursight_bucket_prefix': None,
@@ -1142,6 +1151,7 @@ def test_deployment_utils_main():
                                 'blob_bucket': None,
                                 'system_bucket': None,
                                 'metadata_bundles_bucket': None,
+                                'tibanna_cwls_bucket': None,
                                 'tibanna_output_bucket': None,
                                 'application_bucket_prefix': None,
                                 'foursight_bucket_prefix': None,

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -710,7 +710,7 @@ def test_get_metadata_unit():
 
 @pytest.mark.integratedx
 @pytest.mark.flaky(max_runs=3)  # very flaky for some reason
-def test_get_metadata_integrated(integrated_ff, basestring):
+def test_get_metadata_integrated(integrated_ff):  # , basestring
     # use this test biosource
     test_item = '331111bc-8535-4448-903e-854af460b254'
     res_w_key = ff_utils.get_metadata(test_item, key=integrated_ff['ff_key'])
@@ -743,7 +743,7 @@ def test_get_metadata_integrated(integrated_ff, basestring):
     # check add_on
     assert isinstance(res_w_key['individual'], dict)
     res_obj = ff_utils.get_metadata(test_item, key=integrated_ff['ff_key'], add_on='frame=object')
-    assert isinstance(res_obj['individual'], basestring)
+    assert isinstance(res_obj['individual'], str)  # was basestring
 
 
 @pytest.mark.integrated

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -690,6 +690,7 @@ def test_s3_utils_buckets_modern():
             assert e.es_url == es_server_https
             assert e.env_name == env_name
 
+
 def test_s3_utils_environment_variable_use():
 
     with pytest.raises(SynonymousEnvironmentVariablesMismatched):
@@ -757,7 +758,6 @@ def test_env_manager_fetch_health_page_json():
             self.used_mocked_urlopen = True
             return io.BytesIO(json.dumps(sample_health_page).encode('utf-8'))
 
-
     with mock.patch("requests.get") as mock_get:
         with mock.patch("urllib.request.urlopen") as mock_urlopen:
 
@@ -768,8 +768,8 @@ def test_env_manager_fetch_health_page_json():
             assert EnvManager.fetch_health_page_json("http://something/health?format=json",
                                                      use_urllib=False) == sample_health_page
             # We always use urllib now.
-            assert helper.used_mocked_get == False
-            assert helper.used_mocked_urlopen == True
+            assert helper.used_mocked_get is False
+            assert helper.used_mocked_urlopen is True
 
             helper = MockHelper()
             mock_get.side_effect = helper.mocked_get
@@ -778,8 +778,8 @@ def test_env_manager_fetch_health_page_json():
             assert EnvManager.fetch_health_page_json("http://something/health?format=json",
                                                      use_urllib=True) == sample_health_page
             # We always use urllib now.
-            assert helper.used_mocked_get == False
-            assert helper.used_mocked_urlopen == True
+            assert helper.used_mocked_get is False
+            assert helper.used_mocked_urlopen is True
 
 
 def test_env_manager():

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -78,6 +78,7 @@ def test_s3utils_constants():
     assert s3Utils.RAW_BUCKET_HEALTH_PAGE_KEY == 'file_upload_bucket'
     assert s3Utils.BLOB_BUCKET_HEALTH_PAGE_KEY == 'blob_bucket'
     assert s3Utils.METADATA_BUCKET_HEALTH_PAGE_KEY == 'metadata_bundles_bucket'
+    assert s3Utils.TIBANNA_CWLS_BUCKET_HEALTH_PAGE_KEY == 'tibanna_cwls_bucket'
     assert s3Utils.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY == 'tibanna_output_bucket'
 
 
@@ -631,6 +632,7 @@ def test_s3_utils_legacy_behavior():
         assert s.raw_file_bucket == raw_file_bucket
         assert s.blob_bucket is None
         assert s.metadata_bucket is None
+        assert s.tibanna_cwls_bucket is None
         assert s.tibanna_output_bucket is None
 
         s = s3Utils(sys_bucket=sys_bucket)
@@ -639,6 +641,7 @@ def test_s3_utils_legacy_behavior():
         assert s.raw_file_bucket is None
         assert s.blob_bucket is None
         assert s.metadata_bucket is None
+        assert s.tibanna_cwls_bucket is None
         assert s.tibanna_output_bucket is None
 
     test_it()
@@ -665,6 +668,7 @@ def test_s3_utils_buckets_modern():
                 "file_upload_bucket": "the-raw-file-bucket",
                 "blob-bucket": "the-blob-bucket",
                 "metadata_bundles_bucket": "the-metadata-bundles-bucket",
+                "tibanna_cwls_bucket": "the-tibanna-cwls-bucket",
                 "tibanna_output_bucket": "the-tibanna-output-bucket",
             }
             s = s3Utils(env=env_name)
@@ -673,6 +677,7 @@ def test_s3_utils_buckets_modern():
             assert s.raw_file_bucket != 'the-raw-file-bucket'
             assert s.blob_bucket != 'the-blog-bucket'
             assert s.metadata_bucket != 'the-metadata-bundles-bucket'
+            assert s.tibanna_cwls_bucket != 'the-tibanna-cwls-bucket'
             assert s.tibanna_output_bucket != 'the-tibanna-output-bucket'
 
             assert s.outfile_bucket == 'elasticbeanstalk-fourfront-cgapfoo-wfoutput'
@@ -680,6 +685,7 @@ def test_s3_utils_buckets_modern():
             assert s.raw_file_bucket == 'elasticbeanstalk-fourfront-cgapfoo-files'
             assert s.blob_bucket == 'elasticbeanstalk-fourfront-cgapfoo-blobs'
             assert s.metadata_bucket == 'elasticbeanstalk-fourfront-cgapfoo-metadata-bundles'
+            assert s.tibanna_cwls_bucket == 'tibanna-cwls'
             assert s.tibanna_output_bucket == 'tibanna-output'
 
             e = s.env_manager


### PR DESCRIPTION
This is a branch-to-branch PR adding this capability to the `kmp_s3_utils_env_manager` branch:

* In `qa_utils` add some support for testing new functionality:

  * In `MockBoto3`, create a different way to register client classes.

  * New class `MockBotoElasticBeanstalkClient` for mocking beanstalk behavior.

    * New subclasses `MockBoto4DNLegacyElasticBeanstalkClient` and `MockBotoFooBarElasticBeanstalkClient` that mock behavior of our standard legacy setup and a setup with just a `fourfront-foo` and `fourfront-bar`, respectively.

* In `s3_utils`:

  * Add a class `HealthPageKey` that holds names of keys expected in health page json. This was ported from `cgap-portal`, which can now start importing from here.

    * When an `env` argument is given in creation of `s3Utils`, an `EnvManager` object will be placed in the `.env_manager` property of the resulting `s3Utils` instance. (If no `env` argument is given, no such object can usefully be created since there is insufficient information.)
