### PR TITLE
Default s3_encrypt_key_id correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ dcicutils
 Change Log
 ----------
 
+3.4.1
+=====
+
+* ``deployment_utils``:
+
+  * Default the value of ``s3_encode_key_id`` to the empty string, not ``None``.
+
 
 3.4.0
 =====

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -597,7 +597,7 @@ class IniFileManager:
         s3_bucket_env = s3_bucket_env or os.environ.get("ENCODED_S3_BUCKET_ENV", get_bucket_env(bs_env))
         s3_encrypt_key_id = (s3_encrypt_key_id
                              or os.environ.get("ENCODED_S3_ENCRYPT_KEY_ID")
-                             or None)
+                             or "")
         data_set = (data_set
                     or os.environ.get("ENCODED_DATA_SET")
                     or data_set_for_env(bs_env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.4.1"
+version = "3.4.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.4.0.1b0"
+version = "3.4.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.4.0"
+version = "3.4.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Default `s3_encrypt_key_id` to empty string, not `None`, in `deployment_utils`.