### PR TITLE
New creds_utils migrated from SubmitCGAP (C4-778)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,32 @@ Change Log
 ----------
 
 
+3.10.0
+======
+
+* Adds support for ``creds_utils``.
+
+  * Class ``KeyManager``, with methods:
+
+    * ``KeyManager.get_keydict_for_env(self, env)``
+
+    * ``KeyManager.get_keydict_for_server(self, server)``
+
+    * ``KeyManager.get_keydicts(self)``
+
+    * ``KeyManager.get_keypair_for_env(self, env)``
+
+    * ``KeyManager.get_keypair_for_server(self, server)``
+
+    * ``KeyManager.keydict_to_keypair(auth_dict)``
+
+    * ``KeyManager.keypair_to_keydict(auth_tuple, *, server)``
+
+  * Class ``FourfrontKeyManager``
+
+  * Class ``CGAPKeyManager``
+
+
 3.9.0
 =====
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: test
 
+clear-poetry-cache:  # clear poetry/pypi cache. for user to do explicitly, never automatic
+	poetry cache clear pypi --all
+
 configure:  # does any pre-requisite installs
 	pip install poetry
 
@@ -49,3 +52,4 @@ info:
 	   $(info - Use 'make publish' to publish this library, but only if auto-publishing has failed.)
 	   $(info - Use 'make test' to run tests with the normal options we use on travis)
 	   $(info - Use 'make update' to update dependencies (and the lock file))
