### PR TITLE
Mocked S3 storage classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ dcicutils
 Change Log
 ----------
 
+3.4.2
+=====
+
+* In ``qa_utils``:
+
+  * Fix S3 ``head_object`` operation to return the ``StorageClass`` since
+    the mock already allows you to declare it.
+
+  * Add internal support to be expanded later for making individual S3 files
+    have different storage class.
+
+
 3.4.1
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,13 @@ Change Log
 
 * In ``qa_utils``:
 
-  * Fix S3 ``head_object`` operation to return the ``StorageClass`` since
-    the mock already allows you to declare it.
+  * In ``MockBotoS3Client``:
 
-  * Add internal support to be expanded later for making individual S3 files
-    have different storage class.
+    * Fix ``head_object`` operation to return the ``StorageClass``
+      (since the mock already allows you to declare it per-S3-client-class).
+
+    * Add internal support to be expanded later for making individual S3 files
+      have different storage classes from one another.
 
 
 3.4.1

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -884,15 +884,39 @@ class MockBotoS3Client:
         return self.list_objects(Bucket=Bucket)
 
     def _storage_class_map(self):
+        """
+        Returns the storage class map for this mock.
+
+        Note that this is a property of the boto3 instance (through its .shared_reality) not of the s3 mock itself
+        so that if another client is created by that same boto3 mock, it will see the same storage classes.
+        """
         storage_class_map = self.boto3.shared_reality.get('storage_class_map')
         if not storage_class_map:
             self.boto3.shared_reality['storage_class_map'] = storage_class_map = {}
         return storage_class_map
 
     def _object_storage_class(self, filename):
+        """
+        Returns the storage class for the 'filename' in this S3 mock.
+        Because this is an internal routine, 'filename' is 'bucket/key' to match the mock file system we use internally.
+
+        Note that this is a property of the boto3 instance (through its .shared_reality) not of the s3 mock itself
+        so that if another client is created by that same boto3 mock, it will see the same storage classes.
+        """
         return self._storage_class_map().get(filename) or self.storage_class
 
     def _set_object_storage_class(self, filename, value):
+        """
+        Sets the storage class for the 'filename' in this S3 mock to the given value.
+        Because this is an internal routine, 'filename' is 'bucket/key' to match the mock file system we use internally.
+
+        Presently the value is not error-checked. That might change.
+        By special exception, passing value=None will revert the storage class to the default for the given mock,
+        for which the default default is 'STANDARD'.
+
+        Note that this is a property of the boto3 instance (through its .shared_reality) not of the s3 mock itself
+        so that if another client is created by that same boto3 mock, it will see the same storage classes.
+        """
         self._storage_class_map()[filename] = value
 
     def list_objects(self, Bucket, Prefix=None):  # noQA - AWS argument naming style

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -772,7 +772,6 @@ class MockBotoS3Client:
             other_required_arguments[name] = content
         self.other_required_arguments = other_required_arguments
         self.storage_class = storage_class or self.DEFAULT_STORAGE_CLASS
-        self.storage_class_map = dict()
 
     def upload_fileobj(self, Fileobj, Bucket, Key, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
         if kwargs != self.other_required_arguments:
@@ -884,11 +883,17 @@ class MockBotoS3Client:
         # This is different but similar to list_objects. However we don't really care about that.
         return self.list_objects(Bucket=Bucket)
 
+    def _storage_class_map(self):
+        storage_class_map = self.boto3.shared_reality.get('storage_class_map')
+        if not storage_class_map:
+            self.boto3.shared_reality['storage_class_map'] = storage_class_map = {}
+        return storage_class_map
+
     def _object_storage_class(self, filename):
-        return self.storage_class_map.get(filename) or self.storage_class
+        return self._storage_class_map().get(filename) or self.storage_class
 
     def _set_object_storage_class(self, filename, value):
-        self.storage_class_map[filename] = value
+        self._storage_class_map()[filename] = value
 
     def list_objects(self, Bucket, Prefix=None):  # noQA - AWS argument naming style
         # Ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.4.1"
+version = "3.4.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
In `MockBotoS3Client`, support for per-S3-file storage classes, and a fix to `head_object` to return `StorageClass`.