### PR TITLE
Changes in service of foursight-core (compatible)

### DIFF
--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -1065,6 +1065,7 @@ class CreateMappingOnDeployManager:
     # Set SKIP to True to skip the create_mapping step.
 
     DEFAULT_DEPLOYMENT_OPTIONS = {'SKIP': False, 'STRICT': False, 'WIPE_ES': False}
+    PRODUCTION_DEPLOYMENT_OPTION_OVERRIDES = {'WIPE_ES': False, 'STRICT': True}
     STAGING_DEPLOYMENT_OPTION_OVERRIDES = {'WIPE_ES': True, 'STRICT': True}
     HOTSEAT_DEPLOYMENT_OPTION_OVERRIDES = {'SKIP': True, 'STRICT': True}
     OTHER_TEST_DEPLOYMENT_OPTION_OVERRIDES = {'WIPE_ES': True}
@@ -1129,7 +1130,10 @@ class CreateMappingOnDeployManager:
             if val:
                 deploy_cfg[key] = val
 
-        if env == get_standard_mirror_env(current_prod_env):
+        if env == current_prod_env:
+            description = "currently the production environment"
+            apply_dict_overrides(deploy_cfg, **cls.PRODUCTION_DEPLOYMENT_OPTION_OVERRIDES)
+        elif env == get_standard_mirror_env(current_prod_env):
             description = "currently the staging environment"
             apply_dict_overrides(deploy_cfg, **cls.STAGING_DEPLOYMENT_OPTION_OVERRIDES)
         elif is_stg_or_prd_env(env):

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -33,7 +33,7 @@ import time
 import boto3
 from git import Repo
 
-from .beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env
+from .base import compute_ff_prd_env, compute_cgap_prd_env
 from .common import LEGACY_GLOBAL_ENV_BUCKET, LEGACY_CGAP_GLOBAL_ENV_BUCKET, DEFAULT_ECOSYSTEM
 from .env_utils import (
     get_standard_mirror_env, data_set_for_env, get_bucket_env,

--- a/dcicutils/env_manager.py
+++ b/dcicutils/env_manager.py
@@ -3,12 +3,13 @@ import botocore.client
 # import contextlib
 import json
 import logging
-# import os
+import os
 import urllib.request
 
 from typing import Optional
 # from .common import LEGACY_GLOBAL_ENV_BUCKET
 from .env_basic import EnvBase
+from .env_utils import full_env_name
 from .exceptions import (
     CannotInferEnvFromManyGlobalEnvs,
     MissingGlobalEnv,
@@ -76,7 +77,6 @@ class EnvManager(EnvBase):
         Although the s3 client can be created for you, but if you already have acess to an s3 client via some existing
         object, you should pass that.
         """
-
         self.s3 = s3 or boto3.client('s3')
         if env_name and env_description:
             raise ValueError("You may only specify an env_name or an env_description")
@@ -155,13 +155,16 @@ class EnvManager(EnvBase):
         return self._env_name
 
     @classmethod
-    def verify_and_get_env_config(cls, s3_client, global_bucket: str, env):
+    def verify_and_get_env_config(cls, s3_client, global_bucket: str, env: Optional[str]):
         """
         Verifies the S3 environment from which the env config is coming from, and returns the S3-based env config
         Throws exceptions if the S3 bucket is unreachable, or an env based on the name of the global S3 bucket
         is not present.
         """
         logger.warning(f'Fetching bucket data via global env bucket: {global_bucket}')
+
+        if env:
+            env = full_env_name(env)
 
         # head_response = s3_client.head_bucket(Bucket=global_bucket)
         # status = head_response['ResponseMetadata']['HTTPStatusCode']  # should be 200; raise error for 404 or 403
@@ -198,3 +201,4 @@ class EnvManager(EnvBase):
         res_body = res.read()
         j = json.loads(res_body.decode("utf-8"))
         return j
+

--- a/dcicutils/env_manager.py
+++ b/dcicutils/env_manager.py
@@ -1,25 +1,14 @@
 import boto3
 import botocore.client
-# import contextlib
 import json
 import logging
-import os
 import urllib.request
 
 from typing import Optional
-# from .common import LEGACY_GLOBAL_ENV_BUCKET
 from .env_basic import EnvBase
 from .env_utils import full_env_name
-from .exceptions import (
-    CannotInferEnvFromManyGlobalEnvs,
-    MissingGlobalEnv,
-    # SynonymousEnvironmentVariablesMismatched,
-)
-from .misc_utils import (
-    # override_environ,
-    ignored,
-    # remove_suffix,
-)
+from .exceptions import CannotInferEnvFromManyGlobalEnvs, MissingGlobalEnv
+from .misc_utils import ignored
 
 
 logger = logging.getLogger(__name__)
@@ -201,4 +190,3 @@ class EnvManager(EnvBase):
         res_body = res.read()
         j = json.loads(res_body.decode("utf-8"))
         return j
-

--- a/dcicutils/exceptions.py
+++ b/dcicutils/exceptions.py
@@ -129,7 +129,7 @@ class MissingGlobalEnv(ConfigurationError):
         self.global_bucket = global_bucket
         self.keys = keys
         self.env = env
-        super().__init__("No matches for global env bucket: {global_bucket}; keys: {keys}; desired env: {env}"
+        super().__init__("No matches for env {env} in bucket {global_bucket}; keys: {keys}"
                          .format(global_bucket=global_bucket, keys=keys, env=env))
 
 

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -17,7 +17,7 @@ from dcicutils.qa_utils import (
 )
 from dcicutils.s3_utils import EnvManager
 from unittest import mock
-from . import beanstalk_utils, ff_utils, s3_utils, env_utils, env_basic, env_manager  # env_base, base
+from . import beanstalk_utils, ff_utils, s3_utils, env_utils, env_basic, env_manager
 from .common import LEGACY_GLOBAL_ENV_BUCKET
 
 
@@ -122,9 +122,11 @@ def mocked_s3utils(environments=None, require_sse=False, other_access_key_names=
                            elasticbeanstalk=make_mock_boto_eb_client_class(beanstalks=environments))
     s3_client = mock_boto3.client('s3')  # This creates the s3 file system
     assert isinstance(s3_client, s3_class)
+
     def write_config(config_name, record):
         record_string = json.dumps(record)
         s3_client.s3_files.files[f"{LEGACY_GLOBAL_ENV_BUCKET}/{config_name}"] = bytes(record_string.encode('utf-8'))
+
     ecosystem_file = "main.ecosystem"
     for environment in environments:
         record = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.0.2b39"  # originally based on 3.6.0, but merges 3.14.0, eventually to be "4.0.0"
+version = "3.14.0.2b40"  # originally based on 3.6.0, but merges 3.14.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.0.2b40"  # originally based on 3.6.0, but merges 3.14.0, eventually to be "4.0.0"
+version = "3.14.0.2b41"  # originally based on 3.6.0, but merges 3.14.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,7 +71,7 @@ class IntegratedFixture:
         A dictionary pseudo-element 'self' describes this object itself.
         """
         entries = ', '.join([f'{key!r}: {"<redacted>" if "key" in key else repr(self.INTEGRATED_FF_ITEMS[key])}'
-                               for key in self.INTEGRATED_FF_ITEMS])
+                             for key in self.INTEGRATED_FF_ITEMS])
         return f"{{'self': <{self.__class__.__name__} {self.name!r} {id(self)}>, {entries}}}"
 
     def __repr__(self):

