### PR TITLE
Teach  guess_local_timezone_for_testing about CET (C4-708) and fix orchestrated s3Utils setup (C4-709)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 ----------
 
 
+2.3.2
+=====
+
+* Support Central European Time for testing.
+
+
 2.3.1
 =====
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -78,6 +78,7 @@ LOCAL_TIMEZONE_MAPPINGS = {
     ('CST', 'CDT'): "US/Central",
     ('MST', 'MDT'): "US/Mountain",
     ('PST', 'PDT'): "US/Pacific",
+    ('CET', 'CEST'): "CET",
 }
 
 

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -489,7 +489,7 @@ class EnvManager:
         if described_env_name:
             if not env_name:
                 env_name = described_env_name
-            elif env_name == described_env_name:
+            elif env_name != described_env_name:
                 raise ValueError(f"The given env name, {env_name},"
                                  f" does not match the name given in the description, {env_description}.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "2.3.1"
+version = "2.3.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -205,6 +205,10 @@ def test_guess_local_timezone_for_testing():
         guess = guess_local_timezone_for_testing()
         assert guess == pytz.timezone("MST")
 
+        mock_tzlocal.side_effect = lambda: MockLocalTimezone(summer_tz='CEST', winter_tz='CET')
+        guess = guess_local_timezone_for_testing()
+        assert guess == pytz.timezone("CET")
+
         with pytest.raises(Exception):
             # Unknown times that disagree will fail.
             mock_tzlocal.side_effect = lambda: MockLocalTimezone(summer_tz='GMT', winter_tz='BST')


### PR DESCRIPTION
This adds `CET` and `CEST` to the table of times known to `dcicutils.qa_utils.guess_local_timezone_for_testing`.

In addition to tests given here for [C4-708](https://hms-dbmi.atlassian.net/browse/C4-708), @andreacosolo has tested that this change fixes his problem.

[C4-709](https://hms-dbmi.atlassian.net/browse/C4-709) has no tests but so for now requires visual inspection. Making this change didn't break any tests.