### PR TITLE
Boto3 mocking updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ Change Log
 ----------
 
 
+3.14.1
+======
+* In ``qa_utils``:
+
+  * New class ``MockBotoS3Iam``.
+  * New class ``MockBotoS3Kms``.
+  * New class ``MockBotoS3OpenSearch``.
+  * New class ``MockBotoS3Sts``.
+  * New method  ``MockBotoS3Session.get_credentials``.
+  * New method ``MockBotoS3Session.put_credentials_for_testing``.
+  * New property ``MockBotoS3Session.region_name``.
+  * New method ``MockBotoS3Session.unset_environ_credentials_for_testing``.
+
 3.14.0
 ======
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -732,9 +732,9 @@ class MockBoto3Session:
         for environ_name in self.AWS_CREDENTIALS_ENVIRON_NAMES:
             if environ_name in os.environ:
                 if environ_name.endswith("_FILE"):
-                    os.environ.pop[environ_name] = "/dev/null"
+                    os.environ[environ_name] = "/dev/null"
                 else:
-                    del os.environ.pop[environ_name]
+                    del os.environ[environ_name]
 
     def put_credentials_for_testing(self, *,
                                     aws_access_key_id: str = None,

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1186,7 +1186,7 @@ class MockBoto3Kms:
         elif isinstance(Policy, str):
             key_policy_string = Policy
         key_policies = self._mocked_key_policies()
-        key_policies[KeyId] = { "Policy": key_policy_string }
+        key_policies[KeyId] = {"Policy": key_policy_string}
 
     def get_key_policy(self, KeyId: str, PolicyName: str) -> Optional[dict]:
         if not KeyId:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2,7 +2,6 @@
 qa_utils: Tools for use in quality assurance testing.
 """
 
-from __future__ import annotations  # allows type hint references to containing class
 import configparser
 import contextlib
 import copy
@@ -919,7 +918,7 @@ class MockBoto3Iam:
         def __init__(self) -> None:
             self._access_key_pairs = []
 
-        def add(self, access_key_pair: MockBoto3Iam._UserAccessKeyPair) -> None:
+        def add(self, access_key_pair: object) -> None:
             self._access_key_pairs.append(access_key_pair)
 
         def get(self, key: str) -> Any:
@@ -939,7 +938,7 @@ class MockBoto3Iam:
         def name(self) -> str:
             return self._name
 
-        def create_access_key_pair(self) -> MockBoto3Iam._UserAccessKeyPair:
+        def create_access_key_pair(self) -> object:
             access_key_pair = MockBoto3Iam._UserAccessKeyPair()
             self._access_keys.add(access_key_pair)
             return access_key_pair
@@ -948,7 +947,7 @@ class MockBoto3Iam:
         def __init__(self) -> None:
             self._users = []
 
-        def all(self) -> list[MockBoto3Iam._User]:
+        def all(self) -> list:
             return self._users
 
     class _RoleCollection:
@@ -976,7 +975,7 @@ class MockBoto3Iam:
             shared_data = shared_reality[self._SHARED_DATA_MARKER] = {}
         return shared_data
 
-    def _mocked_users(self) -> MockBoto3Iam._UserCollection:
+    def _mocked_users(self) -> object:
         mocked_shared_data = self._mocked_shared_data()
         mocked_users = mocked_shared_data.get("users")
         if not mocked_users:
@@ -990,14 +989,14 @@ class MockBoto3Iam:
             mocked_shared_data["roles"] = mocked_roles = MockBoto3Iam._RoleCollection()
         return mocked_roles
 
-    def put_users_for_testing(self, users: list[str]) -> None:
+    def put_users_for_testing(self, users: list) -> None:
         if isinstance(users, list) and len(users) > 0:
             existing_users = self._mocked_users().all()
             for user in users:
                 if user not in existing_users:
                     existing_users.append(MockBoto3Iam._User(user))
 
-    def put_roles_for_testing(self, roles: list[str]) -> None:
+    def put_roles_for_testing(self, roles: list) -> None:
         if isinstance(roles, list) and len(roles) > 0:
             existing_roles = self._mocked_roles()["Roles"]
             for role in roles:
@@ -1005,13 +1004,13 @@ class MockBoto3Iam:
                     existing_roles.append(MockBoto3Iam._Role(role))
 
     @property
-    def users(self) -> MockBoto3Iam._UserCollection:
+    def users(self) -> object:
         return self._mocked_users()
 
-    def list_roles(self) -> MockBoto3Iam._RoleCollection:
+    def list_roles(self) -> object:
         return self._mocked_roles()
 
-    def list_access_keys(self, UserName: str) -> Optional[MockBoto3Iam._UserAccessKeyPairCollection]:
+    def list_access_keys(self, UserName: str) -> Optional[object]:
         existing_users = self._mocked_users().all()
         for existing_user in existing_users:
             if existing_user.name == UserName:
@@ -1050,7 +1049,7 @@ class MockBoto3OpenSearch:
         def __init__(self) -> None:
             self._domains = []
 
-        def add(self, domain: MockBoto3OpenSearch._Domain) -> None:
+        def add(self, domain: object) -> None:
             self._domains.append(domain)
 
         def __getitem__(self, key: str) -> Any:
@@ -1144,7 +1143,7 @@ class MockBoto3Kms:
         def __init__(self):
             self._keys = []
 
-        def add(self, key: MockBoto3Kms._Key) -> None:
+        def add(self, key: object) -> None:
             self._keys.append(key)
 
         def __getitem__(self, key: str):

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -771,21 +771,24 @@ class MockBoto3Session:
         :param aws_credentials_file: Full path to AWS credentials (or config) file.
         :return: Tuple containing aws_access_key_id, aws_secret_access_key, region values; None if not present.
         """
-        if not aws_credentials_file or not os.path.isfile(aws_credentials_file):
-            return None, None, None
-        config = configparser.ConfigParser()
-        config.read(aws_credentials_file)
-        if not config or len(config) <= 0:
-            return None, None, None
-        if "default" in config:
-            config_section_name = "default"
-        else:
-            config_section_name = config[0]
-        config_keys_values = {key.lower(): value for key, value in config[config_section_name].items()}
-        aws_access_key_id = config_keys_values.get("aws_access_key_id")
-        aws_secret_access_key = config_keys_values.get("aws_secret_access_key")
-        aws_region = config_keys_values.get("region")
-        return aws_access_key_id, aws_secret_access_key, aws_region
+        try:
+            if not aws_credentials_file or not os.path.isfile(aws_credentials_file):
+                return None, None, None
+            config = configparser.ConfigParser()
+            config.read(aws_credentials_file)
+            if not config or not config.sections() or len(config.sections()) <= 0:
+                return None, None, None
+            if "default" in config.sections():
+                config_section_name = "default"
+            else:
+                config_section_name = config.sections()[0]
+            config_keys_values = {key.lower(): value for key, value in config[config_section_name].items()}
+            aws_access_key_id = config_keys_values.get("aws_access_key_id")
+            aws_secret_access_key = config_keys_values.get("aws_secret_access_key")
+            aws_region = config_keys_values.get("region")
+            return aws_access_key_id, aws_secret_access_key, aws_region
+        except:
+            return None, None, None,
 
     def get_credentials(self) -> Optional[Boto3Credentials]:
         """
@@ -827,7 +830,7 @@ class MockBoto3Session:
         aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(aws_credentials_file)
         if aws_access_key_id and aws_secret_access_key:
             return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
-        return None
+        return Boto3Credentials(access_key=None, secret_key=None)
 
     @property
     def region_name(self) -> Optional[str]:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -803,8 +803,8 @@ class MockBoto3Session:
         if credentials_dir and os.path.isdir(credentials_dir):
             credentials_file = os.path.join(credentials_dir, "credentials")
             aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(credentials_file)
-        if aws_access_key_id and aws_secret_access_key:
-            return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
+            if aws_access_key_id and aws_secret_access_key:
+                return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
         aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
         aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
         if aws_access_key_id and aws_secret_access_key:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -717,7 +717,7 @@ class MockBoto3Session:
         NOTE: AWS session token not currently handled.
 
         FYI: Some things to note about how boto3 (and probably any AWS client) reads AWS credentials/region.
-        - It looks (of course) at envrionment variable before files.
+        - It looks (of course) at envrionment variables before files.
         - It wants access key ID and secret access key BOTH to come from the same source,
           e.g. does not get access key ID from environment variable and secret access key from file.
         - It reads region from EITHER the credentials file OR the config file, the former FIRST;
@@ -759,8 +759,8 @@ class MockBoto3Session:
         set there, then gets them via the standard AWS environment variable names, i.e. AWS_ACCESS_KEY_ID,
         AWS_SECRET_ACCESS_KEY, AWS_SHARED_CREDENTIALS_FILE.
 
-        More specifically, returns AWS credentials, access key ID and secret access key, as a tuple,
-        from the first of these where BOTH are defined; if BOTH not defined returns tuple with None values.
+        More specifically, returns AWS access key ID and secret access key as Boto3Credentials, from the
+        first of these where BOTH are defined; if BOTH not defined returns Boto3Credentials with no values.
         1. From the access_key and secret_key values set explicitly in set_credentials_for_testing().
         2. From the aws_access_key_id and aws_secret_access_key properties in the credentials
            file within the credentials_dir set explicitly in set_credentials_for_testing().

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1091,6 +1091,15 @@ class MockBoto3SecretsManager:
                 secrets[SecretId] = {}
             secrets[SecretId][SecretKey] = SecretKeyValue
 
+    def get_secret_key_value_for_testing(self, SecretId, SecretKey):  # noQA - Argument names must be compatible with AWS
+        secrets = self._mocked_secrets()
+        secret_value = secrets[SecretId]
+        if isinstance(secret_value, dict):
+            secret_value_json = secret_value
+        else:
+            secret_value_json = json_loads(secret_value)
+        return secret_value_json[SecretKey]
+
     def get_secret_value(self, SecretId):  # noQA - Argument names must be compatible with AWS
         secrets = self._mocked_secrets()
         secret_value = secrets[SecretId]

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -898,11 +898,9 @@ class MockBoto3Iam:
         shared_reality = self.boto3.shared_reality
         shared_data = shared_reality.get(self._SHARED_DATA_MARKER)
         if shared_data is None:
-            users = MockBoto3Iam._UsersCollection()
-            roles = { "Roles": [] }
             shared_data = shared_reality[self._SHARED_DATA_MARKER] = {}
-            shared_data["users"] = users
-            shared_data["roles"] = roles
+            shared_data["users"] = MockBoto3Iam._UsersCollection()
+            shared_data["roles"] = { "Roles": [] }
         return shared_data
 
     def _mocked_users(self):

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -729,7 +729,7 @@ class MockBoto3Session:
         - The aws_access_key_id, aws_secret_access_key, and region properties in the credentials/config
           files may be EITHER upper AND/OR lower case; but the environment variables MUST be all upper case.
         - If file environment variables (i.e. AWS_SHARED_CREDENTIALS_FILE, AWS_CONFIG_FILE) are NOT set,
-          i.e. set to None, it WILL look at the default credentials/config files (e.g. ~/.aws/credentials);
+          i.e. SET to None, it WILL look at the default credentials/config files (e.g. ~/.aws/credentials);
           which is why we set to /dev/null in unset_environ_credentials_for_testing().
         """
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -687,10 +687,12 @@ class MockBoto3Session:
 
     def __init__(self, *, region_name=None, boto3=None, **kwargs):
         self.boto3 = boto3 or MockBoto3()
+        # Hmm. Wait. Should credentials/region really be "shared" data?
         self.shared_data = self.boto3.shared_reality.get(self._SHARED_DATA_MARKER)
         if self.shared_data is None:
             self.boto3.shared_reality[self._SHARED_DATA_MARKER] = self.shared_data = {}
         self.shared_data["credentials"] = {}
+        self.shared_data["region"] = ""
 
     def client(self, service_name, **kwargs):
         return self.boto3.client(service_name, **kwargs)

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -760,16 +760,16 @@ class MockBoto3Session:
 
     def get_credentials(self) -> Boto3Credentials:
         """
-        Returns the AWS credentials (Boto3Credentials) from the access_key and secret_key values, or in
-        the credentials file within the credentials_dir, set in set_credentials_for_testing(); or if not
+        Returns the AWS credentials (Boto3Credentials) from the aws_access_key_id and aws_secret_access_key values,
+        or in the credentials file within the aws_credentials_dir, set in set_credentials_for_testing(); or if not
         set there, then gets them via the standard AWS environment variable names, i.e. AWS_ACCESS_KEY_ID,
         AWS_SECRET_ACCESS_KEY, AWS_SHARED_CREDENTIALS_FILE.
 
-        More specifically, returns AWS access key ID and secret access key as Boto3Credentials, from the
-        first of these where BOTH are defined; if BOTH not defined returns Boto3Credentials with no values.
-        1. From the access_key and secret_key values set explicitly in set_credentials_for_testing().
+        More specifically, returns AWS access key ID and secret access key as a Boto3Credentials, from the
+        first of these where BOTH are defined; if BOTH not defined returns a Boto3Credentials with no values.
+        1. From the aws_access_key_id and aws_secret_access_key values set explicitly in set_credentials_for_testing().
         2. From the aws_access_key_id and aws_secret_access_key properties in the credentials
-           file within the credentials_dir set explicitly in set_credentials_for_testing().
+           file within the aws_credentials_dir set explicitly in set_credentials_for_testing().
         3. From the values in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
         4. From the aws_access_key_id and aws_secret_access_key properties in the
            credentials file specified by the AWS_SHARED_CREDENTIALS_FILE environment variable.

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -780,8 +780,8 @@ class MockBoto3Session:
         set there, then gets them via the standard AWS environment variable names, i.e. AWS_ACCESS_KEY_ID,
         AWS_SECRET_ACCESS_KEY, AWS_SHARED_CREDENTIALS_FILE.
 
-        More specifically, returns AWS access key ID and secret access key as a Boto3Credentials, from the
-        first of these where BOTH are defined; if BOTH not defined returns a Boto3Credentials with no values.
+        More specifically, returns AWS access key ID and secret access key as a Boto3Credentials,
+        from the FIRST of these where BOTH are defined; if BOTH are NOT defined returns None.
         1. From the aws_access_key_id and aws_secret_access_key values set explicitly in set_credentials_for_testing().
         2. From the aws_access_key_id and aws_secret_access_key properties in the credentials
            file within the aws_credentials_dir set explicitly in set_credentials_for_testing().

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1138,6 +1138,18 @@ class MockBoto3Kms:
                     }
         return None
 
+    def put_key_policy_for_testing(self, KeyId: str, Policy: str, PolicyName: str) -> None:
+        # TODO
+        pass
+
+    def put_key_policy(self, KeyId: str, Policy: str, PolicyName: str) -> None:
+        # TODO
+        pass
+
+    def get_key_policy(self, KeyId: str, PolicyName: str) -> Optional[dict]:
+        # TODO
+        pass
+
 
 @MockBoto3.register_client(kind='secretsmanager')
 class MockBoto3SecretsManager:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1083,9 +1083,21 @@ class MockBoto3SecretsManager:
         secrets = self._mocked_secrets()
         secrets[SecretId] = Value
 
+    def put_secret_key_value_for_testing(self, SecretId: str, SecretKey: str, SecretKeyValue: str):  # noQA - Argument names chosen for AWS consistency
+        if SecretId and SecretKey:
+            secrets = self._mocked_secrets()
+            secret_value = secrets.get(SecretId)
+            if not secret_value:
+                secrets[SecretId] = {}
+            secrets[SecretId][SecretKey] = SecretKeyValue
+
     def get_secret_value(self, SecretId):  # noQA - Argument names must be compatible with AWS
         secrets = self._mocked_secrets()
-        return {'SecretString': secrets[SecretId]}
+        secret_value = secrets[SecretId]
+        if isinstance(secret_value, dict):
+            return {'SecretString': json_dumps(secret_value)}
+        else:
+            return {'SecretString': secret_value}
 
     def list_secrets(self):
         secrets = self._mocked_secrets()

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -885,7 +885,7 @@ class MockBoto3Iam:
 
     _SHARED_DATA_MARKER = "_IAM_SHARED_DATA_MARKER"
 
-    def __init__(self, boto3=None) -> None:
+    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     class _UserAccessKeyPair:
@@ -1055,7 +1055,7 @@ class MockBoto3OpenSearch:
                 return self._domains
             return None
 
-    def __init__(self, boto3=None) -> None:
+    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     def _mocked_shared_data(self) -> dict:
@@ -1095,7 +1095,7 @@ class MockBoto3Sts:
 
     _SHARED_DATA_MARKER = '_STS_SHARED_DATA_MARKER'
 
-    def __init__(self, boto3=None) -> None:
+    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     def _mocked_shared_data(self) -> dict:
@@ -1149,7 +1149,7 @@ class MockBoto3Kms:
                 return self._keys
             return None
 
-    def __init__(self, boto3=None) -> None:
+    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     def _mocked_shared_data(self) -> dict:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1094,7 +1094,7 @@ class MockBoto3SecretsManager:
 
     def update_secret(self, SecretId: str, SecretString: str) -> None:
         # TODO/dmichaels/2022-06-26: New method IN PROGRESS.
-        secrets = _mocked_secrets()
+        secrets = self._mocked_secrets()
         secrets[SecretId] = SecretString
 
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -787,7 +787,7 @@ class MockBoto3Session:
             aws_secret_access_key = config_keys_values.get("aws_secret_access_key")
             aws_region = config_keys_values.get("region")
             return aws_access_key_id, aws_secret_access_key, aws_region
-        except:
+        except Exception:
             return None, None, None,
 
     def get_credentials(self) -> Optional[Boto3Credentials]:

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -813,18 +813,18 @@ class MockBoto3Session:
         aws_secret_access_key = self._aws_secret_access_key
         if aws_access_key_id and aws_secret_access_key:
             return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
-        credentials_dir = self._aws_credentials_dir
-        if credentials_dir and os.path.isdir(credentials_dir):
-            credentials_file = os.path.join(credentials_dir, "credentials")
-            aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(credentials_file)
+        aws_credentials_dir = self._aws_credentials_dir
+        if aws_credentials_dir and os.path.isdir(aws_credentials_dir):
+            aws_credentials_file = os.path.join(aws_credentials_dir, "credentials")
+            aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(aws_credentials_file)
             if aws_access_key_id and aws_secret_access_key:
                 return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
         aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
         aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
         if aws_access_key_id and aws_secret_access_key:
             return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
-        credentials_file = os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials")
-        aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(credentials_file)
+        aws_credentials_file = os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials")
+        aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(aws_credentials_file)
         if aws_access_key_id and aws_secret_access_key:
             return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.0"
+version = "3.14.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Added these new boto3 mock classes, for 4dn-cloud-infra/setup-remaining-secrets testing, MockBoto3Iam, MockBoto3OpenSearch, and MockBoto3Sts; and updated MockBoto3Client to support get_credentials for same.