### PR TITLE
Allow legacy short name env arguments to S3Utils (C4-706)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Change Log
 ----------
 
 
+2.3.1
+=====
+
+* In ``s3_utils``, fix C4-706, where short names of environments were not accepted
+  as env arguments to s3Utils in legacy CGAP.
+
+
 2.3.0
 =====
 

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -75,7 +75,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
     BLOB_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + BLOB_BUCKET_SUFFIX          # = "elasticbeanstalk-%s-blobs"
     METADATA_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + METADATA_BUCKET_SUFFIX  # = "elasticbeanstalk-%s-metadata-bundles"
     TIBANNA_OUTPUT_BUCKET_TEMPLATE = TIBANNA_OUTPUT_BUCKET_SUFFIX          # = "tibanna-output" (no prefix)
-    TIBANNA_CWLS_BUCKET_TEMPLATE = TIBANNA_CWLS_BUCKET_SUFFIX              # = "tibanna-output" (no prefix)
+    TIBANNA_CWLS_BUCKET_TEMPLATE = TIBANNA_CWLS_BUCKET_SUFFIX              # = "tibanna-cwls" (no prefix)
 
     # NOTE: These are deprecated now and retained for compatibility. Please rewrite uses as HealthPageKey.xyz names.
     SYS_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.SYSTEM_BUCKET                     # = 'system_bucket'
@@ -180,13 +180,14 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
                 #       upstream of the global env bucket branch, too. That's not needed for orchestrated cgap,
                 #       which has no stage, but it will be needed for orchestrated fourfront. -kmp 31-Aug-2021
                 if env:
-                    self.url = get_beanstalk_real_url(env)
                     if is_stg_or_prd_env(env):
+                        self.url = get_beanstalk_real_url(env)  # done BEFORE prod_bucket_env blurring stg/prd
                         env = prod_bucket_env(env)
                     else:
                         # TODO: This is the part that is not yet supported in env_utils, but there is a pending
                         #       patch that will fix that. -kmp 31-AUg-2021
                         env = full_env_name(env)
+                        self.url = get_beanstalk_real_url(env)  # done AFTER maybe prepending cgap- or foursight-.
 
                     health_json_url = f"{self.url}/health?format=json"
                     # In the orchestrated case, we issue a warning here. Do we need that? -kmp 1-Sep-2021

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.3.0"
+version = "2.3.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.3.0.1b0"
+version = "2.3.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -5,12 +5,13 @@ import json
 import os
 import pytest
 
+from botocore.exceptions import ClientError
 from dcicutils import s3_utils as s3_utils_module
 from dcicutils.beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env, compute_cgap_stg_env
 from dcicutils.env_utils import get_standard_mirror_env, FF_PUBLIC_URL_STG, FF_PUBLIC_URL_PRD, CGAP_PUBLIC_URL_PRD
 from dcicutils.exceptions import SynonymousEnvironmentVariablesMismatched, CannotInferEnvFromManyGlobalEnvs
 from dcicutils.misc_utils import ignored, ignorable
-from dcicutils.qa_utils import override_environ, MockBoto3, MockBotoS3Client, MockResponse
+from dcicutils.qa_utils import override_environ, MockBoto3, MockBotoS3Client, MockResponse, known_bug_expected
 from dcicutils.s3_utils import s3Utils, EnvManager
 from unittest import mock
 
@@ -81,6 +82,17 @@ def test_s3utils_constants():
     # We didn't add this slot since it would have been born deprecated. Use HealthPageKey instead.
     # assert s3Utils.TIBANNA_CWLS_BUCKET_HEALTH_PAGE_KEY == 'tibanna_cwls_bucket'
     assert s3Utils.TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY == 'tibanna_output_bucket'
+
+
+@pytest.mark.integrated
+def test_regression_s3_utils_short_name_c4_706():
+
+    # Environment long names work (at least in legacy CGAP)
+    s3Utils(env="fourfront-cgapwolf")
+
+    with known_bug_expected(jira_ticket="C4-706", fixed=False, error_class=ClientError):
+        # Sort names not allowed.
+        s3Utils(env="cgapwolf")
 
 
 @pytest.mark.integrated

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -90,7 +90,7 @@ def test_regression_s3_utils_short_name_c4_706():
     # Environment long names work (at least in legacy CGAP)
     s3Utils(env="fourfront-cgapwolf")
 
-    with known_bug_expected(jira_ticket="C4-706", fixed=False, error_class=ClientError):
+    with known_bug_expected(jira_ticket="C4-706", fixed=True, error_class=ClientError):
         # Sort names not allowed.
         s3Utils(env="cgapwolf")
 


### PR DESCRIPTION
This fixes bug [dcicutils 2.3.0 breaks s3Utils use of env short names (C4-706)](https://hms-dbmi.atlassian.net/browse/C4-706).