### PR TITLE
Add configurable mirroring (C4-734)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,31 @@ Change Log
 4.0.0
 =====
 
-Configurable support for orchestrated CGAP in ``env_utils``.
+* Configurable support for orchestrated CGAP in ``env_utils`` (C4-689).
+
+* Extend that support to allow mirroring to be enabled (C4-734).
+
+The net result is a configurable environment in which the env descriptor in the global env bucket can contain
+these new items:
+
+=============================  ============================================================
+    Key                            Notes
+=============================  ============================================================
+``"dev_data_set_table"``       Dictionary mapping envnames to their preferred data set
+``"dev_env_domain_suffix"``    e.g., .abc123def456ghi789.us-east-1.rds.amazonaws.com
+``"foursight_url_prefix"``
+``"full_env_prefix"``          A string like "cgap-" that precedes all env names
+``"hotseat_envs"``             A list of environments that are for testing with hot data
+``"indexer_env_name"``         The environment name used for indexing
+``"is_legacy"``
+``"stage_mirroring_enabled"``
+``"orchestrated_app"``         This allows us to tell 'cgap' from 'fourfront', in case there ever is one.
+``"prd_bucket"``
+``"prd_env_name"``             The name of the prod env
+``"public_url_table"``         Dictionary mapping envnames & pseudo_envnames to public urls
+``"stg_env_name"``             The name of the stage env (or None)
+``"test_envs"``                A list of environments that are for testing
+=============================  ============================================================
 
 
 3.1.0

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -79,7 +79,7 @@ class EnvNames:
     HOTSEAT_ENVS = 'hotseat_envs'  # a list of environments that are for testing with hot data
     INDEXER_ENV_NAME = 'indexer_env_name'  # the environment name used for indexing
     IS_LEGACY = 'is_legacy'
-    STAGE_MIRRORING_ENABLED = "stage_mirroring_enabled"
+    STAGE_MIRRORING_ENABLED = 'stage_mirroring_enabled'
     ORCHESTRATED_APP = 'orchestrated_app'  # This allows us to tell 'cgap' from 'fourfront', in case there ever is one.
     PRD_BUCKET = 'prd_bucket'
     PRD_ENV_NAME = 'prd_env_name'  # the name of the prod env

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -54,7 +54,7 @@ def if_orchestrated(unimplemented=False, use_legacy=False, assumes_cgap=False, a
                 return legacy_fn(*args, **kwargs)
             elif unimplemented:
                 raise NotImplementedError(f"Unimplemented: {full_object_name(fn)}")
-            elif assumes_no_mirror and STAGE_MIRRORING_ENABLED:
+            elif assumes_no_mirror and EnvUtils.STAGE_MIRRORING_ENABLED:
                 raise NotImplementedError(f"In {full_object_name(fn)}:"
                                           f" Mirroring is not supported in an orchestrated environment.")
             elif assumes_cgap and EnvUtils.ORCHESTRATED_APP != 'cgap':
@@ -79,6 +79,7 @@ class EnvNames:
     HOTSEAT_ENVS = 'hotseat_envs'  # a list of environments that are for testing with hot data
     INDEXER_ENV_NAME = 'indexer_env_name'  # the environment name used for indexing
     IS_LEGACY = 'is_legacy'
+    STAGE_MIRRORING_ENABLED = "stage_mirroring_enabled"
     ORCHESTRATED_APP = 'orchestrated_app'  # This allows us to tell 'cgap' from 'fourfront', in case there ever is one.
     PRD_BUCKET = 'prd_bucket'
     PRD_ENV_NAME = 'prd_env_name'  # the name of the prod env
@@ -133,6 +134,11 @@ class EnvUtils:
     HOTSEAT_ENVS = None
     INDEXER_ENV_NAME = None  # the environment name used for indexing
     IS_LEGACY = None
+    # Don't enable this casually. It's intended only if we make some decision to engage mirroring.
+    # Although it's fine to call an environment your staging environment without enabling this,
+    # what the system means about something being the stg environment is that it's the stage side of a mirror.
+    # -kmp 24-Jul-2021
+    STAGE_MIRRORING_ENABLED = None  # if True, orchestration-enabled function may offer mirroring behavior
     ORCHESTRATED_APP = None  # This allows us to tell 'cgap' from 'fourfront', in case there ever is one.
     PRD_BUCKET = None
     PRD_ENV_NAME = None  # the name of the prod env
@@ -423,16 +429,9 @@ def is_fourfront_env(envname):
         return False
 
 
-# Don't enable this casually. It's intended only if we make some decision to engage mirroring.
-# Although it's fine to call an environment your staging environment without enabling this,
-# what the system means about something being the stg environment is that it's the stage side of a mirror.
-# -kmp 24-Jul-2021
-STAGE_MIRRORING_ENABLED = False
-
-
 def _is_raw_stg_or_prd_env(envname):
     return (envname == EnvUtils.PRD_ENV_NAME or
-            (STAGE_MIRRORING_ENABLED and EnvUtils.STG_ENV_NAME and envname == EnvUtils.STG_ENV_NAME))
+            (EnvUtils.STAGE_MIRRORING_ENABLED and EnvUtils.STG_ENV_NAME and envname == EnvUtils.STG_ENV_NAME))
 
 
 @if_orchestrated