+	   $(info - Use 'make clear-poetry-cache' to clear the poetry pypi cache if in a bad state. (Safe, but later recaching can be slow.))

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -1,0 +1,191 @@
+# import contextlib
+# import functools
+import io
+import json
+import os
+
+# from dcicutils.misc_utils import local_attrs
+from dcicutils.exceptions import AppEnvKeyMissing, AppServerKeyMissing
+
+
+# LOCAL_SERVER = "http://localhost:8000"
+# LOCAL_PSEUDOENV = 'fourfront-cgaplocal'
+#
+# PRODUCTION_SERVER = 'https://cgap.hms.harvard.edu'
+# PRODUCTION_ENV = 'fourfront-cgap'
+#
+# DEFAULT_ENV_VAR = 'SUBMITCGAP_ENV'
+#
+# keys_file_var='CGAP_KEYS_FILE'
+
+
+class KeyManager:
+
+    APP_NAME = None
+    APP_TOKEN = None  # Set this to a string to override APP_NAME.lower() as the app token
+
+    DEFAULT_ENV = None
+    DEFAULT_ENV_VAR = None
+
+    KEYS_FILE = None
+    KEYS_FILE_VAR = None
+
+    # Instance Methods
+
+    def __init__(self, keys_file=None):
+        self.keys_file = keys_file or os.environ.get(self.KEYS_FILE_VAR) or self.KEYS_FILE or self._default_keys_file()
+        if not self.keys_file:
+            raise ValueError("No KEYS_FILE attribute in {self}, and no {self.KEYS_FILE_VAR} environment variable.")
+
+    # @contextlib.contextmanager
+    # def alternate_keys_file_from_environ(self):
+    #     filename = os.environ.get(self.KEYS_FILE_VAR) or None  # Treats empty string as undefined
+    #     with self.alternate_keys_file(filename=filename):
+    #         yield
+
+    # Class Methods
+
+    @classmethod
+    def _default_keys_file(cls):
+        app_token = cls.APP_TOKEN or cls.APP_NAME.lower()
+        return os.path.expanduser(cls.KEYS_FILE or f"~/.{app_token}-keys.json")
+
+    # Replaced by an instance variable. Rewrites weill be needed.
+    #
+    # @classmethod
+    # def keys_file(cls):
+    #     app_token = cls.APP_TOKEN or cls.APP_NAME.lower()
+    #     return os.path.expanduser(cls.KEYS_FILE or f"~/.{app_token}-keys.json")
+
+    # # Formerly a function / classmethod, now a normal instance method of an instance (of KeyManager)
+    # @contextlib.contextmanager
+    # def alternate_keys_file(self, filename):
+    #     if filename is None:
+    #         yield  # If no alternate filename given, change nothing
+    #     else:
+    #         with local_attrs(self, keys_file=filename):
+    #             yield
+
+    # @classmethod
+    # def UsingKeysFile(cls, key_manager):
+    #     def _UsingKeysFile(fn):  # TO DO: declare as decorator
+    #         @functools.wraps(fn)
+    #         def wrapped(*args, **kwargs):
+    #             with key_manager.alternate_keys_file_from_environ():
+    #                 return fn(*args, **kwargs)
+    #         return wrapped
+    #     return _UsingKeysFile
+
+    @classmethod  # tested. good as class method
+    def keypair_to_keydict(cls, auth_tuple, *, server):
+        auth_dict = {
+            'key': auth_tuple[0],
+            'secret': auth_tuple[1],
+            'server': server,
+        }
+        return auth_dict
+
+    @classmethod  # tested. good as class method
+    def keydict_to_keypair(cls, auth_dict):
+        return (
+            auth_dict['key'],
+            auth_dict['secret']
+        )
+
+    # formerly a class method. no longer can be.
+    def get_keydicts(self):  # tested
+        if not os.path.exists(self.keys_file):
+            return {}
+        with io.open(self.keys_file) as fp:
+            keys = json.load(fp)
+            return keys
+
+    @classmethod
+    def _check_env(cls, env):
+        if not env or not isinstance(env, str):
+            raise ValueError(f"Not a valid environment: {env}")
+
+    def get_keydict_for_env(self, env):
+        """
+        Gets the appropriate auth info (as a dict) for talking to a given beanstalk environment.
+
+        Args:
+            env: the name of a beanstalk environment
+
+        Returns:
+            Auth information as a dict with keys 'key', 'secret', and 'server'.
+        """
+
+        self._check_env(env)
+
+        keydicts = self.get_keydicts()
+        keydict = keydicts.get(env)
+        if not keydict:
+            raise AppEnvKeyMissing(env=env, key_manager=self)
+        return keydict
+
+    def get_keypair_for_env(self, env):
+        """
+        Gets the appropriate auth info (as a pair/tuple) for talking to a given beanstalk environment.
+
+        Args:
+            env: the name of an environment
+
+        Returns:
+            Auth information as a (key, secret) tuple.
+        """
+
+        return self.keydict_to_keypair(self.get_keydict_for_env(env=env))
+
+    @classmethod
+    def _check_server(cls, server):
+        if not server or not isinstance(server, str):
+            raise ValueError(f"Not a valid server: {server}")
+
+    def get_keydict_for_server(self, server):  # tested
+        """
+        Gets the appropriate auth info (as a dict) for talking to a given beanstalk environment.
+
+        Args:
+            server: the name of a server
+
+        Returns:
+            Auth information.
+            The auth is a keypair, though we might change this to include a JWT token in the the future.
+        """
+
+        self._check_server(server)
+
+        keydicts = self.get_keydicts()
+        server_to_find = server.rstrip('/')
+        for keydict in keydicts.values():
+            if keydict['server'].rstrip('/') == server_to_find:
+                return keydict
+        raise AppServerKeyMissing(server=server, key_manager=self)
+
+    def get_keypair_for_server(self, server):  # tested
+        """
+        Gets the appropriate auth info (as a pair/tuple) for talking to a given beanstalk environment.
+
+        Args:
+            server: the name of a server
+
+        Returns:
+            Auth information as a (key, secret) tuple.
+        """
+
+        return self.keydict_to_keypair(self.get_keydict_for_server(server=server))
+
+
+class CGAPKeyManager(KeyManager):
+    APP_NAME = 'CGAP'
+    APP_TOKEN = 'cgap'
+    DEFAULT_ENV_VAR = 'CGAP_DEFAULT_ENV'
+    KEYS_FILE_VAR = 'CGAP_KEYS_FILE'
+
+
+class FourfrontKeyManager(KeyManager):
+    APP_NAME = 'Fourfront'
+    APP_TOKEN = 'ff'
+    DEFAULT_ENV_VAR = 'FF_DEFAULT_ENV'
+    KEYS_FILE_VAR = 'FF_KEYS_FILE'

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -47,7 +47,7 @@ class KeyManager:
     #     # something like this:
     #     #
     #     #     class MyKeyManager(KeyManager):
-    #     #         KEY_FILE = 'some file'
+    #     #         KEYS_FILE = 'some file'
     #     #
     #     return self._default_keys_file()
 
@@ -55,7 +55,7 @@ class KeyManager:
     @contextlib.contextmanager
     def default_key_file_for_testing(cls, filename):
         """
-        Sets the default key file for in cls.KEY_FILE to the indicated filename.
+        Sets the default key file for in cls.KEYS_FILE to the indicated filename.
         Ordinarily, in a non-testing environment, one would set an environment variable to do this,
         but in the testing environment that has been set already and to a value that has nothing to
         do with testing. So this bypasses the normal environment variable setup and sets it directly

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -53,9 +53,9 @@ class KeyManager:
 
     @classmethod
     @contextlib.contextmanager
-    def default_key_file_for_testing(cls, filename):
+    def default_keys_file_for_testing(cls, filename):
         """
-        Sets the default key file for in cls.KEYS_FILE to the indicated filename.
+        Sets the default keys file for in cls.KEYS_FILE to the indicated filename.
         Ordinarily, in a non-testing environment, one would set an environment variable to do this,
         but in the testing environment that has been set already and to a value that has nothing to
         do with testing. So this bypasses the normal environment variable setup and sets it directly

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -1,5 +1,6 @@
 # import contextlib
 # import functools
