### PR TITLE
New env_utils functions to replace variable imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Named functions are preferred.
 
   * New function ``short_env_name`` that computes the short name of an environment.
 
+  * New function ``test_permit_load_data`` to gate whether a ``load-data`` command should actually load any data.
+
 
 3.0.1
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,10 @@ Named functions are preferred.
 
   * New function ``test_permit_load_data`` to gate whether a ``load-data`` command should actually load any data.
 
+  * New function ``prod_bucket_env_for_app`` to return the prod_bucket_env for an app.
+
+  * New function ``public_url_for_app`` to return the public production URL for an app.
+
 
 3.0.1
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,29 @@ Change Log
 ----------
 
 
+3.1.0
+=====
+
+This PR is intended to phase out any importation of named constants from ``env_utils``.
+Named functions are preferred.
+
+* New module ``common`` for things that might otherwise go in ``base`` but are OK to import.
+  (The ``base`` module is internal and not for use outside of ``dcicutils``.)
+
+  * Moved ``REGION`` from ``base`` to ``common``, leaving behind an import/exported pair for compatibility,
+    but please import ``REGION`` from ``dcicutils.common`` going forward.
+
+  * ``OrchestratedApp`` and ``EnvName`` for type hinting.
+
+  * ``APP_CGAP`` and ``APP_FOURFRONT`` as a more abstract way of referring to ``'cgap'`` and ``'fourfront'``,
+    respectively, to talk about which orchestrated app is in play.
+
+* In ``env_utils``:
+
+  * New function ``default_workflow_env`` for use in CGAP and Fourfront functions ``run_workflow`` and ``pseudo_run``
+    (in ``src/types/workflow.py``) so that ``CGAP_ENV_WEBDEV`` and ``FF_ENV_WEBDEV`` do not need to be imported.
+
+
 3.0.1
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,11 @@ Named functions are preferred.
   * New function ``default_workflow_env`` for use in CGAP and Fourfront functions ``run_workflow`` and ``pseudo_run``
     (in ``src/types/workflow.py``) so that ``CGAP_ENV_WEBDEV`` and ``FF_ENV_WEBDEV`` do not need to be imported.
 
+  * New function ``infer_foursight_url_from_env``, similar to ``infer_foursight_from_env`` but returns a URL
+    rather than an environment short name.
+
+  * New function ``short_env_name`` that computes the short name of an environment.
+
 
 3.0.1
 =====

--- a/dcicutils/base.py
+++ b/dcicutils/base.py
@@ -2,14 +2,13 @@ import boto3
 import time
 
 from botocore.exceptions import ClientError
+from dcicutils.common import REGION
 from dcicutils.misc_utils import PRINT
 from dcicutils.env_utils import (
     is_cgap_env, is_fourfront_env, is_stg_or_prd_env, public_url_mappings,
     blue_green_mirror_env, get_standard_mirror_env,
 )
 
-
-REGION = 'us-east-1'
 
 FOURSIGHT_URL = 'https://foursight.4dnucleome.org/'
 
@@ -69,7 +68,7 @@ def beanstalk_info(env):
     envs = res['Environments']
     if not envs:
         # Raise an error that will be meaningful to the caller, rather than just getting an index out of range error.
