### PR TITLE
Mocking print to file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ Change Log
 ----------
 
 
+3.15.0
+======
+
+* In ``qa_utils``:
+
+  * Extend the mocking so that output to files by ``PRINT`` can be tested
+    by ``with printed_output as printed`` using ``printed.file_last[fp]``
+    and ``printed.file_lines[fp]``.
+    
+
+
 3.14.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,15 +6,29 @@ dcicutils
 Change Log
 ----------
 
+
+3.16.0
+======
+
+* In ``qa_utils``:
+
+  * Extend the mocking so that output to files by ``PRINT`` can be tested
+    by ``with printed_output as printed`` using ``printed.file_last[fp]``
+    and ``printed.file_lines[fp]``.
+
+
 3.15.0
 ======
+
 * In ``ecs_utils``:
   * Adds the ``service_has_active_deployment`` method.
+
 
 3.14.2
 ======
 * In ``qa_utils``:
   * Minor updates related PEP8.
+
 
 3.14.1
 ======
@@ -29,17 +43,7 @@ Change Log
   * New property ``MockBotoS3Session.region_name``.
   * New method ``MockBotoS3Session.unset_environ_credentials_for_testing``.
 
-3.15.0
-======
-
-* In ``qa_utils``:
-
-  * Extend the mocking so that output to files by ``PRINT`` can be tested
-    by ``with printed_output as printed`` using ``printed.file_last[fp]``
-    and ``printed.file_lines[fp]``.
-    
-
-
+  
 3.14.0
 ======
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ configure:  # does any pre-requisite installs
 	pip install poetry
 
 lint:
-	flake8 dcicutils
+	flake8 dcicutils; flake8 test
 
 build:  # builds
 	make configure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.15.0"
+version = "3.16.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.0"
+version = "3.15.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_diff_utils.py
+++ b/test/test_diff_utils.py
@@ -486,7 +486,7 @@ def interim_run_all():  # TODO: Remove this when the configurable env_utils code
     for unrelated reasons that are going to be fixed later.
     """
     import sys
-    for definition_name in globals():
+    for definition_name in list(globals()):
         if definition_name.startswith("test_"):
             print(f"Running {definition_name}...", end="")
             sys.stdout.flush()

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -2607,7 +2607,7 @@ def interim_run_all():  # TODO: Remove this when the configurable env_utils code
     This function is temporary while the tests on master are broken. Usage:
 
         $ python
-        > from test.test_diff_utils import interim_run_all
+        > from test.test_misc_utils import interim_run_all
         > interim_run_all()
 
     This will run all diff_utils tests without trying to load any other pytest stuff that might fail
@@ -2616,7 +2616,7 @@ def interim_run_all():  # TODO: Remove this when the configurable env_utils code
     import sys
     failed = 0
     print("fFAILED={failed}")
-    for definition_name in globals():
+    for definition_name in list(globals()):
         if definition_name.startswith("test_"):
             print(f"Running {definition_name}...", end="")
             sys.stdout.flush()

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -977,6 +977,58 @@ def test_uppercase_print_with_printed_output():
         assert printed.lines == ["foo", "bar"]
         assert printed.last == "bar"
 
+        printed.reset()
+
+        mfs = MockFileSystem()
+        with mfs.mock_exists_open_remove():
+
+            with io.open("some-file.txt", 'w') as fp:
+                PRINT("stuff to file", file=fp)
+                PRINT("stuff to console")
+                PRINT("more stuff to file", file=fp)
+                PRINT("more stuff to console")
+
+            assert printed.lines == ["stuff to console", "more stuff to console"]
+            assert printed.last == "more stuff to console"
+            assert printed.lines == printed.file_lines[None]
+            assert printed.last == printed.file_last[None]
+            assert printed.file_lines[None] == ["stuff to console", "more stuff to console"]
+            assert printed.file_last[None] == "more stuff to console"
+            assert printed.file_lines[fp] == ["stuff to file", "more stuff to file"]
+            assert printed.file_last[fp] == "more stuff to file"
+
+            PRINT("Done.")
+            assert printed.last == "Done."
+            assert printed.file_last[None] == "Done."
+            assert printed.lines == ["stuff to console", "more stuff to console", "Done."]
+            assert printed.file_lines[None] == ["stuff to console", "more stuff to console", "Done."]
+
+            PRINT("Done, too.", file=fp)
+            assert printed.file_last[fp] == "Done, too."
+            assert printed.file_lines[fp] == ["stuff to file", "more stuff to file", "Done, too."]
+
+            printed.reset()
+
+            with io.open("another-file.txt", 'w') as fp2:
+
+                assert printed.last is None
+                assert printed.file_last[None] is None
+                assert printed.file_last[sys.stdout] is None
+
+                assert printed.lines == []
+                assert printed.file_lines[None] == []
+                assert printed.file_lines[sys.stdout] == []
+
+                assert printed.file_last[fp2] is None
+                assert printed.file_lines[fp2] == []
+
+                PRINT("foo", file=fp2)
+
+                assert printed.last is None
+                assert printed.lines == []
+                assert printed.file_last[fp2] == "foo"
+                assert printed.file_lines[fp2] == ["foo"]
+
 
 def test_uppercase_print_with_time():
 

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -984,20 +984,20 @@ def test_get_and_set_object_tags():
         s3u.set_object_tags(key=key, bucket=bucket, tags=[{'Key': 'b', 'Value': 'bravo'}], merge_existing_tags=True)
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'a', 'Value': 'alpha'}, {'Key': 'b', 'Value': 'bravo'} ]
+        expected = [{'Key': 'a', 'Value': 'alpha'}, {'Key': 'b', 'Value': 'bravo'}]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"
 
         s3u.set_object_tag(key=key, bucket=bucket, tag_key="a", tag_value="alpha_2")
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'a', 'Value': 'alpha_2'}, {'Key': 'b', 'Value': 'bravo'} ]
+        expected = [{'Key': 'a', 'Value': 'alpha_2'}, {'Key': 'b', 'Value': 'bravo'}]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"
 
         s3u.set_object_tag(key=key, bucket=bucket, tag_key="c", tag_value="gamma")
-        
+
         actual = s3u.get_object_tags(key=key, bucket=bucket)
-        expected = [{'Key': 'a', 'Value': 'alpha_2'}, {'Key': 'b', 'Value': 'bravo'}, {'Key': 'c', 'Value': 'gamma'} ]
+        expected = [{'Key': 'a', 'Value': 'alpha_2'}, {'Key': 'b', 'Value': 'bravo'}, {'Key': 'c', 'Value': 'gamma'}]
         # print(f"actual={actual} expected={expected}")
         assert actual == expected, f"Got {actual} but expected {expected}"


### PR DESCRIPTION
This is just a random piece of functionality I half-wrote while talking to David about the print mocking we already had. It seemed potentially useful, so I wanted to go ahead and install it for possible future use.

Because unit testing is generally broken, more specific testing can be done by:
```
>>> from test.test_misc_utils import interim_run_all
>>> interim_run_all()
```