@@ -496,7 +495,7 @@ def get_env_from_context(settings, allow_environ=True):
 def get_mirror_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT, allow_guess=True):
     # This is the same text as the legacy environment, but it needs to call get_standard_mirror_env
     # from this file. -kmp 26-Jul-2021
-    if not STAGE_MIRRORING_ENABLED:
+    if not EnvUtils.STAGE_MIRRORING_ENABLED:
         return None
     elif allow_environ:
         environ_mirror_env_name = os.environ.get('MIRROR_ENV_NAME')
@@ -514,7 +513,7 @@ def get_mirror_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT
 
 @if_orchestrated
 def get_standard_mirror_env(envname):
-    if not STAGE_MIRRORING_ENABLED:
+    if not EnvUtils.STAGE_MIRRORING_ENABLED:
         return None
     elif envname == EnvUtils.PRD_ENV_NAME:
         return EnvUtils.STG_ENV_NAME
@@ -563,7 +562,7 @@ def infer_foursight_url_from_env(request, envname: Optional[EnvName]):
 @if_orchestrated
 def infer_foursight_from_env(request, envname):
     ignored(request)
-    if STAGE_MIRRORING_ENABLED and EnvUtils.STG_ENV_NAME:
+    if EnvUtils.STAGE_MIRRORING_ENABLED and EnvUtils.STG_ENV_NAME:
         classification = classify_server_url(request.domain)
         if classification[c.IS_STG_OR_PRD]:
             public_name = classification[c.PUBLIC_NAME]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.1.0.1b0"  # eventually "4.0.0"
+version = "3.1.0.1b1"  # eventually "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -3,7 +3,6 @@ import functools
 import os
 import pytest
 
-from dcicutils import env_utils
 from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env,
     get_mirror_env_from_context, is_test_env, is_hotseat_env, get_standard_mirror_env,
@@ -20,11 +19,6 @@ from dcicutils.misc_utils import decorator, local_attrs
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
 from urllib.parse import urlparse
-
-# @contextlib.contextmanager
-# def stage_mirroring(*, enabled=True):
-#     with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=enabled):
-#         yield
 
 
 @contextlib.contextmanager

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -21,9 +21,15 @@ from dcicutils.qa_utils import raises_regexp
 from unittest import mock
 from urllib.parse import urlparse
 
+# @contextlib.contextmanager
+# def stage_mirroring(*, enabled=True):
+#     with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=enabled):
+#         yield
+
+
 @contextlib.contextmanager
 def stage_mirroring(*, enabled=True):
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=enabled):
+    with local_attrs(EnvUtils, STAGE_MIRRORING_ENABLED=enabled):
         yield
 
 

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import os
 import pytest
@@ -19,6 +20,11 @@ from dcicutils.misc_utils import decorator, local_attrs
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
 from urllib.parse import urlparse
+
+@contextlib.contextmanager
+def stage_mirroring(*, enabled=True):
+    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=enabled):
+        yield
 
 
 @decorator()
@@ -66,9 +72,9 @@ def test_orchestrated_get_bucket_env():
     # we can only test that by a mock of is_stg_or_prd_env. -kmp 24-Jul-2021
     with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
 
-        test_the_usual_scenario()  # The STG_ENV_NAME is ignored if STAGE_MIRRORING_ENABLED is False
+        test_the_usual_scenario()  # The STG_ENV_NAME is ignored if "stage_mirroring_enabled": false
 
-        with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+        with stage_mirroring(enabled=True):
 
             assert EnvUtils.STG_ENV_NAME == 'acme-stg'
 
@@ -113,9 +119,9 @@ def test_orchestrated_prod_bucket_env():
     # we can only test that by a mock of is_stg_or_prd_env. -kmp 24-Jul-2021
     with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
 
-        test_the_usual_scenario()  # The STG_ENV_NAME is ignored if STAGE_MIRRORING_ENABLED is False
+        test_the_usual_scenario()  # The STG_ENV_NAME is ignored if "stage_mirroring_enabled": false
 
-        with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+        with stage_mirroring(enabled=True):
 
             assert EnvUtils.STG_ENV_NAME == 'acme-stg'
 
@@ -264,13 +270,13 @@ def test_orchestrated_data_set_for_env():
 
     with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
 
-        # Setting EnvUtils.STG_ENV_NAME doesn't work unless STAGE_MIRRORING_ENABLED is enabled at top-level.
+        # Setting EnvUtils.STG_ENV_NAME doesn't work unless "stage_mirroring_enabled": true at top-level.
         assert data_set_for_env('acme-stg') is None
         assert data_set_for_env('stg') is None
         assert data_set_for_env('acme-stg', 'test') == 'test'
         assert data_set_for_env('stg', 'test') == 'test'
 
