### PR TITLE
New mappings and noramalizer support for diff_utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,25 @@ Change Log
 ----------
 
 
+3.12.0
+======
+
+* In ``diff_utils``:
+
+  * Add support for ``.diffs(..., include_mappings=True)``
+  * Add support for ``.diffs(..., normalizer=<fn>)`` where ``<fn>`` is a function of two keyword arguments,
+    ``item`` and ``label`` that can rewrite a given expression to be compared into a canonical form (e.g.,
+    reducing a dictionary with a ``uuid`` to just the ``uuid``, which is what we added the functionality for).
+
+
+3.11.1
+======
+
+* In ``ff_utils``:
+
+  * In ``get_metadata``, strip leading slashes on ids in API functions.
+
+
 3.11.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.11.1"
+version = "3.12.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
* Add support for `include_mappings=True` and `normalizer=<fn>` in `DiffManager.diffs`.
* Backfill `CHANGELOG` documentation for the change in dcicutils 3.11.1