-        raise ClientError({"Error": {"Code": 404, "Message": f"Environment does not exist: {env}"}},
+        raise ClientError({"Error": {"Code": 404, "Message": f"Environment does not exist: {env}"}},  # noQA
                           # Properly speaking, this error does not come from .describe_environments(), so we kind of
                           # have to make up an operation that's failing, even though it's not a boto3 operation.
                           operation_name="beanstalk_info")

--- a/dcicutils/common.py
+++ b/dcicutils/common.py
@@ -1,0 +1,13 @@
+from typing_extensions import Literal
+
+
+REGION = 'us-east-1'
+
+APP_CGAP = 'cgap'
+APP_FOURFRONT = 'fourfront'
+
+ORCHESTRATED_APPS = [APP_CGAP, APP_FOURFRONT]
+
+# Type hinting names
+EnvName = str
+OrchestratedApp = Literal['cgap', 'fourfront']   # Note: these values must be syntactic literals, can't use vars above

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -264,7 +264,38 @@ def blue_green_mirror_env(envname):
         return None
 
 
-def prod_bucket_env(envname):
+def public_url_for_app(appname):
+    """
+    Returns the public production URL for the given application.
+
+    :param appname: the application name token ('cgap' or 'fourfront')
+    """
+
+    return _orchestrated_app_case(orchestrated_app=appname,
+                                  if_cgap=CGAP_PUBLIC_URL_PRD,
+                                  if_fourfront=FF_PUBLIC_URL_PRD)
+
+
+def prod_bucket_env_for_app(appname=None):
+    """
+    Returns the prod bucket app for a given application name.
+    If no application is given, the legacy beanstalk default is 'fourfront',
+    but the orchestrated default will be the currently orchestrated app.
+    That's weird because it means that prod_bucket_env_for_app() will return 'fourfront-webprod' even for cgap
+    when using beanstalks, but that's what we want for compatibility purposes.
+    This will all be better in containers.
+    Passing an explicit argument can still obtain the cgap prod bucket.
+
+    :param appname: the name of the app (either 'cgap' or 'fourfront')
+    """
+    if appname is None:
+        appname = 'fourfront'
+    return _orchestrated_app_case(orchestrated_app=appname,
+                                  if_cgap=CGAP_PROD_BUCKET_ENV,
+                                  if_fourfront=FF_PROD_BUCKET_ENV)
+
+
+def prod_bucket_env(envname=None):
     """
     Given a production-class envname returns the envname of the associated production bucket.
     For other envnames that aren't production envs, this returns None.

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1,7 +1,20 @@
 import os
 
+from .common import EnvName, OrchestratedApp, APP_CGAP, APP_FOURFRONT, ORCHESTRATED_APPS
+from .exceptions import InvalidParameterError
 from .misc_utils import get_setting_from_context, check_true
 from urllib.parse import urlparse
+
+
+# Mechanisms for returning app-dependent values.
+
+def _orchestrated_app_case(orchestrated_app: OrchestratedApp, if_cgap, if_fourfront):
+    if orchestrated_app == APP_CGAP:
+        return if_cgap
+    elif orchestrated_app == APP_FOURFRONT:
+        return if_fourfront
+    else:
+        raise InvalidParameterError(parameter='orchestrated_app', value=orchestrated_app, options=ORCHESTRATED_APPS)
 
 
 FF_ENV_DEV = 'fourfront-dev'  # Maybe not used
@@ -152,7 +165,7 @@ BEANSTALK_DEV_DATA_SETS = {
 }
 
 
-def is_indexer_env(envname):
+def is_indexer_env(envname: EnvName):
     """ Checks whether envname is an indexer environment.
 
     :param envname:  envname to check
@@ -219,6 +232,16 @@ def prod_bucket_env(envname):
     that ecosystem.
     """
     return BEANSTALK_PROD_BUCKET_ENVS.get(envname)
+
+
+def default_workflow_env(orchestrated_app) -> EnvName:
+    """
+    Given orchestrated app ('cgap' or 'fourfront'), this returns the default env name (in case None is supplied)
+    to use for actual and simulated tibanna workflow runs.
+    """
+    return _orchestrated_app_case(orchestrated_app=orchestrated_app,
+                                  if_cgap=CGAP_ENV_WEBDEV,
+                                  if_fourfront=FF_ENV_WEBDEV)
 
 
 def get_bucket_env(envname):

--- a/docs/source/dcicutils.rst
+++ b/docs/source/dcicutils.rst
@@ -26,6 +26,13 @@ command_utils
    :members:
 
 
+common
+^^^^^^
+
+.. automodule:: dcicutils.common
+   :members:
+
+
 cloudformation_utils
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1.1b0"
+version = "3.0.1.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1.1b1"
+version = "3.0.1.1b2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1.1b4"
+version = "3.0.1.1b5"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1.1b3"
+version = "3.0.1.1b4"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1.1b5"
+version = "3.1.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1.1b2"
+version = "3.0.1.1b3"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.0.1"
+version = "3.0.1.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/fixtures/sample_fixtures.py
+++ b/test/fixtures/sample_fixtures.py
@@ -19,7 +19,7 @@ class MockMath:
             raise MockMathError("Math is not enabled.")
 
 
-@pytest.yield_fixture()
+@pytest.fixture()  # formerly pytest.yield_fixture, but that is now deprecated. -kmp 3-Oct-2021
 def math_enabled():
     with mock.patch.object(MockMath, "MATH_ENABLED", True):
         yield

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -261,27 +261,27 @@ def _mocked_describe_beanstalk_environments(*args, **kwargs):
     return {
         'Environments': [
             {
-                "CNAME": "not." + base._CGAP_MAGIC_CNAME,
+                "CNAME": "not." + base._CGAP_MAGIC_CNAME,  # noQA - for testing, don't fuss access protected member
                 "EnvironmentName": "cgap-env-1"
             },
             {
-                "CNAME": base._CGAP_MAGIC_CNAME,
+                "CNAME": base._CGAP_MAGIC_CNAME,  # noQA - for testing, don't fuss access protected member
                 "EnvironmentName": "cgap-env-2"
             },
             {
-                "CNAME": "also-not." + base._CGAP_MAGIC_CNAME,
+                "CNAME": "also-not." + base._CGAP_MAGIC_CNAME,  # noQA - for testing, don't fuss access protected member
                 "EnvironmentName": "cgap-env-3"
             },
             {
-                "CNAME": "not." + base._FF_MAGIC_CNAME,
+                "CNAME": "not." + base._FF_MAGIC_CNAME,  # noQA - for testing, don't fuss access protected member
                 "EnvironmentName": "ff-env-1"
             },
             {
-                "CNAME": base._FF_MAGIC_CNAME,
+                "CNAME": base._FF_MAGIC_CNAME,  # noQA - for testing, don't fuss access protected member
                 "EnvironmentName": "ff-env-2"
             },
             {
-                "CNAME": "also-not." + base._FF_MAGIC_CNAME,
+                "CNAME": "also-not." + base._FF_MAGIC_CNAME,  # noQA - for testing, don't fuss access protected member
                 "EnvironmentName": "ff-env-3"
             },
         ]

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,8 @@
+from dcicutils.common import EnvName, OrchestratedApp, APP_CGAP, APP_FOURFRONT, ORCHESTRATED_APPS
+
+
+def test_app_constants():
+
+    assert set(ORCHESTRATED_APPS) == {APP_CGAP, APP_FOURFRONT} == {'cgap', 'fourfront'}
+
+

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -5,4 +5,6 @@ def test_app_constants():
 
     assert set(ORCHESTRATED_APPS) == {APP_CGAP, APP_FOURFRONT} == {'cgap', 'fourfront'}
 
-
+    # For thexe next two, which are really type hints, just test that they exist.
+    assert EnvName
+    assert OrchestratedApp

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -88,65 +88,74 @@ def test_permit_load_data():
     fourfront_envs = ['fourfront-blue', 'fourfront-green', 'fourfront-hotseat', 'fourfront-webdev',
                       'fourfront-webprod', 'fourfront-webprod2']
 
-    for fourfront_env in fourfront_envs:
-        for allow_prod in [True, False]:
-            expected = True if fourfront_env == 'fourfront-hotseat' else allow_prod
-            assert permit_load_data(fourfront_env, allow_prod=allow_prod, orchestrated_app='fourfront') == expected
+    # This shows concisely what's going on...
 
-    # assert permit_load_data('fourfront-blue', allow_prod=True, orchestrated_app='fourfront') is True
-    # assert permit_load_data('fourfront-blue', allow_prod=False, orchestrated_app='fourfront') is False
-    #
-    # assert permit_load_data('fourfront-green', allow_prod=True, orchestrated_app='fourfront') is True
-    # assert permit_load_data('fourfront-green', allow_prod=False, orchestrated_app='fourfront') is False
-    #
-    # assert permit_load_data('fourfront-hotseat', allow_prod=True, orchestrated_app='fourfront') is True
-    # assert permit_load_data('fourfront-hotseat', allow_prod=False, orchestrated_app='fourfront') is True
-    #
-    # assert permit_load_data('fourfront-webdev', allow_prod=True, orchestrated_app='fourfront') is True
-    # assert permit_load_data('fourfront-webdev', allow_prod=False, orchestrated_app='fourfront') is False
-    #
-    # assert permit_load_data('fourfront-webprod', allow_prod=True, orchestrated_app='fourfront') is True
-    # assert permit_load_data('fourfront-webprod', allow_prod=False, orchestrated_app='fourfront') is False
-    #
-    # assert permit_load_data('fourfront-webprod2', allow_prod=True, orchestrated_app='fourfront') is True
-    # assert permit_load_data('fourfront-webprod2', allow_prod=False, orchestrated_app='fourfront') is False
+    for ff_env in fourfront_envs:
+        for allow_prod in [True, False]:
+            expected = False if ff_env == 'fourfront-hotseat' else (allow_prod or not is_stg_or_prd_env(ff_env))
+            print(f"ff_env={ff_env} allow_prod={allow_prod} orchestrated_app='fourfront' expected={expected}")
+            assert permit_load_data(ff_env, allow_prod=allow_prod, orchestrated_app='fourfront') == expected
+
+    # This is redundant, doing it longhand for review...
+
+    assert permit_load_data('fourfront-blue', allow_prod=True, orchestrated_app='fourfront') is True
+    assert permit_load_data('fourfront-blue', allow_prod=False, orchestrated_app='fourfront') is False
+
+    assert permit_load_data('fourfront-green', allow_prod=True, orchestrated_app='fourfront') is True
+    assert permit_load_data('fourfront-green', allow_prod=False, orchestrated_app='fourfront') is False
+
+    assert permit_load_data('fourfront-hotseat', allow_prod=True, orchestrated_app='fourfront') is False
+    assert permit_load_data('fourfront-hotseat', allow_prod=False, orchestrated_app='fourfront') is False
+
+    assert permit_load_data('fourfront-webdev', allow_prod=True, orchestrated_app='fourfront') is True
+    assert permit_load_data('fourfront-webdev', allow_prod=False, orchestrated_app='fourfront') is True
+
+    assert permit_load_data('fourfront-webprod', allow_prod=True, orchestrated_app='fourfront') is True
+    assert permit_load_data('fourfront-webprod', allow_prod=False, orchestrated_app='fourfront') is False
+
+    assert permit_load_data('fourfront-webprod2', allow_prod=True, orchestrated_app='fourfront') is True
+    assert permit_load_data('fourfront-webprod2', allow_prod=False, orchestrated_app='fourfront') is False
 
     # CGAP envs
 
     cgap_envs = ['fourfront-cgap', 'fourfront-cgapdev', 'fourfront-cgaptest', 'fourfront-cgapwolf',
                  'cgap-blue', 'cgap-green', 'cgap-dev', 'cgap-test', 'cgap-wolf']
 
+    # This shows concisely what's going on...
+
     for cgap_env in cgap_envs:
         for allow_prod in [True, False]:
             expected = True if cgap_env == 'fourfront-cgaptest' else allow_prod
             assert permit_load_data(cgap_env, allow_prod=allow_prod, orchestrated_app='cgap') == expected
 
-    # assert permit_load_data('fourfront-cgap', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('fourfront-cgap', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('fourfront-cgapdev', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('fourfront-cgapdev', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('fourfront-cgaptest', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('fourfront-cgaptest', allow_prod=False, orchestrated_app='cgap') is True
-    #
-    # assert permit_load_data('fourfront-cgapwolf', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('fourfront-cgapwolf', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('cgap-blue', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('cgap-blue', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('cgap-green', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('cgap-green', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('cgap-dev', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('cgap-dev', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('cgap-test', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('cgap-test', allow_prod=False, orchestrated_app='cgap') is False
-    #
-    # assert permit_load_data('cgap-wolf', allow_prod=True, orchestrated_app='cgap') is True
-    # assert permit_load_data('cgap-wolf', allow_prod=False, orchestrated_app='cgap') is False
+    # This is redundant, doing it longhand for review...
+
+    assert permit_load_data('fourfront-cgap', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('fourfront-cgap', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('fourfront-cgapdev', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('fourfront-cgapdev', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('fourfront-cgaptest', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('fourfront-cgaptest', allow_prod=False, orchestrated_app='cgap') is True
+
+    assert permit_load_data('fourfront-cgapwolf', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('fourfront-cgapwolf', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('cgap-blue', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('cgap-blue', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('cgap-green', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('cgap-green', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('cgap-dev', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('cgap-dev', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('cgap-test', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('cgap-test', allow_prod=False, orchestrated_app='cgap') is False
+
+    assert permit_load_data('cgap-wolf', allow_prod=True, orchestrated_app='cgap') is True
+    assert permit_load_data('cgap-wolf', allow_prod=False, orchestrated_app='cgap') is False
 
 
 def test_data_set_for_env():

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -11,13 +11,14 @@ from dcicutils.env_utils import (
     CGAP_ENV_PRODUCTION_BLUE_NEW, CGAP_ENV_PRODUCTION_GREEN_NEW, CGAP_ENV_WEBPROD_NEW, CGAP_ENV_MASTERTEST_NEW,
     CGAP_ENV_HOTSEAT_NEW, CGAP_ENV_STAGING_NEW, CGAP_ENV_WEBDEV_NEW, CGAP_ENV_WOLF_NEW,
     FF_PRODUCTION_IDENTIFIER, CGAP_PRODUCTION_IDENTIFIER,
-    get_mirror_env_from_context, is_test_env, is_hotseat_env, get_standard_mirror_env,
+    get_mirror_env_from_context, is_test_env, is_hotseat_env, get_standard_mirror_env, prod_bucket_env_for_app,
     prod_bucket_env, public_url_mappings, CGAP_PUBLIC_URLS, FF_PUBLIC_URLS, FF_PROD_BUCKET_ENV, CGAP_PROD_BUCKET_ENV,
+    CGAP_PUBLIC_URL_PRD, FF_PUBLIC_URL_PRD,
     infer_repo_from_env, data_set_for_env, get_bucket_env, infer_foursight_from_env, infer_foursight_url_from_env,
     FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV, CGAP_PUBLIC_DOMAIN_PRD,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env, classify_server_url,
     short_env_name, full_env_name, full_cgap_env_name, full_fourfront_env_name, is_cgap_server, is_fourfront_server,
-    make_env_name_cfn_compatible, default_workflow_env, permit_load_data,
+    make_env_name_cfn_compatible, default_workflow_env, permit_load_data, public_url_for_app,
 )
 from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import raises_regexp
@@ -55,6 +56,18 @@ def test_get_bucket_env():
 
     assert get_bucket_env('fourfront-cgapdev') == 'fourfront-cgapdev'
     assert get_bucket_env('fourfront-cgapwolf') == 'fourfront-cgapwolf'
+
+
+def test_prod_bucket_env_for_app():
+
+    assert prod_bucket_env_for_app('fourfront') == FF_PROD_BUCKET_ENV
+    assert prod_bucket_env_for_app('cgap') == CGAP_PROD_BUCKET_ENV
+
+    assert prod_bucket_env_for_app() == FF_PROD_BUCKET_ENV
+    assert prod_bucket_env_for_app(None) == FF_PROD_BUCKET_ENV
+
+    with pytest.raises(InvalidParameterError):
+        prod_bucket_env_for_app('foo')
 
 
 def test_prod_bucket_env():
@@ -192,6 +205,15 @@ def test_public_url_mappings():
     assert public_url_mappings('fourfront-cgap-green') == CGAP_PUBLIC_URLS
     assert public_url_mappings('cgap-blue') == CGAP_PUBLIC_URLS
     assert public_url_mappings('cgap-green') == CGAP_PUBLIC_URLS
+
+
+def test_public_url_for_app():
+
+    assert public_url_for_app('cgap') == CGAP_PUBLIC_URL_PRD
+    assert public_url_for_app('fourfront') == FF_PUBLIC_URL_PRD
+
+    with pytest.raises(InvalidParameterError):
+        public_url_for_app('foo')
 
 
 def test_blue_green_mirror_env():

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -27,8 +27,14 @@ from unittest import mock
 
 def test_default_workflow_env():
 
-    assert default_workflow_env('fourfront') == default_workflow_env(APP_FOURFRONT) == FF_ENV_WEBDEV
-    assert default_workflow_env('cgap') == default_workflow_env(APP_CGAP) == CGAP_ENV_WEBDEV
+    assert (default_workflow_env('fourfront')
+            == default_workflow_env(APP_FOURFRONT)
+            == FF_ENV_WEBDEV
+            == 'fourfront-webdev')
+    assert (default_workflow_env('cgap')
+            == default_workflow_env(APP_CGAP)
+            == CGAP_ENV_WOLF
+            == 'fourfront-cgapwolf')
 
     with pytest.raises(InvalidParameterError):
         default_workflow_env('foo')

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 
+from dcicutils.common import APP_CGAP, APP_FOURFRONT
 from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env, BEANSTALK_PROD_MIRRORS,
     FF_ENV_PRODUCTION_BLUE, FF_ENV_PRODUCTION_GREEN, FF_ENV_WEBPROD, FF_ENV_WEBPROD2, FF_ENV_MASTERTEST,
@@ -15,10 +16,20 @@ from dcicutils.env_utils import (
     FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env, classify_server_url,
     full_env_name, full_cgap_env_name, full_fourfront_env_name, is_cgap_server, is_fourfront_server,
-    make_env_name_cfn_compatible,
+    make_env_name_cfn_compatible, default_workflow_env,
 )
+from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
+
+
+def test_default_workflow_env():
+
+    assert default_workflow_env('fourfront') == default_workflow_env(APP_FOURFRONT) == FF_ENV_WEBDEV
+    assert default_workflow_env('cgap') == default_workflow_env(APP_CGAP) == CGAP_ENV_WEBDEV
+
+    with pytest.raises(InvalidParameterError):
+        default_workflow_env('foo')
 
 
 def test_get_bucket_env():

--- a/test/test_env_utils.py
+++ b/test/test_env_utils.py
@@ -17,7 +17,7 @@ from dcicutils.env_utils import (
     FF_STAGING_IDENTIFIER, FF_PUBLIC_DOMAIN_PRD, FF_PUBLIC_DOMAIN_STG, CGAP_ENV_DEV, CGAP_PUBLIC_DOMAIN_PRD,
     FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, indexer_env_for_env, classify_server_url,
     short_env_name, full_env_name, full_cgap_env_name, full_fourfront_env_name, is_cgap_server, is_fourfront_server,
-    make_env_name_cfn_compatible, default_workflow_env,
+    make_env_name_cfn_compatible, default_workflow_env, permit_load_data,
 )
 from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import raises_regexp
@@ -79,6 +79,74 @@ def test_prod_bucket_env():
 
     assert prod_bucket_env('fourfront-cgapdev') is None
     assert prod_bucket_env('fourfront-cgapwolf') is None
+
+
+def test_permit_load_data():
+
+    # Fourfront envs
+
+    fourfront_envs = ['fourfront-blue', 'fourfront-green', 'fourfront-hotseat', 'fourfront-webdev',
+                      'fourfront-webprod', 'fourfront-webprod2']
+
+    for fourfront_env in fourfront_envs:
+        for allow_prod in [True, False]:
+            expected = True if fourfront_env == 'fourfront-hotseat' else allow_prod
+            assert permit_load_data(fourfront_env, allow_prod=allow_prod, orchestrated_app='fourfront') == expected
+
+    # assert permit_load_data('fourfront-blue', allow_prod=True, orchestrated_app='fourfront') is True
+    # assert permit_load_data('fourfront-blue', allow_prod=False, orchestrated_app='fourfront') is False
+    #
+    # assert permit_load_data('fourfront-green', allow_prod=True, orchestrated_app='fourfront') is True
+    # assert permit_load_data('fourfront-green', allow_prod=False, orchestrated_app='fourfront') is False
+    #
+    # assert permit_load_data('fourfront-hotseat', allow_prod=True, orchestrated_app='fourfront') is True
+    # assert permit_load_data('fourfront-hotseat', allow_prod=False, orchestrated_app='fourfront') is True
+    #
+    # assert permit_load_data('fourfront-webdev', allow_prod=True, orchestrated_app='fourfront') is True
+    # assert permit_load_data('fourfront-webdev', allow_prod=False, orchestrated_app='fourfront') is False
+    #
+    # assert permit_load_data('fourfront-webprod', allow_prod=True, orchestrated_app='fourfront') is True
+    # assert permit_load_data('fourfront-webprod', allow_prod=False, orchestrated_app='fourfront') is False
+    #
+    # assert permit_load_data('fourfront-webprod2', allow_prod=True, orchestrated_app='fourfront') is True
+    # assert permit_load_data('fourfront-webprod2', allow_prod=False, orchestrated_app='fourfront') is False
+
+    # CGAP envs
+
+    cgap_envs = ['fourfront-cgap', 'fourfront-cgapdev', 'fourfront-cgaptest', 'fourfront-cgapwolf',
+                 'cgap-blue', 'cgap-green', 'cgap-dev', 'cgap-test', 'cgap-wolf']
+
+    for cgap_env in cgap_envs:
+        for allow_prod in [True, False]:
+            expected = True if cgap_env == 'fourfront-cgaptest' else allow_prod
+            assert permit_load_data(cgap_env, allow_prod=allow_prod, orchestrated_app='cgap') == expected
+
+    # assert permit_load_data('fourfront-cgap', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('fourfront-cgap', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('fourfront-cgapdev', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('fourfront-cgapdev', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('fourfront-cgaptest', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('fourfront-cgaptest', allow_prod=False, orchestrated_app='cgap') is True
+    #
+    # assert permit_load_data('fourfront-cgapwolf', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('fourfront-cgapwolf', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('cgap-blue', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('cgap-blue', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('cgap-green', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('cgap-green', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('cgap-dev', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('cgap-dev', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('cgap-test', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('cgap-test', allow_prod=False, orchestrated_app='cgap') is False
+    #
+    # assert permit_load_data('cgap-wolf', allow_prod=True, orchestrated_app='cgap') is True
+    # assert permit_load_data('cgap-wolf', allow_prod=False, orchestrated_app='cgap') is False
 
 
 def test_data_set_for_env():

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -2,7 +2,6 @@ import contextlib
 import datetime
 import io
 import json
-import logging
 import os
 import pytest
 import requests
@@ -95,6 +94,7 @@ def _env_is_up_and_healthy(env):
     env_url = beanstalk_utils.get_beanstalk_real_url(env)
     health_page_url = f"{env_url}/health?format=json"
     return requests.get(health_page_url).status_code == 200
+
 
 @pytest.mark.integrated
 @pytest.mark.parametrize('ff_ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev', 'fourfront-hotseat'])


### PR DESCRIPTION
Support for phasing out variable imports from env_utils in other repos.

* New module `common` for things that might otherwise go in `base` but are OK to import. (The `base` module is internal and not for use outside of `dcicutils`.)

  * Moved `REGION` from `base` to `common`, leaving behind an import/exported pair for compatibility, but please import `REGION` from `dcicutils.common` going forward.

  * `OrchestratedApp` and `EnvName` for type hinting.

  * `APP_CGAP` and `APP_FOURFRONT` as a more abstract way of referring to `'cgap'` and `'fourfront'`, respectively, to talk about which orchestrated app is in play.

* In `env_utils`:

  * New function `default_workflow_env` for use in CGAP and Fourfront functions `run_workflow` and `pseudo_run` (in `src/types/workflow.py`) so that `CGAP_ENV_WEBDEV` and `FF_ENV_WEBDEV` do not need to be imported.

  * New function `infer_foursight_url_from_env`, similar to `infer_foursight_from_env` but returns a URL rather than an environment short name.

  * New function `short_env_name` that computes the short name of an environment.

  * New function `test_permit_load_data` to gate whether a `load-data` command should actually load any data.

  * New function `prod_bucket_env_for_app` to return the prod_bucket_env for an app.

  * New function `public_url_for_app` to return the public production URL for an app.

Also, opportunistic:

* Some related PEP8.
* Replace `pytest.yield_fixture` with `pytest.fixture` to deal with deprecation warning.