-        with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+        with stage_mirroring(enabled=True):
 
             assert data_set_for_env('acme-stg') == 'prod'
             assert data_set_for_env('stg') == 'prod'
@@ -748,7 +754,7 @@ def test_orchestrated_is_fourfront_server_for_fourfront():
         assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
         assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
 
-        with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+        with stage_mirroring(enabled=True):
 
             assert is_fourfront_server("https://staging.4dnucleome.org") is False
             assert is_fourfront_server("https://staging.4dnucleome.org") is False
@@ -1090,7 +1096,7 @@ def test_orchestrated_is_stg_or_prd_env_for_cgap():
 
         assert is_stg_or_prd_env('acme-stg') is False
 
-        with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+        with stage_mirroring(enabled=True):
 
             assert is_stg_or_prd_env('acme-stg') is True
 
@@ -1110,7 +1116,7 @@ def test_orchestrated_is_stg_or_prd_env_for_fourfront():
 
         assert is_stg_or_prd_env('acme-stg') is False
 
-        with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+        with stage_mirroring(enabled=True):
 
             assert is_stg_or_prd_env('acme-stg') is True
 
@@ -1235,7 +1241,7 @@ def test_orchestrated_get_mirror_env_from_context_without_environ_with_mirror_di
 def test_orchestrated_get_mirror_env_from_context_without_environ_with_mirror_enabled():
     """ Tests that when getting mirror env on various envs returns the correct mirror """
 
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+    with stage_mirroring(enabled=True):
         with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
             for allow_environ in (False, True):
                 # If the environment doesn't have either the ENV_NAME or MIRROR_ENV_NAME environment variables,
@@ -1317,7 +1323,7 @@ def test_orchestrated_get_mirror_env_from_context_with_environ_has_env_with_mirr
 def test_orchestrated_get_mirror_env_from_context_with_environ_has_env_with_mirror_enabled():
     """ Tests override of env name from os.environ when getting mirror env on various envs """
 
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+    with stage_mirroring(enabled=True):
         with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
 
             with mock.patch.object(os, "environ", {'ENV_NAME': 'foo'}):
@@ -1372,7 +1378,7 @@ def test_orchestrated_get_mirror_env_from_context_with_environ_has_mirror_env_wi
 def test_orchestrated_get_mirror_env_from_context_with_environ_has_mirror_env_with_mirror_enabled():
     """ Tests override of mirror env name from os.environ when getting mirror env on various envs """
 
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+    with stage_mirroring(enabled=True):
         with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
 
             with mock.patch.object(os, "environ", {"MIRROR_ENV_NAME": 'bar'}):
@@ -1395,7 +1401,7 @@ def test_orchestrated_get_mirror_env_from_context_with_environ_has_env_and_mirro
 def test_orchestrated_get_mirror_env_from_context_with_environ_has_env_and_mirror_env_with_mirror_enabled():
     """ Tests override of env name and mirror env name from os.environ when getting mirror env on various envs """
 
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+    with stage_mirroring(enabled=True):
         with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
 
             with mock.patch.object(os, "environ", {'ENV_NAME': 'acme-stg', "MIRROR_ENV_NAME": 'bar'}):
@@ -1409,7 +1415,7 @@ def test_orchestrated_get_standard_mirror_env_for_cgap():
 
     for mirroring_enabled in [True, False]:
         with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
-            with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=mirroring_enabled):
+            with stage_mirroring(enabled=mirroring_enabled):
 
                 def expected_result(value):
                     return value if mirroring_enabled else None
@@ -1428,7 +1434,7 @@ def test_orchestrated_get_standard_mirror_env_for_fourfront():
 
     for mirroring_enabled in [True, False]:
         with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
-            with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=mirroring_enabled):
+            with stage_mirroring(enabled=mirroring_enabled):
 
                 def expected_result(value):
                     return value if mirroring_enabled else None
@@ -1538,7 +1544,7 @@ def test_orchestrated_infer_foursight_env():
     assert infer_foursight_from_env(mock_request('acme-webdev' + dev_suffix), 'acme-webdev') == 'webdev'
     assert infer_foursight_from_env(mock_request('acme-hotseat' + dev_suffix), 'acme-hotseat') == 'hotseat'
 
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+    with stage_mirroring(enabled=True):
 
         with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):
 
@@ -1846,7 +1852,7 @@ def test_orchestrated_classify_server_url_cgap():
 @using_orchestrated_behavior()
 def test_orchestrated_classify_server_url_fourfront():
 
-    with local_attrs(env_utils, STAGE_MIRRORING_ENABLED=True):
+    with stage_mirroring(enabled=True):
 
         with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):
 


### PR DESCRIPTION
Instead of setting a top-level variable in the library, this requires that to enable mirroring, you have to set:
```
"stage_mirroring_allowed": true
```
in the env descriptor. This addresses [C4-734](https://hms-dbmi.atlassian.net/browse/C4-734).