--- a/test/data_files/foursight-cgap-envs/main.ecosystem
+++ b/test/data_files/foursight-cgap-envs/main.ecosystem
@@ -1,0 +1,19 @@
+{
+    "dev_env_domain_suffix": ".hms.harvard.edu",
+    "full_env_prefix": "cgap-",
+    "foursight_url_prefix": "https://cgap.hms.harvard.edu/view/",
+    "orchestrated_app": "cgap",
+    "prd_env_name": "cgap-prd",
+    "test_envs": ["cgap-mastertest", "cgap-dev", "cgap-test", "cgap-wolf"],
+    "hotseat_envs": ["cgap-wolf"],
+    "public_url_table": [
+        {
+            "name": "cgap",
+	        "url": "https://cgap.hms.harvard.edu",
+            "host": "cgap.hms.harvard.edu",
+            "environment": "cgap-prd"
+        }
+    ],
+    "foursight_bucket_prefix": "foursight",
+    "default_workflow_env": "cgap-wolf"
+}

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -27,7 +27,6 @@ def using_fresh_legacy_state():
     return wrap
 
 
-
 @decorator()
 def using_fresh_cgap_state():
     def wrap(function):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,50 @@
+import contextlib
+import functools
+import json
+import os
+
+from dcicutils.env_utils import EnvUtils
+from dcicutils.misc_utils import file_contents, decorator
+from .conftest_settings import TEST_DIR
+
+
+@contextlib.contextmanager
+def fresh_cgap_state():
+    cgap_declaration = json.loads(file_contents(os.path.join(TEST_DIR,
+                                                             'data_files/foursight-cgap-envs/main.ecosystem')))
+    with EnvUtils.fresh_state_from(data=cgap_declaration):
+        yield
+
+
+@decorator()
+def using_fresh_legacy_state():
+    def wrap(function):
+        @functools.wraps(function)
+        def _wrapped(*args, **kwargs):
+            with EnvUtils.fresh_state_from(data={'is_legacy': True}):
+                return function(*args, **kwargs)
+        return _wrapped
+    return wrap
+
+
+
+@decorator()
+def using_fresh_cgap_state():
+    def wrap(function):
+        @functools.wraps(function)
+        def _wrapped(*args, **kwargs):
+            with fresh_cgap_state():
+                return function(*args, **kwargs)
+        return _wrapped
+    return wrap
+
+
+@decorator()
+def using_fresh_ff_state():
+    def wrap(function):
+        @functools.wraps(function)
+        def _wrapped(*args, **kwargs):
+            with EnvUtils.fresh_ff_state():
+                return function(*args, **kwargs)
+        return _wrapped
+    return wrap

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -1303,23 +1303,26 @@ def test_get_deployment_config_cgap_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
     with fresh_cgap_state():
         my_log = MockedInfoLog()
