### PR TITLE
Remove Service Count Protection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,16 @@ dcicutils
 Change Log
 ----------
 
-=======
+=====
+3.7.1
+=====
+
+* In ``ecs_utils``:
+  
+  * No longer throw exception when listing services if <4 are returned
+
+
+=====
 3.7.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ dcicutils
 Change Log
 ----------
 
+3.6.1
+=====
+
+* In ``ecs_utils``:
+
+  * Add ``list_ecs_tasks``
+  * Add ``run_ecs_task``
+
 3.6.0
 =====
 

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -43,3 +43,25 @@ class ECSUtils:
         for service_name in self.list_ecs_services(cluster_name=cluster_name):
             self.update_ecs_service(cluster_name=cluster_name, service_name=service_name)
         return True
+
+    def list_ecs_tasks(self):
+        """ Lists all available ECS task definitions. """
+        return self.client.list_task_definitions().get('taskDefinitionArns', [])
+
+    def run_ecs_task(self, *, cluster_name, task_name, subnet, security_group):
+        """ Runs the given task name on the given cluster. """
+        return self.client.run_task(
+            cluster=cluster_name,
+            count=1,
+            taskDefinition=task_name,
+            networkConfiguration={
+                'awsvpcConfiguration': {
+                    'subnets': [
+                        subnet
+                    ],
+                    'securityGroups': [
+                        security_group
+                    ]
+                }
+            }
+        )

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -49,7 +49,14 @@ class ECSUtils:
         return self.client.list_task_definitions().get('taskDefinitionArns', [])
 
     def run_ecs_task(self, *, cluster_name, task_name, subnet, security_group):
-        """ Runs the given task name on the given cluster. """
+        """ Runs the given task name on the given cluster.
+
+        :param cluster_name: name of cluster to run task on
+        :param task_name: name of task (including revision) to run
+        :param subnet: subnet to run task in
+        :param security_group: SG to associate with task
+        :return: dict response
+        """
         return self.client.run_task(
             cluster=cluster_name,
             count=1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.6.0"
+version = "3.6.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ecs_utils.py
+++ b/test/test_ecs_utils.py
@@ -26,6 +26,33 @@ def mock_list_ecs_services(*, cluster):
     }
 
 
+def mock_list_ecs_tasks():
+    """ list_task_definitions structure - for future tests """
+    return {
+        'taskDefinitionArns':
+            [
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPDeployment-FwJgj7hSQA2p:1',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPIndexer-iHDWcWOG5r9m:1',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPIngester-tU6SCdUoTAT0:1',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPInitialDeployment-FPYnleE9YwvH:1',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPInitialDeployment-FPYnleE9YwvH:2',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPportal-9kgkd5ZfVtxP:1',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPportal-9kgkd5ZfVtxP:2',
+                'arn:aws:ecs:us-east-1:262461168236:task-definition/c4-ecs-cgap-devtest-stack-CGAPportal-9kgkd5ZfVtxP:3', ],
+        'ResponseMetadata': {
+            'RequestId': '82c590ec-980e-4eea-8fea-2843b5ffdd6a',
+            'HTTPStatusCode': 200,
+            'HTTPHeaders': {
+                'x-amzn-requestid': '82c590ec-980e-4eea-8fea-2843b5ffdd6a',
+                'content-type': 'application/x-amz-json-1.1',
+                'content-length': '1393',
+                'date': 'Mon, 10 Jan 2022 19:52:06 GMT'
+            },
+            'RetryAttempts': 0
+        }
+    }
+
+
 def mock_update_service(*, cluster, service, forceNewDeployment):  # noQA - AWS chose mixed case argument name
     """ Mock matching the relevant API signature for below (we don't actually want
         to trigger an ECS deploy in unit testing.


### PR DESCRIPTION
- Removes a check in the `ecs_utils` code that throws exception when <4 services are detected
- This restriction made sense in previous testing but is thwarting us now as we containerize Fourfront