+import contextlib
 import io
 import json
 import os
@@ -49,6 +50,24 @@ class KeyManager:
     #     #         KEY_FILE = 'some file'
     #     #
     #     return self._default_keys_file()
+
+    @classmethod
+    @contextlib.contextmanager
+    def default_key_file_for_testing(cls, filename):
+        """
+        Sets the default key file for in cls.KEY_FILE to the indicated filename.
+        Ordinarily, in a non-testing environment, one would set an environment variable to do this,
+        but in the testing environment that has been set already and to a value that has nothing to
+        do with testing. So this bypasses the normal environment variable setup and sets it directly
+        in the class and only for the duration of an evaluation context.
+        """
+
+        old_filename = cls.KEYS_FILE
+        try:
+            cls.KEYS_FILE = filename
+            yield
+        finally:
+            cls.KEYS_FILE = old_filename
 
     @classmethod
     def register(cls, *, name):

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -64,7 +64,7 @@ class KeyManager:
 
         old_filename = cls.KEYS_FILE
         try:
-            cls.KEYS_FILE = filename
+            cls.KEYS_FILE = filename or cls._default_keys_file()
             yield
         finally:
             cls.KEYS_FILE = old_filename

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -64,7 +64,7 @@ class KeyManager:
 
         old_filename = cls.KEYS_FILE
         try:
-            cls.KEYS_FILE = filename or cls._default_keys_file()
+            cls.KEYS_FILE = filename or cls._default_keys_file(for_testing=True)
             yield
         finally:
             cls.KEYS_FILE = old_filename
@@ -131,8 +131,9 @@ class KeyManager:
     # Class Methods
 
     @classmethod
-    def _default_keys_file(cls):
-        return os.path.expanduser(f"~/.{cls.APP_TOKEN.lower()}-keys.json")
+    def _default_keys_file(cls, for_testing=False):
+        suffix = "-for-testing" if for_testing else ""
+        return os.path.expanduser(f"~/.{cls.APP_TOKEN.lower()}-keys{suffix}.json")
 
     # Replaced by an instance variable. Rewrites weill be needed.
     #

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -43,13 +43,16 @@ class KeyManager:
         """
         Parses and returns the keys file (held by self.keys_file)
 
+        NOTE: No caching is done on a theory that you don't do this super-often, and you might have edited the
+              keys file since last look, so you'd want most-up-to-date credentials. If those assumptions don't
+              hold, please request additional support for this class rather than creating ad hoc solutions outside.
+
         Returns:
             a dictionary that maps an environment name to its auth information,
             which is a dict with keys 'key', 'secret', and 'server'.
 
-        NOTE: No caching is done on a theory that you don't do this super-often, and you might have edited the
-              keys file since last look, so you'd want most-up-to-date credentials. If those assumptions don't
-              hold, please request additional support for this class rather than creating ad hoc solutions outside.
+        Raises:
+            ValueError: if the file is ill-formatted (does not contain JSON or JSON is not a dictionary)
         """
         if not os.path.exists(self.keys_file):
             return {}
@@ -68,6 +71,9 @@ class KeyManager:
 
         Returns:
             Auth information as a dict with keys 'key', 'secret', and 'server'.