-        with pytest.raises(RuntimeError):
-            _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
+        cfg = _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
+        assert cfg['ENV_NAME'] == EnvUtils.PRD_ENV_NAME  # sanity
+        assert cfg['SKIP'] is False
+        assert cfg['WIPE_ES'] is False
+        assert cfg['STRICT'] is True
         assert my_log.last_msg == (f"Environment {EnvUtils.PRD_ENV_NAME} is currently the production environment."
-                                   f" Something is definitely wrong. We never deploy there, we always CNAME swap."
-                                   f" This deploy cannot proceed. DeploymentFailure will be raised.")
-
+                                   f" Processing mode: STRICT")
 
 @pytest.mark.integrated
 def test_get_deployment_config_ff_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
     with EnvUtils.fresh_ff_state():
         my_log = MockedInfoLog()
-        with pytest.raises(RuntimeError):
-            _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
+        cfg = _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
+        assert cfg['ENV_NAME'] == EnvUtils.PRD_ENV_NAME  # sanity
+        assert cfg['SKIP'] is False
+        assert cfg['WIPE_ES'] is False
+        assert cfg['STRICT'] is True
         assert my_log.last_msg == (f"Environment {EnvUtils.PRD_ENV_NAME} is currently the production environment."
-                                   f" Something is definitely wrong. We never deploy there, we always CNAME swap."
-                                   f" This deploy cannot proceed. DeploymentFailure will be raised.")
+                                   f" Processing mode: STRICT")
 
 
 @pytest.mark.integrated

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -1,5 +1,4 @@
 import argparse
-import contextlib
 import datetime
 import io
 import json

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -4,7 +4,7 @@ from unittest import mock
 from dcicutils.ecr_utils import ECRUtils
 from dcicutils.docker_utils import DockerUtils
 from dcicutils.misc_utils import ignored
-from .helpers import fresh_cgap_state, using_fresh_cgap_state
+from .helpers import using_fresh_cgap_state
 
 
 REPO_URL = '123456789.dkr.ecr.us-east-2.amazonaws.com/cgap-mastertest'  # dummy URL

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -4,6 +4,7 @@ from unittest import mock
 from dcicutils.ecr_utils import ECRUtils
 from dcicutils.docker_utils import DockerUtils
 from dcicutils.misc_utils import ignored
+from .helpers import fresh_cgap_state, using_fresh_cgap_state
 
 
 REPO_URL = '123456789.dkr.ecr.us-east-2.amazonaws.com/cgap-mastertest'  # dummy URL
@@ -21,6 +22,7 @@ def mocked_ecr_login(*, username, password, registry):
     return
 
 
+@using_fresh_cgap_state()
 def test_ecr_utils_basic():
     """ Tests something simple for now, more tests to be added later. """
     cli = ECRUtils()  # default args ok
@@ -30,6 +32,7 @@ def test_ecr_utils_basic():
 
 
 @pytest.mark.skipif(not DockerUtils.docker_is_running(), reason="Docker is not running.")
+@using_fresh_cgap_state()
 def test_ecr_utils_workflow():
     """ Tests URL + Login via Docker_cli"""
     ecr_cli = ECRUtils()

