### PR TITLE
Add S3 object tagging functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Change Log
 
   * Add ``s3Utils.get_object_tags``
   * Add ``s3Utils.set_object_tags``
+  * Add ``s3Utils.get_object_tag``
 
 
 3.13.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Change Log
 
   * Add ``s3Utils.get_object_tags``
   * Add ``s3Utils.set_object_tags``
-  * Add ``s3Utils.get_object_tag``
+  * Add ``s3Utils.set_object_tag``
 
 
 3.13.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ Change Log
 
 * In ``misc_utils``:
 
-  * New function ``key_value_pair``.
-  * New function ``merge_key_value_pairs``.
+  * New function ``key_value_dict``.
+  * New function ``merge_key_value_dict_lists``.
 
 * In ``qa_utils``:
 

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -1518,17 +1518,27 @@ class NamedObject(object):
         return f"<{self.name}@{id(self):x}>"
 
 
-def key_value_pair(key, value):
+def key_value_dict(key, value):
+    """
+    Given a key k and a value v, returns the dictionary {"Key": k, "Value": v}, which is a format AWS is fond of.
+    """
     return {'Key': key, 'Value': value}
 
 
-def merge_key_value_pairs(x, y):
+def merge_key_value_dict_lists(x, y):
+    """
+    Merges two lists of the form [{"Key": k1, "Value": v1}, {"Key": k2, "Value": v2}].
+    It is assumed that neither list has repeated keys, and that the resulting list also should not.
+    Entries in the resulting list will be in the same order as the original two lists except when both
+    lists contain entries that share a key. In that case, the two entries will be merged
+    into a single entry with the position of the first such entry and value of the second.
+    """
     merged = {}
     for pair in x:
         merged[pair['Key']] = pair['Value']
     for pair in y:
         merged[pair['Key']] = pair['Value']
-    return [key_value_pair(k, v) for k, v in merged.items()]
+    return [key_value_dict(k, v) for k, v in merged.items()]
 
 
 # The names HMS_TZ and hms_now were deprecated for a while and are removed in dcicutils 3.0

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -20,7 +20,6 @@ import uuid
 import warnings
 
 from botocore.exceptions import ClientError
-from collections import defaultdict
 from json import dumps as json_dumps, loads as json_loads
 from unittest import mock
 from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix
@@ -1045,7 +1044,6 @@ class MockBotoS3Client:
         )
         attribute_block = self._object_attribute_block(filename)
         attribute_block.tagset = copy.deepcopy(tagset)  # Don't share state with our argument
-
 
     def _object_storage_class(self, filename):
         """

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -315,7 +315,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
         except Exception as e:
             logger.warning(f'Could not get tags for object {bucket}/{key}: {str(e)}')
             raise e
-    
+
     def set_object_tag(self, *, bucket, key, tag_key, tag_value):
         """
         Adds (tag_key,tag_value) pair to the object. If a tag with key tag_key is already present,
@@ -334,7 +334,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
         return self.set_object_tags(
             bucket=bucket,
             key=key,
-            tags=[key_value_dict(tag_key,tag_value)],
+            tags=[key_value_dict(tag_key, tag_value)],
             merge_existing_tags=True,
         )
 

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -300,9 +300,9 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
         Args:
             key (string): object key
             bucket (string): S3 bucket
-            
+
         Returns:
-            Returns list of object tags. 
+            Returns list of object tags.
             The format is [{'Key': 'KEY1','Value': 'VALUE1'},{...}]
         """
 
@@ -324,7 +324,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
             key (string): object key
             bucket (string): S3 bucket
             tags (list): List of tags of the form [{'Key': 'KEY1','Value': 'VALUE1'}, {...}]
-            replace_tags (bool): If True, existing tags are replaced with the provided ones. 
+            replace_tags (bool): If True, existing tags are replaced with the provided ones.
                 Otherwise, the provided tags are added to the existing ones
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.13.1"
+version = "3.14.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.13.0"
+version = "3.13.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -25,7 +25,7 @@ from dcicutils.misc_utils import (
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
     capitalize1, local_attrs, dict_zip, json_leaf_subst, _is_function_of_exactly_one_required_arg, string_list,
-    string_md5, key_value_pair, merge_key_value_pairs,
+    string_md5, key_value_dict, merge_key_value_dict_lists,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp
@@ -2571,16 +2571,16 @@ def test_json_leaf_subst():
     assert json_leaf_subst({"x": "y", "y": "x"}, subs) == {"ex": "why", "why": "ex"}
 
 
-def test_key_value_pair():
+def test_key_value_dict():
 
-    assert key_value_pair('a', 'b') == {'Key': 'a', 'Value': 'b'}
+    assert key_value_dict('a', 'b') == {'Key': 'a', 'Value': 'b'}
 
 
-def test_merge_key_value_pairs():
+def test_merge_key_value_dict_lists():
 
     old = [{'Key': 'a', 'Value': '1'}, {'Key': 'b', 'Value': '2'}]
     new = [{'Key': 'c', 'Value': '3'}, {'Key': 'd', 'Value': '4'}]
-    actual = merge_key_value_pairs(old, new)
+    actual = merge_key_value_dict_lists(old, new)
     expected = [
         {'Key': 'a', 'Value': '1'},
         {'Key': 'b', 'Value': '2'},
@@ -2591,13 +2591,13 @@ def test_merge_key_value_pairs():
 
     old = [{'Key': 'a', 'Value': '1'}, {'Key': 'b', 'Value': '2'}]
     new = [{'Key': 'b', 'Value': '3'}, {'Key': 'd', 'Value': '4'}]
-    actual = merge_key_value_pairs(old, new)
+    actual = merge_key_value_dict_lists(old, new)
     expected = [{'Key': 'a', 'Value': '1'}, {'Key': 'b', 'Value': '3'}, {'Key': 'd', 'Value': '4'}]
     assert actual == expected
 
     old = [{'Key': 'a', 'Value': '1'}, {'Key': 'b', 'Value': '2'}]
     new = [{'Key': 'b', 'Value': '3'}, {'Key': 'd', 'Value': '4'}, {'Key': 'a', 'Value': '7'}]
-    actual = merge_key_value_pairs(old, new)
+    actual = merge_key_value_dict_lists(old, new)
     expected = [{'Key': 'a', 'Value': '7'}, {'Key': 'b', 'Value': '3'}, {'Key': 'd', 'Value': '4'}]
     assert actual == expected
 

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -970,7 +970,7 @@ def test_get_and_set_object_tags():
         s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'b', 'Value': 'beta'}])
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'a', 'Value': 'alpha'},{'Key': 'b', 'Value': 'beta'}]
+        expected = [{'Key': 'a', 'Value': 'alpha'}, {'Key': 'b', 'Value': 'beta'}]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"
 

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -970,20 +970,34 @@ def test_get_and_set_object_tags():
         s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'b', 'Value': 'beta'}])
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'b', 'Value': 'beta'}]
+        expected = [{'Key': 'a', 'Value': 'alpha'},{'Key': 'b', 'Value': 'beta'}]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"
 
-        s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'a', 'Value': 'alpha'}], replace_tags=False)
+        s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'a', 'Value': 'alpha'}], merge_existing_tags=False)
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'b', 'Value': 'beta'}, {'Key': 'a', 'Value': 'alpha'}]
+        expected = [{'Key': 'a', 'Value': 'alpha'}]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"
 
-        s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'b', 'Value': 'bravo'}], replace_tags=False)
+        s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'b', 'Value': 'bravo'}], merge_existing_tags=True)
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'b', 'Value': 'bravo'}, {'Key': 'a', 'Value': 'alpha'}]
+        expected = [{'Key': 'a', 'Value': 'alpha'}, {'Key': 'b', 'Value': 'bravo'} ]
+        # print(f"actual={actual} expected={expected}")
+        assert actual == expected, f"Got {actual} but expected {expected}"
+
+        s3u.set_object_tag(key=key, bucket=bucket, tag_key="a", tag_value="alpha_2")
+
+        actual = s3u.get_object_tags(key=key, bucket=bucket)
+        expected = [{'Key': 'a', 'Value': 'alpha_2'}, {'Key': 'b', 'Value': 'bravo'} ]
+        # print(f"actual={actual} expected={expected}")
+        assert actual == expected, f"Got {actual} but expected {expected}"
+
+        s3u.set_object_tag(key=key, bucket=bucket, tag_key="c", tag_value="gamma")
+        
+        actual = s3u.get_object_tags(key=key, bucket=bucket)
+        expected = [{'Key': 'a', 'Value': 'alpha_2'}, {'Key': 'b', 'Value': 'bravo'}, {'Key': 'c', 'Value': 'gamma'} ]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"


### PR DESCRIPTION
This PR adds two simple functions to get and set tags for S3 objects. The functions are simple wrappers of the corresponding boto3 commands.

I thought about adding tests, but given that this basically just calls boto3, I am not sure, if that would add any value. Please let me know if you think otherwise.

As discussed with Kent, I added it to s3_utils for now.