+
+        Raises:
+            ValueError: if the file is ill-formatted (does not contain JSON or JSON is not a dictionary)
         """
 
         self._check_env(env)

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -39,15 +39,16 @@ class KeyManager:
         if not self.keys_file:
             raise ValueError(f"No KEYS_FILE attribute in {self}, and no {self.KEYS_FILE_VAR} environment variable.")
 
-    @property
-    def KEYS_FILE(self):  # noQA
-        # By default this will be computed dynamically, but a KeyManager class can declare a static value by doing
-        # something like this:
-        #
-        #     class MyKeyManager(KeyManager):
-        #         KEY_FILE = 'some file'
-        #
-        return self._default_keys_file()
+    KEYS_FILE = None
+    # @property
+    # def KEYS_FILE(self):  # noQA
+    #     # By default this will be computed dynamically, but a KeyManager class can declare a static value by doing
+    #     # something like this:
+    #     #
+    #     #     class MyKeyManager(KeyManager):
+    #     #         KEY_FILE = 'some file'
+    #     #
+    #     return self._default_keys_file()
 
     @classmethod
     def register(cls, *, name):
@@ -90,6 +91,8 @@ class KeyManager:
             cls.KEYS_FILE_VAR = f"{app_prefix}KEYS_FILE"
         elif not cls.KEYS_FILE_VAR.startswith(app_prefix):
             raise ValueError("The {class_name}.KEYS_FILE_VAR must begin with {app_prefix!r}.")
+        if not cls.KEYS_FILE:
+            cls.KEYS_FILE = cls._default_keys_file()
         # print(f"Defining {class_name} "
         #       f"with APP_NAME={app_name!r} APP_TOKEN={app_token!r} KEYS_FILE_VAR={cls.KEYS_FILE_VAR!r}.")
 
@@ -246,4 +249,4 @@ class CGAPKeyManager(KeyManager):
 
 @KeyManager.register(name='fourfront')
 class FourfrontKeyManager(KeyManager):
-    APP_TOKEN = 'FF'
+    pass

--- a/dcicutils/exceptions.py
+++ b/dcicutils/exceptions.py
@@ -180,3 +180,27 @@ class InvalidParameterError(ValueError):
             message = f"The value{parameter_part}{value_part} was not {valid}. {restriction}"
 
         super().__init__(message)
+
+
+class AppKeyMissing(RuntimeError):
+
+    def __init__(self, context, key_manager):
+        self.context = context
+        self.key_manager = key_manager
+        super().__init__(f"Missing credential in file {key_manager.keys_file} for {context}.")
+
+
+class AppEnvKeyMissing(AppKeyMissing):
+
+    def __init__(self, env, key_manager):
+        self.env = env
+        super().__init__(context=f"{key_manager.APP_NAME} environment {env}",
+                         key_manager=key_manager)
+
+
+class AppServerKeyMissing(AppKeyMissing):
+
+    def __init__(self, server, key_manager):
+        self.server = server
+        super().__init__(context=f"{key_manager.APP_NAME} server {server}",
+                         key_manager=key_manager)

--- a/docs/source/dcicutils.rst
+++ b/docs/source/dcicutils.rst
@@ -33,6 +33,13 @@ command_utils
    :members:
 
 
+creds_utils
+^^^^^^^^^^^
+
+.. automodule:: dcicutils.creds_utils
+   :members:
+
+
 common
 ^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b9"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b10"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b3"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b4"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0"
+version = "3.9.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -40,7 +40,8 @@ classifiers = [
 python = ">=3.6.1,<3.10"
 boto3 = "^1.17.39"
 botocore = "^1.20.39"
-# TODO: elasticsearch is on version 7. -kmp 15-Feb-2020
+# The DCIC portals (cgap-portal and fourfront) are very particular about which ElasticSearch version.
+# This value is intentionally pinned and must not be changed casually.
 elasticsearch = "6.8.1"
 aws-requests-auth = ">=0.4.2,<1"
 docker = "^4.4.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b4"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b5"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b8"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b9"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b1"
+version = "3.9.0.1b2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b0"
+version = "3.9.0.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b11"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b10"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b11"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b7"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b8"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.9.0.1b5"  # incorporates 3.10.0, targets "3.11.0"
+version = "3.9.0.1b7"  # incorporates 3.10.0, targets "3.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_creds_utils.py
+++ b/test/test_creds_utils.py
@@ -1,12 +1,10 @@
-# import contextlib
-import json
 import io
+import json
 import os
 import pytest
 
 from dcicutils.creds_utils import KeyManager, CGAPKeyManager, FourfrontKeyManager
 from dcicutils.exceptions import AppEnvKeyMissing, AppServerKeyMissing  # , AppKeyMissing
-# from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ, MockFileSystem
 
 
@@ -97,24 +95,16 @@ def test_keymanager_keys_file():
 
     assert isinstance(original_file, str)
 
-    # with key_manager.alternate_keys_file(None):
-    #     assert key_manager.keys_file == original_file
-
     assert key_manager.keys_file == original_file
 
     with override_environ(CGAP_KEYS_FILE=None):
         assert os.environ.get('CGAP_KEYS_FILE') is None
         assert key_manager.keys_file == original_file
 
-        # with key_manager.alternate_keys_file_from_environ():
-        #     assert key_manager.keys_file == original_file
-        # assert key_manager.keys_file == original_file
-
     assert key_manager.keys_file == original_file
 
     with override_environ(CGAP_KEYS_FILE=""):
         assert os.environ.get('CGAP_KEYS_FILE') == ""
-        # with key_manager.alternate_keys_file_from_environ():
         assert key_manager.keys_file == original_file
 
     assert key_manager.keys_file == original_file

--- a/test/test_creds_utils.py
+++ b/test/test_creds_utils.py
@@ -1,0 +1,313 @@
+# import contextlib
+import json
+import os
+import pytest
+
+from dcicutils.creds_utils import KeyManager, CGAPKeyManager, FourfrontKeyManager
+from dcicutils.exceptions import AppEnvKeyMissing, AppServerKeyMissing  # , AppKeyMissing
+# from dcicutils.misc_utils import ignored
+from dcicutils.qa_utils import override_environ, MockFileSystem
+from unittest import mock
+
+SAMPLE_CGAP_DEFAULT_ENV = 'cgap-sample'
+SAMPLE_CGAP_KEYS_FILE = 'cgap.keys'
+SAMPLE_CGAP_PRODUCTION_ENV = 'cgap-production'
+SAMPLE_CGAP_PRODUCTION_SERVER = 'https://cgap-prod.hms.harvard.edu'
+SAMPLE_CGAP_LOCAL_SERVER = "http://localhost:8001"
+SAMPLE_CGAP_LOCAL_PSEUDOENV = 'cgap-local'
+
+SAMPLE_FOURFRONT_DEFAULT_ENV = 'fourfront-sample'
+SAMPLE_FOURFRONT_KEYS_FILE = 'fourfront.keys'
+SAMPLE_FOURFRONT_PRODUCTION_ENV = 'fourfront-production'
+SAMPLE_FOURFRONT_PRODUCTION_SERVER = 'https://cgap-prod.hms.harvard.edu'
+SAMPLE_FOURFRONT_LOCAL_SERVER = "http://localhost:8002"
+SAMPLE_FOURFRONT_LOCAL_PSEUDOENV = 'fourfront-local'
+
+
+def _make_sample_cgap_key_manager():
+    return CGAPKeyManager(keys_file=SAMPLE_CGAP_KEYS_FILE)
+
+
+def _make_sample_fourfront_key_manager():
+    return FourfrontKeyManager(keys_file=SAMPLE_FOURFRONT_KEYS_FILE)
+
+
+def test_cgap_keymanager_creation():
+
+    sample_cgap_key_manager_1 = CGAPKeyManager()
+
+    assert sample_cgap_key_manager_1.keys_file == CGAPKeyManager._default_keys_file()
+
+    sample_cgap_key_manager_2 = _make_sample_cgap_key_manager()
+
+    assert sample_cgap_key_manager_2.keys_file == SAMPLE_CGAP_KEYS_FILE
+
+    with override_environ(CGAP_DEFAULT_ENV=SAMPLE_CGAP_LOCAL_PSEUDOENV):
+
+        sample_cgap_key_manager_3 = CGAPKeyManager()
+
+        assert sample_cgap_key_manager_3.keys_file == CGAPKeyManager._default_keys_file()
+        # Make sure class default is different than test value. More of a test-integrity test than an absolute need.
+        assert sample_cgap_key_manager_3.keys_file != SAMPLE_CGAP_KEYS_FILE
+
+    other_keys_file = "other-cgap-keys.json"
+
+    class MyCGAPKeyManager(CGAPKeyManager):
+        KEYS_FILE = other_keys_file
+
+    sample_cgap_key_manager_4 = MyCGAPKeyManager()  # Tests that no error is raised
+
+    assert sample_cgap_key_manager_4.keys_file == other_keys_file
+
+
+def test_fourfront_keymanager_creation():
+
+    sample_ff_key_manager_1 = FourfrontKeyManager()
+
+    assert sample_ff_key_manager_1.keys_file == FourfrontKeyManager._default_keys_file()
+
+    sample_ff_key_manager_2 = _make_sample_fourfront_key_manager()
+
+    assert sample_ff_key_manager_2.keys_file == SAMPLE_FOURFRONT_KEYS_FILE
+
+    with override_environ(FF_DEFAULT_ENV=SAMPLE_FOURFRONT_LOCAL_PSEUDOENV):
+
+        sample_ff_key_manager_3 = FourfrontKeyManager()
+
+        assert sample_ff_key_manager_3.keys_file == FourfrontKeyManager._default_keys_file()
+        # Make sure class default is different than test value. More of a test-integrity test than an absolute need.
+        assert sample_ff_key_manager_3.keys_file != SAMPLE_FOURFRONT_KEYS_FILE
+
+    other_keys_file = "other-ff-keys.json"
+
+    class MyFourfrontKeyManager(FourfrontKeyManager):
+        KEYS_FILE = other_keys_file
+
+    sample_ff_key_manager_4 = MyFourfrontKeyManager()  # Tests that no error is raised
+
+    assert sample_ff_key_manager_4.keys_file == other_keys_file
+
+
+def test_keymanager_keys_file():
+
+    key_manager = _make_sample_cgap_key_manager()
+
+    original_file = key_manager.keys_file
+
+    assert isinstance(original_file, str)
+
+    # with key_manager.alternate_keys_file(None):
+    #     assert key_manager.keys_file == original_file
+
+    assert key_manager.keys_file == original_file
+
+    with override_environ(CGAP_KEYS_FILE=None):
+        assert os.environ.get('CGAP_KEYS_FILE') is None
+        assert key_manager.keys_file == original_file
+
+        # with key_manager.alternate_keys_file_from_environ():
+        #     assert key_manager.keys_file == original_file
+        # assert key_manager.keys_file == original_file
+
+    assert key_manager.keys_file == original_file
+
+    with override_environ(CGAP_KEYS_FILE=""):
+        assert os.environ.get('CGAP_KEYS_FILE') == ""
+        # with key_manager.alternate_keys_file_from_environ():
+        assert key_manager.keys_file == original_file
+
+    assert key_manager.keys_file == original_file
+
+    alternate_file = 'some-other-file'
+
+    with override_environ(CGAP_KEYS_FILE=alternate_file):
+        assert os.environ.get('CGAP_KEYS_FILE') == alternate_file
+
+        key_manager = CGAPKeyManager()
+        assert key_manager.keys_file == alternate_file
+
+    key_manager = _make_sample_cgap_key_manager()
+
+    assert key_manager.keys_file == original_file
+
+
+def test_keydict_to_keypair():  # KeyManager.keydict_to_keypair is a class method.
+
+    sample_key, sample_secret, sample_server = 'foo', 'bar', 'baz'
+    sample_keydict = {'key': sample_key, 'secret': sample_secret, 'server': sample_server}
+    sample_keypair = (sample_key, sample_secret)
+
+    assert KeyManager.keydict_to_keypair(sample_keydict) == sample_keypair
+
+
+def test_keypair_to_keydict():  # KeyManager.keypair_to_keydict is a class method.
+
+    sample_key, sample_secret, sample_server = 'foo', 'bar', 'baz'
+    sample_keydict = {'key': sample_key, 'secret': sample_secret, 'server': sample_server}
+    sample_keypair = (sample_key, sample_secret)
+
+    assert KeyManager.keypair_to_keydict(sample_keypair, server=sample_server) == sample_keydict
+
+
+def test_get_cgap_keydicts_missing():
+
+    mfs = MockFileSystem()
+
+    with mock.patch.object(os.path, "exists", mfs.exists):
+        assert _make_sample_cgap_key_manager().get_keydicts() == {}  # When missing, it appears empty
+
+
+SAMPLE_MISSING_ENV = 'fourfront-cgapwolf'
+SAMPLE_MISSING_SERVER = "http://localhost:6666"
+
+SAMPLE_CGAP_PAIR = ('key000', 'secret000')
+
+SAMPLE_CGAP_DICT = {
+    'key': SAMPLE_CGAP_PAIR[0],
+    'secret': SAMPLE_CGAP_PAIR[1],
+    'server': SAMPLE_CGAP_PRODUCTION_SERVER,
+}
+
+SAMPLE_CGAP_FOO_ENV = 'fourfront-cgapfoo'
+
+SAMPLE_CGAP_FOO_PAIR = ('key123', 'secret123')
+
+SAMPLE_CGAP_FOO_SERVER = 'https://foo.cgap.hms.harvard.edu'
+
+SAMPLE_CGAP_FOO_DICT = {
+    'key': SAMPLE_CGAP_FOO_PAIR[0],
+    'secret': SAMPLE_CGAP_FOO_PAIR[1],
+    'server': SAMPLE_CGAP_FOO_SERVER,
+}
+
+SAMPLE_CGAP_LOCAL_PAIR = ('key456', 'secret456')
+
+# SAMPLE_CGAP_LOCAL_SERVER dfeined above
+# cgap_local_server = 'http://localhost:8000'
+
+SAMPLE_CGAP_LOCAL_DICT = {
+    'key': SAMPLE_CGAP_LOCAL_PAIR[0],
+    'secret': SAMPLE_CGAP_LOCAL_PAIR[1],
+    'server': SAMPLE_CGAP_LOCAL_SERVER,
+}
+
+SAMPLE_CGAP_KEYS_FILE_CONTENT = {
+    SAMPLE_CGAP_FOO_ENV: SAMPLE_CGAP_FOO_DICT,
+    SAMPLE_CGAP_LOCAL_PSEUDOENV: SAMPLE_CGAP_LOCAL_DICT,
+    SAMPLE_CGAP_PRODUCTION_ENV: SAMPLE_CGAP_DICT,
+}
+
+SAMPLE_CGAP_KEYS_FILE_TEXT = json.dumps(SAMPLE_CGAP_KEYS_FILE_CONTENT)
+
+# The content of the keys file will be a dictionary like this (though not indented):
+#   {
+#       'fourfront-cgap': {
+#           'key': 'key1',
+#           'secret': 'somesecret1',
+#           'server': 'https://cgap.hms.harvard.edu'
+#       },
+#       'fourfront-cgapfoo': {
+#           'key': 'key2',
+#           'secret': 'somesecret2',
+#           'server': 'http://fourfront-cgapfoo.whatever.aws.com'
+#       },
+#       'fourfront-cgaplocal': {
+#           'key': 'key3',
+#           'secret': 'somesecret3',
+#           'server': 'http://localhost:8000'
+#       }
+#   }
+
+
+def test_get_keydicts():
+
+    key_manager = _make_sample_cgap_key_manager()
+    mfs = MockFileSystem(files={key_manager.keys_file: SAMPLE_CGAP_KEYS_FILE_TEXT})
+
+    with mfs.mock_exists_open_remove():
+
+        assert key_manager.get_keydicts() == SAMPLE_CGAP_KEYS_FILE_CONTENT
+
+
+def test_get_keypair_for_env():
+
+    key_manager = _make_sample_cgap_key_manager()
+    mfs = MockFileSystem(files={key_manager.keys_file: SAMPLE_CGAP_KEYS_FILE_TEXT})
+
+    with mfs.mock_exists_open_remove():
+
+        assert key_manager.get_keypair_for_env(SAMPLE_CGAP_PRODUCTION_ENV) == SAMPLE_CGAP_PAIR
+        assert key_manager.get_keypair_for_env(SAMPLE_CGAP_FOO_ENV) == SAMPLE_CGAP_FOO_PAIR
+        assert key_manager.get_keypair_for_env(SAMPLE_CGAP_LOCAL_PSEUDOENV) == SAMPLE_CGAP_LOCAL_PAIR
+
+        with pytest.raises(AppEnvKeyMissing):  # If an environment is missing, an error is raised.
+            key_manager.get_keypair_for_env(SAMPLE_MISSING_ENV)
+
+        with pytest.raises(ValueError):  # None is not a valid environment name. There is no default.
+            key_manager.get_keypair_for_env(None)
+
+        with pytest.raises(Exception):  # Wrong number of arguments. The environment name does not default.
+            key_manager.get_keypair_for_env()  # noQA
+
+
+def test_get_keydict_for_env():
+
+    key_manager = _make_sample_cgap_key_manager()
+    mfs = MockFileSystem(files={key_manager.keys_file: SAMPLE_CGAP_KEYS_FILE_TEXT})
+
+    with mfs.mock_exists_open_remove():
+
+        assert key_manager.get_keydict_for_env(SAMPLE_CGAP_PRODUCTION_ENV) == SAMPLE_CGAP_DICT
+        assert key_manager.get_keydict_for_env(SAMPLE_CGAP_FOO_ENV) == SAMPLE_CGAP_FOO_DICT
+        assert key_manager.get_keydict_for_env(SAMPLE_CGAP_LOCAL_PSEUDOENV) == SAMPLE_CGAP_LOCAL_DICT
+
+        with pytest.raises(AppEnvKeyMissing):  # If an environment is missing, an error is raised.
+            key_manager.get_keydict_for_env(SAMPLE_MISSING_ENV)
+
+        with pytest.raises(ValueError):  # None is not a valid environment name. There is no default.
+            key_manager.get_keydict_for_env(None)
+
+        with pytest.raises(Exception):  # Wrong number of arguments. The environment name does not default.
+            key_manager.get_keydict_for_env()  # noQA
+
+
+def test_get_keypair_for_server():
+
+    key_manager = _make_sample_cgap_key_manager()
+    mfs = MockFileSystem(files={key_manager.keys_file: SAMPLE_CGAP_KEYS_FILE_TEXT})
+
+    with mfs.mock_exists_open_remove():
+
+        assert key_manager.get_keypair_for_server(SAMPLE_CGAP_PRODUCTION_SERVER) == SAMPLE_CGAP_PAIR
+        assert key_manager.get_keypair_for_server(SAMPLE_CGAP_FOO_SERVER) == SAMPLE_CGAP_FOO_PAIR
+        assert key_manager.get_keypair_for_server(SAMPLE_CGAP_LOCAL_SERVER) == SAMPLE_CGAP_LOCAL_PAIR
+
+        with pytest.raises(AppServerKeyMissing):
+            key_manager.get_keypair_for_server(SAMPLE_MISSING_SERVER)
+
+        with pytest.raises(ValueError):  # None is not a valid server name. There is no default.
+            key_manager.get_keypair_for_server(None)
+
+        with pytest.raises(Exception):  # wrong number of arguments
+            key_manager.get_keypair_for_server()  # noQA
+
+
+def test_get_keydict_for_server():
+
+    key_manager = _make_sample_cgap_key_manager()
+    mfs = MockFileSystem(files={key_manager.keys_file: SAMPLE_CGAP_KEYS_FILE_TEXT})
+
+    with mfs.mock_exists_open_remove():
+
+        assert key_manager.get_keydict_for_server(SAMPLE_CGAP_PRODUCTION_SERVER) == SAMPLE_CGAP_DICT
+        assert key_manager.get_keydict_for_server(SAMPLE_CGAP_FOO_SERVER) == SAMPLE_CGAP_FOO_DICT
+        assert key_manager.get_keydict_for_server(SAMPLE_CGAP_LOCAL_SERVER) == SAMPLE_CGAP_LOCAL_DICT
+
+        with pytest.raises(AppServerKeyMissing):
+            key_manager.get_keydict_for_server(SAMPLE_MISSING_SERVER)
+
+        with pytest.raises(ValueError):  # None is not a valid server name. There is no default.
+            key_manager.get_keydict_for_server(None)
+
+        with pytest.raises(Exception):  # wrong number of arguments
+            key_manager.get_keydict_for_server()  # noQA

--- a/test/test_creds_utils.py
+++ b/test/test_creds_utils.py
@@ -42,13 +42,13 @@ def test_cgap_keymanager_creation():
 
     assert sample_cgap_key_manager_2.keys_file == SAMPLE_CGAP_KEYS_FILE
 
-    with override_environ(CGAP_DEFAULT_ENV=SAMPLE_CGAP_LOCAL_PSEUDOENV):
+    with override_environ(CGAP_KEYS_FILE=SAMPLE_CGAP_KEYS_FILE):
 
         sample_cgap_key_manager_3 = CGAPKeyManager()
 
-        assert sample_cgap_key_manager_3.keys_file == CGAPKeyManager._default_keys_file()
+        assert sample_cgap_key_manager_3.keys_file == SAMPLE_CGAP_KEYS_FILE
         # Make sure class default is different than test value. More of a test-integrity test than an absolute need.
-        assert sample_cgap_key_manager_3.keys_file != SAMPLE_CGAP_KEYS_FILE
+        assert sample_cgap_key_manager_3.keys_file != CGAPKeyManager._default_keys_file()
 
     other_keys_file = "other-cgap-keys.json"
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -2,8 +2,9 @@ from dcicutils.exceptions import (
     ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix,
     ConfigurationError, SynonymousEnvironmentVariablesMismatched, InferredBucketConflict,
     CannotInferEnvFromNoGlobalEnvs, CannotInferEnvFromManyGlobalEnvs, MissingGlobalEnv, GlobalBucketAccessError,
-    InvalidParameterError,
+    InvalidParameterError, AppKeyMissing, AppServerKeyMissing, AppEnvKeyMissing
 )
+from dcicutils.creds_utils import CGAPKeyManager
 
 
 def test_expected_error_not_seen():
@@ -253,3 +254,38 @@ def test_invalid_parameter_error_with_dynamic_options():
     n += 1  # n == 3. Valid values for newly created errors = ['val0', 'val1', 'val2']
     assert str(e2a) == "The value was not valid. Valid values are 'val0' and 'val1'."  # created when n == 2
     assert str(e2b) == "The value was not valid. Valid values are 'val0' and 'val1'."  # ditto
+
+
+def test_app_key_missing():
+
+    error = AppKeyMissing(context="testing", key_manager=CGAPKeyManager())
+
+    assert isinstance(error, RuntimeError)
+    assert isinstance(error, AppKeyMissing)
+
+    assert str(error) == "Missing credential in file %s for testing." % CGAPKeyManager._default_keys_file()
+
+
+def test_app_env_key_missing():
+    some_env = 'fourfront-cgapsomething'
+
+    error = AppEnvKeyMissing(env=some_env, key_manager=CGAPKeyManager())
+
+    assert isinstance(error, RuntimeError)
+    assert isinstance(error, AppKeyMissing)
+
+    assert str(error) == ("Missing credential in file %s for CGAP environment %s."
+                          % (CGAPKeyManager._default_keys_file(), some_env))
+
+
+def test_app_server_key_missing():
+
+    some_server = "http://127.0.0.1:5000"
+
+    error = AppServerKeyMissing(server=some_server, key_manager=CGAPKeyManager())
+
+    assert isinstance(error, RuntimeError)
+    assert isinstance(error, AppKeyMissing)
+
+    assert str(error) == ("Missing credential in file %s for CGAP server %s."
+                          % (CGAPKeyManager._default_keys_file(), some_server))


### PR DESCRIPTION
* Adds support for `creds_utils`.

  * Class `KeyManager`, with methods:

    * `KeyManager.get_keydict_for_env(self, env)`

    * `KeyManager.get_keydict_for_server(self, server)`

    * `KeyManager.get_keydicts(self)`

    * `KeyManager.get_keypair_for_env(self, env)`

    * `KeyManager.get_keypair_for_server(self, server)`

    * `KeyManager.keydict_to_keypair(auth_dict)`

    * `KeyManager.keypair_to_keydict(auth_tuple, *, server)`

  * Class `FourfrontKeyManager`

  * Class `CGAPKeyManager`

Opportunistic:

* Adds a `clear-poetry-cache` target in `Makefile`