--- a/test/test_env_utils_legacy.py
+++ b/test/test_env_utils_legacy.py
@@ -27,8 +27,10 @@ from dcicutils.env_utils_legacy import (
 from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
+from .helpers import using_fresh_cgap_state, using_fresh_ff_state, using_fresh_legacy_state
 
 
+@using_fresh_legacy_state()
 def test_default_workflow_env():
 
     assert (default_workflow_env('fourfront')
@@ -40,10 +42,11 @@ def test_default_workflow_env():
             == CGAP_ENV_WOLF
             == 'fourfront-cgapwolf')
 
-    with pytest.raises(InvalidParameterError):
+    with pytest.raises(Exception):
         default_workflow_env('foo')  # noQA - we expect this error
 
 
+@using_fresh_legacy_state()
 def test_get_bucket_env():
 
     # Fourfront tests
@@ -68,6 +71,7 @@ def test_get_bucket_env():
     assert get_bucket_env('fourfront-cgapwolf') == 'fourfront-cgapwolf'
 
 
+@using_fresh_legacy_state()
 def test_prod_bucket_env_for_app():
 
     assert prod_bucket_env_for_app('fourfront') == FF_PROD_BUCKET_ENV
@@ -80,6 +84,7 @@ def test_prod_bucket_env_for_app():
         prod_bucket_env_for_app('foo')  # noQA - we expect this error
 
 
+@using_fresh_legacy_state()
 def test_prod_bucket_env():
 
     # Fourfront tests
@@ -104,6 +109,7 @@ def test_prod_bucket_env():
     assert prod_bucket_env('fourfront-cgapwolf') is None
 
 
+@using_fresh_legacy_state()
 def test_permit_load_data():
 
     # Fourfront envs
@@ -181,6 +187,7 @@ def test_permit_load_data():
     assert permit_load_data('cgap-wolf', allow_prod=False, orchestrated_app='cgap') is False
 
 
+@using_fresh_legacy_state()
 def test_data_set_for_env():
 
     assert data_set_for_env('fourfront-blue') == 'prod'
@@ -203,6 +210,7 @@ def test_data_set_for_env():
     assert data_set_for_env('cgap-wolf') == 'prod'  # see above
 
 
+@using_fresh_legacy_state()
 def test_public_url_mappings():
 
     assert public_url_mappings('fourfront-webprod') == FF_PUBLIC_URLS
@@ -217,6 +225,7 @@ def test_public_url_mappings():
     assert public_url_mappings('cgap-green') == CGAP_PUBLIC_URLS
 
 
+@using_fresh_legacy_state()
 def test_public_url_for_app():
 
     assert public_url_for_app('cgap') == _CGAP_MGB_PUBLIC_URL_PRD
@@ -226,6 +235,7 @@ def test_public_url_for_app():
         public_url_for_app('foo')  # noQA - we expect this error
 
 
+@using_fresh_legacy_state()
 def test_blue_green_mirror_env():
 
     # Should work for basic fourfront
@@ -255,6 +265,7 @@ def test_blue_green_mirror_env():
         blue_green_mirror_env('green-blue')  # needs to be one or the other
 
 
+@using_fresh_legacy_state()
 def test_is_cgap_server():
 
     with pytest.raises(ValueError):
@@ -288,6 +299,7 @@ def test_is_cgap_server():
     assert is_cgap_server("www.google.com") is False
 
 
+@using_fresh_legacy_state()
 def test_is_fourfront_server():
     with pytest.raises(ValueError):
         is_fourfront_server(None)
@@ -320,6 +332,7 @@ def test_is_fourfront_server():
     assert is_fourfront_server("www.google.com") is False
 
 
+@using_fresh_legacy_state()
 def test_is_cgap_env():
 
     assert is_cgap_env(None) is False
@@ -329,6 +342,7 @@ def test_is_cgap_env():
     assert is_cgap_env('fourfront-blue') is False
 
 
+@using_fresh_legacy_state()
 def test_is_fourfront_env():
 
     assert is_fourfront_env('fourfront-cgap') is False
@@ -338,6 +352,7 @@ def test_is_fourfront_env():
     assert is_fourfront_env(None) is False
 
 
+@using_fresh_legacy_state()
 def test_is_beanstalk_env():
 
     assert is_beanstalk_env('fourfront-webprod') is True
@@ -378,6 +393,7 @@ def test_is_beanstalk_env():
     assert is_beanstalk_env('anything-at-all') is False
 
 
+@using_fresh_legacy_state()
 def test_is_stg_or_prd_env():
 
     assert is_stg_or_prd_env("fourfront-green") is True
@@ -433,6 +449,7 @@ def test_is_stg_or_prd_env():
     assert is_stg_or_prd_env(None) is False
 
 
+@using_fresh_legacy_state()
 def test_is_test_env():
 
     assert is_test_env(FF_ENV_PRODUCTION_BLUE) is False
@@ -462,6 +479,7 @@ def test_is_test_env():
     assert is_test_env(None) is False
 
 
+@using_fresh_legacy_state()
 def test_is_hotseat_env():
 
     assert is_hotseat_env(FF_ENV_PRODUCTION_BLUE) is False
@@ -496,6 +514,7 @@ def test_is_hotseat_env():
     assert is_hotseat_env(None) is False
 
 
+@using_fresh_legacy_state()
 def test_get_mirror_env_from_context_without_environ():
     """ Tests that when getting mirror env on various envs returns the correct mirror """
 
@@ -545,6 +564,7 @@ def test_get_mirror_env_from_context_without_environ():
             assert mirror is None
 
 
+@using_fresh_legacy_state()
 def test_get_mirror_env_from_context_with_environ_has_env():
     """ Tests override of env name from os.environ when getting mirror env on various envs """
 
@@ -590,6 +610,7 @@ def test_get_mirror_env_from_context_with_environ_has_env():
         assert mirror is None  # env name explicitly declared, but guessing disallowed (but no CGAP mirror)
 
 
+@using_fresh_legacy_state()
 def test_get_mirror_env_from_context_with_environ_has_mirror_env():
     """ Tests override of mirror env name from os.environ when getting mirror env on various envs """
 
@@ -599,6 +620,7 @@ def test_get_mirror_env_from_context_with_environ_has_mirror_env():
         assert mirror == 'bar'  # explicitly declared, even if nothing else ise
 
 
+@using_fresh_legacy_state()
 def test_get_mirror_env_from_context_with_environ_has_env_and_mirror_env():
     """ Tests override of env name and mirror env name from os.environ when getting mirror env on various envs """
 
@@ -608,6 +630,7 @@ def test_get_mirror_env_from_context_with_environ_has_env_and_mirror_env():
         assert mirror == 'bar'  # mirror explicitly declared, ignoring env name
 
 
+@using_fresh_legacy_state()
 def test_get_standard_mirror_env():
 
     def assert_prod_mirrors(env, expected_mirror_env):
@@ -650,6 +673,7 @@ def test_get_standard_mirror_env():
     assert_prod_mirrors('cgap', None)
 
 
+@using_fresh_legacy_state()
 def test_infer_repo_from_env():
 
     assert infer_repo_from_env(FF_ENV_PRODUCTION_BLUE) == 'fourfront'
@@ -685,6 +709,7 @@ def test_infer_repo_from_env():
     assert infer_repo_from_env('who-knows') is None
 
 
+@using_fresh_legacy_state()
 def test_infer_foursight_from_env():
 
     class MockedRequest:
@@ -741,6 +766,7 @@ def test_infer_foursight_from_env():
     check(None, None)
 
 
+@using_fresh_legacy_state()
 def test_infer_foursight_url_from_env():
 
     class MockedRequest:
@@ -802,6 +828,7 @@ def test_infer_foursight_url_from_env():
     check(None, None, cgap=True)
 
 
+@using_fresh_legacy_state()
 def test_indexer_env_for_env():
 
     assert indexer_env_for_env('fourfront-mastertest') == FF_ENV_INDEXER
@@ -820,6 +847,7 @@ def test_indexer_env_for_env():
     assert indexer_env_for_env('blah-env') is None
 
 
+@using_fresh_legacy_state()
 def test_is_indexer_env():
 
     assert is_indexer_env('fourfront-indexer')
@@ -836,6 +864,7 @@ def test_is_indexer_env():
     assert not is_indexer_env('fourfront-cgapwolf')
 
 
+@using_fresh_legacy_state()
 def test_short_env_name():
 
     assert short_env_name('cgapdev') == 'cgapdev'
@@ -858,6 +887,7 @@ def test_short_env_name():
     assert short_env_name('fourfront_mastertest') == 'fourfront_mastertest'
 
 
+@using_fresh_legacy_state()
 def test_full_env_name():
 
     assert full_env_name('cgapdev') == 'fourfront-cgapdev'
@@ -880,6 +910,7 @@ def test_full_env_name():
         full_env_name('data')
 
 
+@using_fresh_legacy_state()
 def test_full_cgap_env_name():
     assert full_cgap_env_name('cgapdev') == 'fourfront-cgapdev'
     assert full_cgap_env_name('fourfront-cgapdev') == 'fourfront-cgapdev'
@@ -907,6 +938,7 @@ def test_full_cgap_env_name():
         full_cgap_env_name('data')
 
 
+@using_fresh_legacy_state()
 def test_full_fourfront_env_name():
 
     assert full_fourfront_env_name('mastertest') == 'fourfront-mastertest'
@@ -934,6 +966,7 @@ def test_full_fourfront_env_name():
         full_fourfront_env_name('data')
 
 
+@using_fresh_legacy_state()
 def test_classify_server_url_localhost():
 
     assert classify_server_url("http://localhost/foo/bar") == {
@@ -961,6 +994,7 @@ def test_classify_server_url_localhost():
     }
 
 
+@using_fresh_legacy_state()
 def test_classify_server_url_cgap():
 
     assert classify_server_url("https://cgap.hms.harvard.edu/foo/bar") == {
@@ -988,6 +1022,7 @@ def test_classify_server_url_cgap():
     }
 
 
+@using_fresh_legacy_state()
 def test_classify_server_url_fourfront():
 
     assert classify_server_url("https://data.4dnucleome.org/foo/bar") == {
@@ -1021,6 +1056,7 @@ def test_classify_server_url_fourfront():
     }
 
 
+@using_fresh_legacy_state()
 def test_classify_server_url_other():
 
     with raises_regexp(RuntimeError, "not a Fourfront or CGAP server"):

--- a/test/test_env_utils_legacy.py
+++ b/test/test_env_utils_legacy.py
@@ -7,9 +7,7 @@ from dcicutils.env_utils import (
     full_env_name, full_fourfront_env_name, get_bucket_env, get_mirror_env_from_context, get_standard_mirror_env,
     indexer_env_for_env, infer_foursight_from_env, infer_foursight_url_from_env, infer_repo_from_env,
     is_cgap_env, is_cgap_server, is_fourfront_env, is_fourfront_server, is_hotseat_env, is_indexer_env,
-    is_stg_or_prd_env, is_test_env,
-    # make_env_name_cfn_compatible,
-    permit_load_data,
+    is_stg_or_prd_env, is_test_env, permit_load_data,
     prod_bucket_env, prod_bucket_env_for_app, public_url_for_app, public_url_mappings, short_env_name, is_beanstalk_env,
 )
 from dcicutils.env_utils_legacy import (
@@ -27,7 +25,7 @@ from dcicutils.env_utils_legacy import (
 from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
-from .helpers import using_fresh_cgap_state, using_fresh_ff_state, using_fresh_legacy_state
+from .helpers import using_fresh_legacy_state
 
 
 @using_fresh_legacy_state()

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -4,6 +4,7 @@ import json
 import os
 import pytest
 
+from dcicutils.common import APP_CGAP, APP_FOURFRONT
 from dcicutils.env_base import EnvManager
 from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env,
@@ -20,13 +21,14 @@ from dcicutils.env_utils import (
 )
 from dcicutils.exceptions import (
     BeanstalkOperationNotImplemented, MissingFoursightBucketTable, IncompleteFoursightBucketTable,
-    EnvUtilsLoadError,
+    EnvUtilsLoadError, InvalidParameterError,
 )
 from dcicutils.misc_utils import decorator, local_attrs, ignorable, override_environ
 from dcicutils.qa_utils import raises_regexp
 from typing import Optional
 from unittest import mock
 from urllib.parse import urlparse
+from .helpers import using_fresh_cgap_state, using_fresh_ff_state
 
 
 ignorable(BeanstalkOperationNotImplemented)  # Stuff that does or doesn't use this might come and go
@@ -65,7 +67,8 @@ def using_orchestrated_behavior(data: Optional[dict] = None):
         @functools.wraps(fn)
         def _wrapped(*args, **kwargs):
             with orchestrated_behavior_for_testing(data=data):
-                return fn(*args, **kwargs)
+                result = fn(*args, **kwargs)
+            return result
 
         return _wrapped
 
@@ -211,28 +214,32 @@ def test_orchestrated_infer_foursight_url_from_env():
                 == 'https://u9feld4va7.execute-api.us-east-1.amazonaws.com/api/view/cgapwolf')
 
 
-@using_orchestrated_behavior()
-def test_orchestrated_default_workflow_env():
+@using_fresh_ff_state()
+def test_ff_default_workflow_env():
 
-    assert default_workflow_env('cgap') == EnvUtils.WEBPROD_PSEUDO_ENV == 'production-data'  # the Acme producton bucket
+    assert (default_workflow_env('fourfront')
+            == default_workflow_env(APP_FOURFRONT)
+            == 'fourfront-webdev')
+
     with pytest.raises(Exception):
-        default_workflow_env('fourfront')
+        default_workflow_env('foo')  # noQA - we expect this error
+
     with pytest.raises(Exception):
-        default_workflow_env(None)  # noQA - We're expecting a problem
+        default_workflow_env(APP_CGAP)  # noQA - we expect this error
 
-    with local_attrs(EnvUtils, **CGAP_SETTINGS_FOR_TESTING):
-        assert default_workflow_env('cgap') == EnvUtils.WEBPROD_PSEUDO_ENV == 'fourfront-cgap'
-        with pytest.raises(Exception):
-            default_workflow_env('fourfront')
-        with pytest.raises(Exception):
-            default_workflow_env(None)  # noQA - We're expecting a problem
 
-    with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):
-        assert default_workflow_env('fourfront') == EnvUtils.WEBPROD_PSEUDO_ENV == 'fourfront-webprod'
-        with pytest.raises(Exception):
-            default_workflow_env('cgap')
-        with pytest.raises(Exception):
-            default_workflow_env(None)  # noQA - We're expecting a problem
+@using_fresh_cgap_state()
+def test_cgap_default_workflow_env():
+
+    assert (default_workflow_env('cgap')
+            == default_workflow_env(APP_CGAP)
+            == 'cgap-wolf')
+
+    with pytest.raises(Exception):
+        default_workflow_env('foo')  # noQA - we expect this error
+
+    with pytest.raises(Exception):
+        default_workflow_env(APP_FOURFRONT)  # noQA - we expect this error
 
 
 @using_orchestrated_behavior()

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -21,7 +21,7 @@ from dcicutils.env_utils import (
 )
 from dcicutils.exceptions import (
     BeanstalkOperationNotImplemented, MissingFoursightBucketTable, IncompleteFoursightBucketTable,
-    EnvUtilsLoadError, InvalidParameterError,
+    EnvUtilsLoadError,
 )
 from dcicutils.misc_utils import decorator, local_attrs, ignorable, override_environ
 from dcicutils.qa_utils import raises_regexp

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -147,9 +147,8 @@ def test_cannot_infer_env_from_many_global_envs():
 
 def test_missing_global_env():
     e = MissingGlobalEnv(global_bucket="my-envs", keys=['myorg-prod', 'myorg-dev', 'myorg-test'], env='my-demo')
-    assert str(e) == ("No matches for global env bucket: my-envs;"
-                      " keys: ['myorg-prod', 'myorg-dev', 'myorg-test'];"
-                      " desired env: my-demo")
+    assert str(e) == ("No matches for env my-demo in bucket my-envs;"
+                      " keys: ['myorg-prod', 'myorg-dev', 'myorg-test']")
     assert isinstance(e, MissingGlobalEnv)
     assert isinstance(e, ConfigurationError)
     assert isinstance(e, ValueError)

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -7,6 +7,7 @@ import requests
 import shutil
 import time
 
+from dcicutils.env_utils import EnvUtils
 from botocore.exceptions import ClientError
 from dcicutils import es_utils, ff_utils, s3_utils
 from dcicutils.exceptions import MissingGlobalEnv
@@ -19,6 +20,7 @@ from dcicutils.qa_utils import (
 from types import GeneratorType
 from unittest import mock
 from urllib.parse import urlsplit, parse_qsl
+from .helpers import using_fresh_ff_state, using_fresh_cgap_state
 
 
 pytestmark = pytest.mark.working
@@ -254,6 +256,7 @@ def mocked_s3utils_with_sse(beanstalks=None, require_sse=True, files=None):
 def test_unified_authentication_unit():
 
     ts = TestScenarios
+
 
     with mocked_s3utils_with_sse(beanstalks=['fourfront-mastertest', ts.foo_env, ts.bar_env]):
 
@@ -1225,6 +1228,7 @@ def test_get_es_search_generator(integrated_ff):
 
 @pytest.mark.integrated
 @pytest.mark.flaky
+@using_fresh_ff_state()
 def test_get_health_page(integrated_ff):
     health_res = ff_utils.get_health_page(key=integrated_ff['ff_key'])
     assert health_res and 'error' not in health_res
@@ -1705,6 +1709,7 @@ def test_convert_param():
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_get_page(integrated_ff):
     ff_env = integrated_ff['ff_env']
     ff_env_index_namespace = integrated_ff['ff_env_index_namespace']

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -7,7 +7,6 @@ import requests
 import shutil
 import time
 
-from dcicutils.env_utils import EnvUtils
 from botocore.exceptions import ClientError
 from dcicutils import es_utils, ff_utils, s3_utils
 from dcicutils.exceptions import MissingGlobalEnv
@@ -15,12 +14,12 @@ from dcicutils.ff_mocks import mocked_s3utils, TestScenarios, TestRecorder
 from dcicutils.misc_utils import make_counter, remove_prefix, remove_suffix, check_true
 from dcicutils.qa_utils import (
     check_duplicated_items_by_key, ignored, raises_regexp, MockResponse, MockBoto3, MockBotoSQSClient,
-    MockBotoS3Client
+    MockBotoS3Client,
 )
 from types import GeneratorType
 from unittest import mock
 from urllib.parse import urlsplit, parse_qsl
-from .helpers import using_fresh_ff_state, using_fresh_cgap_state
+from .helpers import using_fresh_ff_state
 
 
 pytestmark = pytest.mark.working
@@ -256,7 +255,6 @@ def mocked_s3utils_with_sse(beanstalks=None, require_sse=True, files=None):
 def test_unified_authentication_unit():
 
     ts = TestScenarios
-
 
     with mocked_s3utils_with_sse(beanstalks=['fourfront-mastertest', ts.foo_env, ts.bar_env]):
 

--- a/test/test_jh_utils.py
+++ b/test/test_jh_utils.py
@@ -9,6 +9,7 @@ import urllib.parse
 from dcicutils import s3_utils, ff_utils
 from dcicutils.qa_utils import override_environ, MockFileSystem
 from unittest import mock
+from .helpers import using_fresh_ff_state
 
 pytestmark = pytest.mark.working
 
@@ -37,6 +38,7 @@ def test_import_fails_without_initialization():
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_proper_initialization(integrated_ff):
     test_server = integrated_ff['ff_key']['server']
     initialize_jh_env(test_server)
@@ -52,6 +54,7 @@ def test_proper_initialization(integrated_ff):
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_some_decorated_methods_work(integrated_ff):
     test_server = integrated_ff['ff_key']['server']
     initialize_jh_env(test_server)
@@ -147,6 +150,7 @@ class MockResponse:
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_find_valid_file_or_extra_file(integrated_ff):
 
     # This setup isn't good for a unit test, but right now we can't load jh_utils otherwise. -kmp 15-Feb-2021
@@ -218,6 +222,7 @@ def test_find_valid_file_or_extra_file(integrated_ff):
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_jh_open_4dn_file_unit(integrated_ff):
 
     # This setup isn't good for a unit test, but right now we can't load jh_utils otherwise. -kmp 15-Feb-2021
@@ -286,6 +291,7 @@ def test_jh_open_4dn_file_unit(integrated_ff):
 
 
 @pytest.mark.integratedx
+@using_fresh_ff_state()
 def test_jh_open_4dn_file_integrated(integrated_ff):
     # this is tough because uploaded files don't actually exist on mastertest s3
     # so, this test pretty much assumes urllib will work for actually present
@@ -349,6 +355,7 @@ def test_add_mounted_file_to_session(integrated_ff):
     assert 'test' in res2.get('jupyterhub_session', {}).get('files_mounted', [])
 
 
+@using_fresh_ff_state()
 def test_mount_4dn_file(integrated_ff):
     """ Tests getting full filepath of test file on JH
         Needs an additional test (how to?)

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -25,9 +25,8 @@ from dcicutils.qa_utils import override_environ, MockBoto3, MockResponse, known_
 from dcicutils.s3_utils import s3Utils, EnvManager, HealthPageKey
 from requests.exceptions import ConnectionError
 from unittest import mock
-from .helpers import using_fresh_ff_state, using_fresh_cgap_state
+from .helpers import using_fresh_ff_state
 from .test_ff_utils import mocked_s3utils_with_sse
-from .test_env_utils_orchestrated import using_orchestrated_behavior
 
 
 @contextlib.contextmanager

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -25,7 +25,9 @@ from dcicutils.qa_utils import override_environ, MockBoto3, MockResponse, known_
 from dcicutils.s3_utils import s3Utils, EnvManager, HealthPageKey
 from requests.exceptions import ConnectionError
 from unittest import mock
+from .helpers import using_fresh_ff_state, using_fresh_cgap_state
 from .test_ff_utils import mocked_s3utils_with_sse
+from .test_env_utils_orchestrated import using_orchestrated_behavior
 
 
 @contextlib.contextmanager
@@ -248,6 +250,7 @@ def test_s3utils_creation_cgap_stg():
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_s3utils_get_keys_for_data():
     util = s3Utils(env='data')
     keys = util.get_access_keys()
@@ -262,6 +265,7 @@ def test_s3utils_get_keys_for_data():
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_s3utils_get_keys_for_staging():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'staging' implies the GA test environment has overbroad privilege.
@@ -269,10 +273,11 @@ def test_s3utils_get_keys_for_staging():
     #   -kmp 13-Jan-2021
     util = s3Utils(env='staging')
     keys = util.get_ff_key()
-    assert keys['server'] == 'http://staging.4dnucleome.org'
+    assert keys['server'] == 'https://staging.4dnucleome.org'
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_s3utils_get_jupyterhub_key():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'data' implies the GA test environment has overbroad privilege.
@@ -285,6 +290,7 @@ def test_s3utils_get_jupyterhub_key():
 
 
 @pytest.mark.integrated
+@using_fresh_ff_state()
 def test_s3utils_get_higlass_key_integrated():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'staging' implies the GA test environment has overbroad privilege.
@@ -293,9 +299,11 @@ def test_s3utils_get_higlass_key_integrated():
     util = s3Utils(env='staging')
     keys = util.get_higlass_key()
     assert isinstance(keys, dict)
-    assert 3 == len(keys.keys())
+    assert len(keys.keys()) == 3
 
 
+@pytest.mark.integrated
+@using_fresh_ff_state()
 def test_s3utils_get_google_key():
     util = s3Utils(env='staging')
     keys = util.get_google_key()
@@ -307,6 +315,7 @@ def test_s3utils_get_google_key():
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_s3utils_get_access_keys_with_old_style_default():
     util = s3Utils(env='fourfront-mastertest')
     with mock.patch.object(util, "get_key") as mock_get_key:
@@ -323,6 +332,7 @@ def test_s3utils_get_access_keys_with_old_style_default():
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_s3utils_get_key_non_json_data():
 
     util = s3Utils(env='fourfront-mastertest')
@@ -339,6 +349,7 @@ def test_s3utils_get_key_non_json_data():
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_s3utils_delete_key():
 
     sample_key_name = "--- reserved_key_name_for_unit_testing ---"
@@ -373,6 +384,7 @@ def test_s3utils_delete_key():
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_s3utils_s3_put():
 
     util = s3Utils(env='fourfront-mastertest')
@@ -403,6 +415,7 @@ def test_s3utils_s3_put():
 
 
 @pytest.mark.unit
+@using_fresh_ff_state()
 def test_s3utils_s3_put_secret():
 
     util = s3Utils(env='fourfront-mastertest')
@@ -936,7 +949,7 @@ def test_env_manager_fetch_health_page_json():
 def test_env_manager():
 
     test_env = 'fourfront-foo'
-    test_env2 = 'another-plausible-env'
+    test_env2 = 'fourfront-another-plausible-env'
 
     # This tests that with no env_name argument, we can figure out there's only one environment
     with mocked_s3utils_with_sse(beanstalks=[test_env]):


### PR DESCRIPTION
This PR is built on [PR #197: env_xxx refactor (compatible)](https://github.com/4dn-dcic/utils/pull/197), which creates new files `dcicutils/env_basic.py` and `dcicutils/env_manager.py`, and uses `dcicutils.env_base.py` as thin glue compatibly connecting them.

The big changes are:
* In `dcicutils/env_manager.py` (lines 166/155): Change `verify_and_get_env_config` to call `full-env-name` on its `env` argument so that all three names (public, short and long) can be given without having to have 3 different declarations in the global env bucket. NOTE: This change is the one that forced the env refactor. 
* In `dcicutils/env_utils.py` (lines 536/569): There is a configuration change to add `"default_workflow_env"` as a configuration option. (The default was erroneously going to the `"webprod_pseudo_env"`.)
* In `dcicutils/env_utils.py` (lines 895/928): There is an additional argument to `infer_foursight_from_env` and some additional defaulting of the result.

Lesser changes, still of note:
* In `dcicutils/env_utils.py`, some new methods on `EnvUtils` support local uses of `EnvUtils` in various modalities.
* In `dcicutils/ff_mocks.py`, `mocked_s3utils` now automatically mocks up a minimal ecosystem file.
* In `test/conftest.py`, new class `IntegratedFixture` supports the `integrated_ff` fixture in a way that more reliably assures initialization of certain quantities happens at file load time. Along the way, this also fixes [Test credentials appear in stack trace on GA (C4-847)](https://hms-dbmi.atlassian.net/browse/C4-847).
* In `test/helpers.py`, some additional context managers.
* In `test/test_deployment_utils.py`, in addition to fixing some tests, I got rid of some old useless ones and updated them to do something more relevant instead.
* In `test/test_s3_utils.py`, repaired an expectation that `staging` would use `http` so it now expects `https`.
* Added a bunch of context decorators in various files to make tests not be so sensitive to orrder.
