### PR TITLE
Synthetic foursight decls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,23 @@ dcicutils
 Change Log
 ----------
 
+
+3.16.0
+======
+
+* In ``qa_utils``:
+
+  * Extend the mocking so that output to files by ``PRINT`` can be tested
+    by ``with printed_output as printed`` using ``printed.file_last[fp]``
+    and ``printed.file_lines[fp]``.
+
+
 3.15.0
 ======
+
 * In ``ecs_utils``:
   * Adds the ``service_has_active_deployment`` method.
+
 
 3.14.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ dcicutils
 Change Log
 ----------
 
+3.14.2
+======
+* In ``qa_utils``:
+  * Minor updates related PEP8.
 
 4.0.0
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ dcicutils
 Change Log
 ----------
 
+3.15.0
+======
+* In ``ecs_utils``:
+  * Adds the ``service_has_active_deployment`` method.
+
 3.14.2
 ======
 * In ``qa_utils``:

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ configure:  # does any pre-requisite installs
 	pip install poetry
 
 lint:
-	flake8 dcicutils
-	flake8 test
+	@echo "Running flake8..."
+	@flake8 dcicutils || echo "'flake8 dcicutils' failed."
+	@flake8 test || echo "'flake8 test' failed."
 
 build:  # builds
 	make configure

--- a/dcicutils/cloudformation_utils.py
+++ b/dcicutils/cloudformation_utils.py
@@ -32,6 +32,11 @@ def hyphenify(s):
     return s.replace('_', '-')
 
 
+def tokenify(s):
+    """Strip out everything but alphanumerics from a given token"""
+    return ''.join([ch for ch in s if ch.isalpha() or ch.isdigit()])
+
+
 def make_required_key_for_ecs_application_url(env_name):
     """
     This pattern needs to remain fixed for various things to connect up.

--- a/dcicutils/common.py
+++ b/dcicutils/common.py
@@ -8,7 +8,7 @@ REGION = 'us-east-1'
 APP_CGAP = 'cgap'
 APP_FOURFRONT = 'fourfront'
 
-LEGACY_GLOBAL_ENV_BUCKET = 'foursight-envs'
+LEGACY_GLOBAL_ENV_BUCKET = 'foursight-prod-envs'
 LEGACY_CGAP_GLOBAL_ENV_BUCKET = 'foursight-cgap-envs'
 
 DEFAULT_ECOSYSTEM = 'main'

--- a/dcicutils/common.py
+++ b/dcicutils/common.py
@@ -8,7 +8,7 @@ REGION = 'us-east-1'
 APP_CGAP = 'cgap'
 APP_FOURFRONT = 'fourfront'
 
-LEGACY_GLOBAL_ENV_BUCKET = 'foursight-prod-envs'
+LEGACY_GLOBAL_ENV_BUCKET = 'foursight-test-envs'
 LEGACY_CGAP_GLOBAL_ENV_BUCKET = 'foursight-cgap-envs'
 
 DEFAULT_ECOSYSTEM = 'main'

--- a/dcicutils/creds_utils.py
+++ b/dcicutils/creds_utils.py
@@ -177,7 +177,7 @@ class KeyManager:
     @classmethod
     def _init_class_variables(cls):
         class_name = cls.__name__
-        print(f"cls={cls!r}, name={class_name!r}")
+        # print(f"cls={cls!r}, name={class_name!r}")
         suffix = "KeyManager"
         if not class_name.endswith(suffix):
             raise ValueError(f"The name, {class_name!r}, of a KeyManager class to be registered"
@@ -261,10 +261,9 @@ class KeyManager:
         ('my-key', 'abra-cadabra')
 
         Args:
-            auth_tuple (tuple): an auth tuple of the form (key, secret)
-            server (str): a server name, such as "https://cgap.hms.harvard.edu" or "http://localhost:8000"
+            auth_dict (dict): a dictionary with entries for 'key' and 'secret'; any 'server' will be ignored
         Returns:
-            a keydict of the form {"key": ..., "secret": ..., "server": ...}
+            a keypair of the form (key, secret)
 
         """
         return (

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -419,6 +419,7 @@ class IniFileManager:
                                      bs_env=None, bs_mirror_env=None, s3_bucket_org=None, s3_bucket_env=None,
                                      s3_encrypt_key_id=None, env_bucket=None, env_ecosystem=None, env_name=None,
                                      data_set=None, es_server=None, es_namespace=None, identity=None,
+                                     higlass_server=None,
                                      indexer=None, index_server=None, sentry_dsn=None, tibanna_cwls_bucket=None,
                                      tibanna_output_bucket=None,
                                      application_bucket_prefix=None, foursight_bucket_prefix=None,
@@ -448,6 +449,7 @@ class IniFileManager:
             es_server (str): The server name (or server:port) for the ElasticSearch server.
             es_namespace (str): The ElasticSearch namespace to use (probably but not necessarily same as env_name).
             identity (str): The AWS application configuration key that represents the current environment.
+            higlass_server (str): The server name (or server:port) for the HiGlass server.
             indexer (bool): Whether or not we are building an ini file for an indexer.
             index_server (bool): Whether or not we are building an ini file for an index server.
             sentry_dsn (str): A sentry DSN specifier, or the empty string if none is desired.
@@ -478,6 +480,7 @@ class IniFileManager:
                                                es_server=es_server,
                                                es_namespace=es_namespace,
                                                identity=identity,
+                                               higlass_server=higlass_server,
                                                indexer=indexer,
                                                index_server=index_server,
                                                sentry_dsn=sentry_dsn,
@@ -545,6 +548,7 @@ class IniFileManager:
                                        bs_env=None, bs_mirror_env=None, s3_bucket_org=None, s3_bucket_env=None,
                                        s3_encrypt_key_id=None, env_bucket=None, env_ecosystem=None, env_name=None,
                                        data_set=None, es_server=None, es_namespace=None, identity=None,
+                                       higlass_server=None,
                                        indexer=None, index_server=None, sentry_dsn=None, tibanna_cwls_bucket=None,
                                        tibanna_output_bucket=None,
                                        application_bucket_prefix=None, foursight_bucket_prefix=None,
@@ -571,6 +575,7 @@ class IniFileManager:
             es_server: The name of an es server to use.
             es_namespace: The namespace to use on the es server. If None, this uses the env_name.
             identity (str): The AWS application configuration key that represents the current environment.
+            higlass_server: The name of a HiGlass server to use.
             indexer: Whether or not we are building an ini file for an indexer.
             index_server: Whether or not we are building an ini file for an index server.
             sentry_dsn (str): A sentry DSN specifier, or the empty string if none is desired.
@@ -596,6 +601,7 @@ class IniFileManager:
                 and os.environ.get("ENCODED_BS_ENV") != os.environ.get("ENCODED_ENV_NAME")):
             raise ValueError("If both ENCODED_BS_ENV and ENCODED_ENV_NAME are supplied, they must agree.")
 
+        higlass_server = higlass_server or os.environ.get('ENCODED_HIGLASS_SERVER', "MISSING_ENCODED_HIGLASS_SERVER")
         es_server = es_server or os.environ.get('ENCODED_ES_SERVER', "MISSING_ENCODED_ES_SERVER")
         env_bucket = (env_bucket
                       or EnvManager.global_env_bucket_name()
@@ -720,6 +726,7 @@ class IniFileManager:
             'PROJECT_VERSION': toml.load(cls.PYPROJECT_FILE_NAME)['tool']['poetry']['version'],
             'SNOVAULT_VERSION': pkg_resources.get_distribution("dcicsnovault").version,
             'UTILS_VERSION': pkg_resources.get_distribution("dcicutils").version,
+            'HIGLASS_SERVER': higlass_server,
             'ES_SERVER': es_server,
             'ENV_BUCKET': env_bucket,
             'ENV_ECOSYSTEM': env_ecosystem,
@@ -869,6 +876,9 @@ class IniFileManager:
             parser.add_argument("--identity",
                                 help="the AWS application configuration key that represents the current environment",
                                 default=None)
+            parser.add_argument("--higlass_server",
+                                help="a HiGlass servername or servername:port",
+                                default=None)
             parser.add_argument("--indexer",
                                 help="whether this server does indexing at all",
                                 choices=["true", "false"],
@@ -935,7 +945,7 @@ class IniFileManager:
                                              data_set=args.data_set, s3_encrypt_key_id=args.s3_encrypt_key_id,
                                              es_server=args.es_server, es_namespace=args.es_namespace,
                                              indexer=args.indexer, index_server=args.index_server,
-                                             identity=args.identity,
+                                             identity=args.identity, higlass_server=args.higlass_server,
                                              sentry_dsn=args.sentry_dsn,
                                              tibanna_cwls_bucket=args.tibanna_cwls_bucket,
                                              tibanna_output_bucket=args.tibanna_output_bucket,

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -38,7 +38,7 @@ from .common import LEGACY_GLOBAL_ENV_BUCKET, LEGACY_CGAP_GLOBAL_ENV_BUCKET, DEF
 from .env_utils import (
     get_standard_mirror_env, data_set_for_env, get_bucket_env,
     is_fourfront_env, is_cgap_env, is_stg_or_prd_env, is_test_env, is_hotseat_env,
-    is_indexer_env, indexer_env_for_env,
+    is_indexer_env, indexer_env_for_env, full_env_name,
 )
 from .misc_utils import PRINT, Retry, apply_dict_overrides, override_environ, file_contents
 from .s3_utils import s3Utils, EnvManager
@@ -1117,6 +1117,8 @@ class CreateMappingOnDeployManager:
             if called on a production environment
 
         """
+
+        env = full_env_name(env)
 
         deploy_cfg = {
             'ENV_NAME': env

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -41,7 +41,7 @@ from .env_utils import (
     is_indexer_env, indexer_env_for_env, full_env_name,
 )
 from .misc_utils import PRINT, Retry, apply_dict_overrides, override_environ, file_contents
-from .s3_utils import s3Utils, EnvManager
+from .env_base import EnvBase, s3Base
 
 
 # constants associated with EB-related APIs
@@ -537,10 +537,10 @@ class IniFileManager:
 
     AUTO_INDEX_SERVER_TOKEN = "__index_server"
 
-    LEGACY_APPLICATION_BUCKET_ORG = s3Utils.EB_PREFIX                        # = "elasticbeanstalk"
+    LEGACY_APPLICATION_BUCKET_ORG = s3Base.EB_PREFIX                        # = "elasticbeanstalk"
     LEGACY_APPLICATION_BUCKET_PREFIX = LEGACY_APPLICATION_BUCKET_ORG + "-"   # = "elasticbeanstalk-"
-    LEGACY_TIBANNA_CWLS_BUCKET = s3Utils.TIBANNA_CWLS_BUCKET_TEMPLATE      # = "tibanna-cwls"
-    LEGACY_TIBANNA_OUTPUT_BUCKET = s3Utils.TIBANNA_OUTPUT_BUCKET_TEMPLATE    # = "tibanna-output"
+    LEGACY_TIBANNA_CWLS_BUCKET = s3Base.TIBANNA_CWLS_BUCKET_TEMPLATE      # = "tibanna-cwls"
+    LEGACY_TIBANNA_OUTPUT_BUCKET = s3Base.TIBANNA_OUTPUT_BUCKET_TEMPLATE    # = "tibanna-output"
     LEGACY_FOURSIGHT_BUCKET_PREFIX = "foursight-"
 
     @classmethod
@@ -604,7 +604,7 @@ class IniFileManager:
         higlass_server = higlass_server or os.environ.get('ENCODED_HIGLASS_SERVER', "MISSING_ENCODED_HIGLASS_SERVER")
         es_server = es_server or os.environ.get('ENCODED_ES_SERVER', "MISSING_ENCODED_ES_SERVER")
         env_bucket = (env_bucket
-                      or EnvManager.global_env_bucket_name()
+                      or EnvBase.global_env_bucket_name()
                       or ("MISSING_GLOBAL_ENV_BUCKET"
                           if cls.APP_ORCHESTRATED
                           else (LEGACY_CGAP_GLOBAL_ENV_BUCKET if cls.APP_KIND == 'cgap' else LEGACY_GLOBAL_ENV_BUCKET)))
@@ -652,41 +652,41 @@ class IniFileManager:
         auth0_client = auth0_client or os.environ.get("ENCODED_AUTH0_CLIENT", "")
         auth0_secret = auth0_secret or os.environ.get("ENCODED_AUTH0_SECRET", "")
 
-        # corresponds to s3Utils legacy "elasticbeanstalk-%s-files"
+        # corresponds to s3Base/s3Utils legacy "elasticbeanstalk-%s-files"
         file_upload_bucket = (file_upload_bucket
                               or os.environ.get("ENCODED_FILE_UPLOAD_BUCKET")
-                              or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.RAW_BUCKET_SUFFIX}")
+                              or f"{application_bucket_prefix}{s3_bucket_env}-{s3Base.RAW_BUCKET_SUFFIX}")
 
-        # corresponds to s3Utils legacy "elasticbeanstalk-%s-wfoutput"
+        # corresponds to s3Base/s3Utils legacy "elasticbeanstalk-%s-wfoutput"
         file_wfout_bucket = (file_wfout_bucket
                              or os.environ.get("ENCODED_FILE_WFOUT_BUCKET")
-                             or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.OUTFILE_BUCKET_SUFFIX}")
+                             or f"{application_bucket_prefix}{s3_bucket_env}-{s3Base.OUTFILE_BUCKET_SUFFIX}")
 
-        # corresponds to s3Utils legacy "elasticbeanstalk-%s-blobs"
+        # corresponds to s3Base/s3Utils legacy "elasticbeanstalk-%s-blobs"
         blob_bucket = (blob_bucket
                        or os.environ.get("ENCODED_BLOB_BUCKET")
-                       or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.BLOB_BUCKET_SUFFIX}")
+                       or f"{application_bucket_prefix}{s3_bucket_env}-{s3Base.BLOB_BUCKET_SUFFIX}")
 
-        # corresponds to s3Utils legacy "elasticbeanstalk-%s-system"
+        # corresponds to s3Base/s3Utils legacy "elasticbeanstalk-%s-system"
         system_bucket = (system_bucket
                          or os.environ.get("ENCODED_SYSTEM_BUCKET")
-                         or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.SYS_BUCKET_SUFFIX}")
+                         or f"{application_bucket_prefix}{s3_bucket_env}-{s3Base.SYS_BUCKET_SUFFIX}")
 
-        # corresponds to s3Utils legacy "elasticbeanstalk-%s-metadata-bundles"
+        # corresponds to s3Base/s3Utils legacy "elasticbeanstalk-%s-metadata-bundles"
         metadata_bundles_bucket = (metadata_bundles_bucket
                                    or os.environ.get("ENCODED_METADATA_BUNDLES_BUCKET")
-                                   or f"{application_bucket_prefix}{s3_bucket_env}-{s3Utils.METADATA_BUCKET_SUFFIX}")
+                                   or f"{application_bucket_prefix}{s3_bucket_env}-{s3Base.METADATA_BUCKET_SUFFIX}")
 
-        # corresponds to s3Utils legacy "tibanna-cwls" (no prefix)
+        # corresponds to s3Base/s3Utils legacy "tibanna-cwls" (no prefix)
         tibanna_cwls_bucket = (tibanna_cwls_bucket
                                or os.environ.get("ENCODED_TIBANNA_CWLS_BUCKET")
-                               or (f"{application_bucket_prefix}{s3Utils.TIBANNA_CWLS_BUCKET_SUFFIX}"
+                               or (f"{application_bucket_prefix}{s3Base.TIBANNA_CWLS_BUCKET_SUFFIX}"
                                    if cls.APP_ORCHESTRATED
                                    else cls.LEGACY_TIBANNA_CWLS_BUCKET))
-        # corresponds to s3Utils legacy "tibanna-output" (no prefix)
+        # corresponds to s3Base/s3Utils legacy "tibanna-output" (no prefix)
         tibanna_output_bucket = (tibanna_output_bucket
                                  or os.environ.get("ENCODED_TIBANNA_OUTPUT_BUCKET")
-                                 or (f"{application_bucket_prefix}{s3Utils.TIBANNA_OUTPUT_BUCKET_SUFFIX}"
+                                 or (f"{application_bucket_prefix}{s3Base.TIBANNA_OUTPUT_BUCKET_SUFFIX}"
                                      if cls.APP_ORCHESTRATED
                                      else cls.LEGACY_TIBANNA_OUTPUT_BUCKET))
         app_kind = cls.APP_KIND or "unknown"

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -1,6 +1,7 @@
 import boto3
+
+from .common import REGION as COMMON_REGION
 from .misc_utils import PRINT
-from .ecr_utils import CGAP_ECR_REGION as CGAP_ECS_REGION
 
 
 class ECSUtils:
@@ -8,9 +9,11 @@ class ECSUtils:
         expand a lot.
     """
 
-    def __init__(self):
+    REGION = COMMON_REGION  # this default must match what ecr_utils.ECRUtils and secrets_utils.assume_identity use
+
+    def __init__(self, region=None):
         """ Creates a boto3 client for 'ecs'. """
-        self.client = boto3.client('ecs', region_name=CGAP_ECS_REGION)  # same as ECR
+        self.client = boto3.client('ecs', region_name=region or self.REGION)
 
     def list_ecs_clusters(self):
         """ Returns a list of ECS clusters ARNs. """

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -83,4 +83,3 @@ class ECSUtils:
                 if deployment['rolloutState'] != self.DEPLOYMENT_COMPLETED:
                     return True
         return False
-

--- a/dcicutils/ecs_utils.py
+++ b/dcicutils/ecs_utils.py
@@ -8,6 +8,7 @@ class ECSUtils:
     """ Utility class for interacting with ECS - mostly stubs at this point, but will likely
         expand a lot.
     """
+    DEPLOYMENT_COMPLETED = 'COMPLETED'
 
     REGION = COMMON_REGION  # this default must match what ecr_utils.ECRUtils and secrets_utils.assume_identity use
 
@@ -73,3 +74,13 @@ class ECSUtils:
                 }
             }
         )
+
+    def service_has_active_deployment(self, *, cluster_name: str, services: list) -> bool:
+        """ Checks if the given cluster/service has an active deployment running """
+        service_meta = self.client.describe_services(cluster=cluster_name, services=services)
+        for service in service_meta.get('services', []):
+            for deployment in service.get('deployments', []):
+                if deployment['rolloutState'] != self.DEPLOYMENT_COMPLETED:
+                    return True
+        return False
+

--- a/dcicutils/env_base.py
+++ b/dcicutils/env_base.py
@@ -82,3 +82,39 @@ class EnvBase:
     @classmethod
     def get_all_ecosystems(cls, env_bucket=None):
         return cls._get_configs(env_bucket=env_bucket, kind='ecosystem')
+
+
+class s3Base:
+
+    # Some extra variables used in setup here so that other modules can be consistent with chosen values.
+
+    SYS_BUCKET_SUFFIX = "system"
+    OUTFILE_BUCKET_SUFFIX = "wfoutput"
+    RAW_BUCKET_SUFFIX = "files"
+    BLOB_BUCKET_SUFFIX = "blobs"
+    METADATA_BUCKET_SUFFIX = "metadata-bundles"
+    TIBANNA_OUTPUT_BUCKET_SUFFIX = 'tibanna-output'
+    TIBANNA_CWLS_BUCKET_SUFFIX = 'tibanna-cwls'
+
+    # NOTE: These were deprecated and retained for compatibility in dcicutils 2.
+    #       For dcicutils 3.0, please rewrite uses as HealthPageKey.xyz names.
+    # SYS_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.SYSTEM_BUCKET                     # = 'system_bucket'
+    # OUTFILE_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.PROCESSED_FILE_BUCKET         # = 'processed_file_bucket'
+    # RAW_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.FILE_UPLOAD_BUCKET                # = 'file_upload_bucket'
+    # BLOB_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.BLOB_BUCKET                      # = 'blob_bucket'
+    # METADATA_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.METADATA_BUNDLES_BUCKET      # = 'metadata_bundles_bucket'
+    # TIBANNA_CWLS_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.TIBANNA_CWLS_BUCKET      # = 'tibanna_cwls_bucket'
+    # TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.TIBANNA_OUTPUT_BUCKET  # = 'tibanna_output_bucket'
+    # This is also deprecated, even though not a bucket name. Use HealthPageKey.ELASTICSEARCH.
+    # ELASTICSEARCH_HEALTH_PAGE_KEY = HealthPageKey.ELASTICSEARCH                  # = 'elasticsearch'
+
+    EB_PREFIX = "elasticbeanstalk"
+    EB_AND_ENV_PREFIX = EB_PREFIX + "-%s-"  # = "elasticbeanstalk-%s-"
+
+    SYS_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + SYS_BUCKET_SUFFIX            # = "elasticbeanstalk-%s-system"
+    OUTFILE_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + OUTFILE_BUCKET_SUFFIX    # = "elasticbeanstalk-%s-wfoutput"
+    RAW_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + RAW_BUCKET_SUFFIX            # = "elasticbeanstalk-%s-files"
+    BLOB_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + BLOB_BUCKET_SUFFIX          # = "elasticbeanstalk-%s-blobs"
+    METADATA_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + METADATA_BUCKET_SUFFIX  # = "elasticbeanstalk-%s-metadata-bundles"
+    TIBANNA_OUTPUT_BUCKET_TEMPLATE = TIBANNA_OUTPUT_BUCKET_SUFFIX          # = "tibanna-output" (no prefix)
+    TIBANNA_CWLS_BUCKET_TEMPLATE = TIBANNA_CWLS_BUCKET_SUFFIX              # = "tibanna-cwls" (no prefix)

--- a/dcicutils/env_base.py
+++ b/dcicutils/env_base.py
@@ -11,13 +11,17 @@ from .common import LEGACY_GLOBAL_ENV_BUCKET
 from .exceptions import (
     # CannotInferEnvFromManyGlobalEnvs,
     # MissingGlobalEnv,
-    SynonymousEnvironmentVariablesMismatched,
+    SynonymousEnvironmentVariablesMismatched, LegacyDispatchDisabled,
 )
 from .misc_utils import (
     override_environ,
     # ignored,
     remove_suffix,
 )
+
+
+class LegacyController:
+    LEGACY_DISPATCH_ENABLED = False
 
 
 class EnvBase:
@@ -51,6 +55,14 @@ class EnvBase:
             yield
 
     @classmethod
+    def _legacy_global_env_bucket_for_testing(cls):
+        if not LegacyController.LEGACY_DISPATCH_ENABLED:
+            raise LegacyDispatchDisabled(operation="_legacy_global_env_bucket_for_testing", mode='setup-envbase')
+        # Strictly speaking, this isn't accessing the legacy state, but it's definitely not accessin gproduction state,
+        # so it does not want to be used in production. -kmp 18-Jul-2022
+        return LEGACY_GLOBAL_ENV_BUCKET
+
+    @classmethod
     def _get_configs(cls, env_bucket, kind):
         env_bucket_name = (
             # prefer a given bucket
@@ -58,7 +70,7 @@ class EnvBase:
             # or GLOBAL_ENV_BUCKET
             or cls.global_env_bucket_name()
             # but failing that, for legacy system, just use legacy name
-            or LEGACY_GLOBAL_ENV_BUCKET)
+            or cls._legacy_global_env_bucket_for_testing())
         s3_resource = boto3.resource('s3')
         env_bucket_model = s3_resource.Bucket(env_bucket_name)
         key_names = [key_obj.key for key_obj in env_bucket_model.objects.all()]

--- a/dcicutils/env_manager.py
+++ b/dcicutils/env_manager.py
@@ -66,6 +66,7 @@ class EnvManager(EnvBase):
         Although the s3 client can be created for you, but if you already have acess to an s3 client via some existing
         object, you should pass that.
         """
+
         self.s3 = s3 or boto3.client('s3')
         if env_name and env_description:
             raise ValueError("You may only specify an env_name or an env_description")

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -43,7 +43,7 @@ def _make_no_legacy(fn, function_name):
     @functools.wraps(fn)
     def _missing_legacy_function(*args, **kwargs):
         ignored(*args, **kwargs)
-        raise NotImplementedError(f"There is only an orchestrated version of {function_name}, not a legacy version.")
+        raise NotImplementedError(f"There is only an orchestrated version of {function_name}, not a legacy version. args={args} kwargs={kwargs}")
     return _missing_legacy_function
 
 
@@ -633,7 +633,7 @@ def get_env_real_url(envname):
         # Fourfront is a low-security application, so only 'data' is 'https' and the rest are 'http'.
         # TODO: This should be table-driven, too, but we're not planning to distribute Fourfront,
         #       so it's not high priority. -kmp 13-May-2022
-        protocol = 'https' if envname == 'data' else 'http'
+        protocol = 'https' if is_stg_or_prd_env(envname) else 'http'
         return f"{protocol}://{short_env_name(envname)}{EnvUtils.DEV_ENV_DOMAIN_SUFFIX}"
     else:
         # For CGAP, everything has to be 'https'. Part of our security model.
@@ -899,7 +899,7 @@ def infer_repo_from_env(envname):
 
 
 @if_orchestrated()
-def infer_foursight_url_from_env(request=None, envname: Optional[EnvName] = None):
+def infer_foursight_url_from_env(*, request=None, envname: Optional[EnvName] = None):
     """
     Infers the Foursight URL for the given envname and request context.
 
@@ -916,7 +916,7 @@ def infer_foursight_url_from_env(request=None, envname: Optional[EnvName] = None
 
 
 @if_orchestrated
-def infer_foursight_from_env(request=None, envname: Optional[EnvName] = None, short: bool = True):
+def infer_foursight_from_env(*, request=None, envname: Optional[EnvName] = None, short: bool = True):
     """
     Infers the Foursight environment token to view based on the given envname and request context
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -70,7 +70,7 @@ def if_orchestrated(*, unimplemented=False, use_legacy=False, assumes_cgap=False
 
     def _decorate(fn):
 
-        EnvUtils.init(raise_load_errors=False)
+        # EnvUtils.init(raise_load_errors=False)
 
         orchestrated_function_name = fn.__name__
 
@@ -87,6 +87,9 @@ def if_orchestrated(*, unimplemented=False, use_legacy=False, assumes_cgap=False
 
         @functools.wraps(legacy_fn)
         def wrapped(*args, **kwargs):
+
+            EnvUtils.init()  # In case this is the first time
+
             if EnvUtils.IS_LEGACY:
                 if not LegacyController.LEGACY_DISPATCH_ENABLED:
                     raise LegacyDispatchDisabled(operation=orchestrated_function_name,

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -399,7 +399,7 @@ class EnvUtils:
 
     @classmethod
     @contextlib.contextmanager
-    def fresh_state_from(cls, *, bucket=None, data=None, global_bucket=None):
+    def fresh_testing_state_from(cls, *, bucket=None, data=None, global_bucket=None):
         with EnvBase.global_env_bucket_named(global_bucket or bucket):
             with EnvUtils.temporary_state():
                 if bucket:
@@ -417,14 +417,14 @@ class EnvUtils:
 
     @classmethod
     @contextlib.contextmanager
-    def fresh_ff_deployed_state(cls):
-        with cls.fresh_state_from(bucket=cls.FF_DEPLOYED_BUCKET):
+    def fresh_ff_deployed_state_for_testing(cls):
+        with cls.fresh_testing_state_from(bucket=cls.FF_DEPLOYED_BUCKET):
             yield
 
     @classmethod
     @contextlib.contextmanager
-    def fresh_cgap_deployed_state(cls):
-        with cls.fresh_state_from(bucket=cls.CGAP_BUCKET):
+    def fresh_cgap_deployed_state_for_testing(cls):
+        with cls.fresh_testing_state_from(bucket=cls.CGAP_BUCKET):
             yield
 
     # Vaguely, the thing we're trying to recognize is this (sanitized slightly here),

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -43,7 +43,8 @@ def _make_no_legacy(fn, function_name):
     @functools.wraps(fn)
     def _missing_legacy_function(*args, **kwargs):
         ignored(*args, **kwargs)
-        raise NotImplementedError(f"There is only an orchestrated version of {function_name}, not a legacy version. args={args} kwargs={kwargs}")
+        raise NotImplementedError(f"There is only an orchestrated version of {function_name}, not a legacy version."
+                                  f" args={args} kwargs={kwargs}")
     return _missing_legacy_function
 
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -914,7 +914,7 @@ def get_foursight_bucket(envname: EnvName, stage: ChaliceStage) -> str:
             return bucket
 
     if EnvUtils.FOURSIGHT_BUCKET_PREFIX:
-        return f"{EnvUtils.FOURSIGHT_BUCKET_PREFIX}-{stage}-{infer_foursight_from_env(envname=envname)}"
+        return f"{EnvUtils.FOURSIGHT_BUCKET_PREFIX}-{stage}-{full_env_name(envname)}"
 
     if bucket_table_seen:
         raise IncompleteFoursightBucketTable(f"No foursight bucket is defined for envname={envname} stage={stage}"

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -619,8 +619,16 @@ def prod_bucket_env(envname: EnvName) -> None:
 
 @if_orchestrated()
 def default_workflow_env(orchestrated_app: OrchestratedApp) -> EnvName:
+    """
+    Returns the default workflow environment to be used in testing (and with ill-constructed .ini files)
+    for WorkFlowRun situations in the portal when there is no env.name in the registry.
+    """
     _check_appname(orchestrated_app, required=True)
-    return EnvUtils.DEFAULT_WORKFLOW_ENV or (EnvUtils.HOTSEAT_ENVS[0] if EnvUtils.HOTSEAT_ENVS else None)
+    return (EnvUtils.DEFAULT_WORKFLOW_ENV
+            or (EnvUtils.HOTSEAT_ENVS[0]
+                if EnvUtils.HOTSEAT_ENVS
+                else None)
+            or EnvUtils.PRD_ENV_NAME)
 
 
 @if_orchestrated()
@@ -984,6 +992,14 @@ def infer_foursight_from_env(*, request=None, envname: Optional[EnvName] = None,
     :param short: whether to shorten the result using short_env_name.
     :return: Foursight env at the end of the url ie: for fourfront-green, could be either 'data' or 'staging'
     """
+
+    # We're phasing out this argument for this operation.  We should perhaps have a separate infer_foursight_from_url
+    # that can be used outside of the core operations by something that knows it has a public-facing URL,
+    # but this does not work in our orchestrated configuration to make necessary portal decisions because
+    # we sometimes receive URLs using hosts that contain explicit references to private IP addresses from
+    # which nothing useful can be inferred.  -kmp 20-Jul-2022
+    ignored(request)
+
     if envname is None:
         # We allow None only so we can gracefully phase out the 'request' argument. -kmp 15-May-2022
         raise ValueError("A non-null envname is required by infer_foursight_from_env.")

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -691,32 +691,38 @@ def get_env_real_url(envname):
 
 @if_orchestrated
 def is_cgap_server(server, allow_localhost=False) -> bool:
-    check_true(isinstance(server, str), "The 'url' argument must be a string.", error_class=ValueError)
-    is_cgap = EnvUtils.ORCHESTRATED_APP == 'cgap'
-    if not is_cgap:
-        return False
-    kind = classify_server_url(server, raise_error=False).get(c.KIND)
-    if kind == 'cgap':
-        return True
-    elif allow_localhost and kind == 'localhost':
-        return True
-    else:
-        return False
+    ignored(server, allow_localhost)
+    return EnvUtils.ORCHESTRATED_APP == 'cgap'
+    #
+    # check_true(isinstance(server, str), "The 'url' argument must be a string.", error_class=ValueError)
+    # is_cgap = EnvUtils.ORCHESTRATED_APP == 'cgap'
+    # if not is_cgap:
+    #     return False
+    # kind = classify_server_url(server, raise_error=False).get(c.KIND)
+    # if kind == 'cgap':
+    #     return True
+    # elif allow_localhost and kind == 'localhost':
+    #     return True
+    # else:
+    #     return False
 
 
 @if_orchestrated
 def is_fourfront_server(server, allow_localhost=False) -> bool:
-    check_true(isinstance(server, str), "The 'url' argument must be a string.", error_class=ValueError)
-    is_fourfront = EnvUtils.ORCHESTRATED_APP == 'fourfront'
-    if not is_fourfront:
-        return False
-    kind = classify_server_url(server, raise_error=False).get(c.KIND)
-    if kind == 'fourfront':
-        return True
-    elif allow_localhost and kind == 'localhost':
-        return True
-    else:
-        return False
+    ignored(server, allow_localhost)
+    return EnvUtils.ORCHESTRATED_APP == 'fourfront'
+    #
+    # check_true(isinstance(server, str), "The 'url' argument must be a string.", error_class=ValueError)
+    # is_fourfront = EnvUtils.ORCHESTRATED_APP == 'fourfront'
+    # if not is_fourfront:
+    #     return False
+    # kind = classify_server_url(server, raise_error=False).get(c.KIND)
+    # if kind == 'fourfront':
+    #     return True
+    # elif allow_localhost and kind == 'localhost':
+    #     return True
+    # else:
+    #     return False
 
 
 @if_orchestrated
@@ -979,15 +985,19 @@ def infer_foursight_from_env(*, request=None, envname: Optional[EnvName] = None,
         # We allow None only so we can gracefully phase out the 'request' argument. -kmp 15-May-2022
         raise ValueError("A non-null envname is required by infer_foursight_from_env.")
 
-    # If a request is passed and stage-mirroring is enabled, we can tell from the URL if we're staging
-    # then for anything that is a stg or prd, return its 'public name' token.
-    # TODO: Find a simpler way to write this block of code? It's not very abstract. -kmp 23-May-2022
-    if request and EnvUtils.STAGE_MIRRORING_ENABLED and EnvUtils.STG_ENV_NAME:
-        classification = classify_server_url(request if isinstance(request, str) else request.domain)
-        if classification[c.IS_STG_OR_PRD]:
-            public_name = classification[c.PUBLIC_NAME]
-            if public_name:
-                return public_name
+    # This isn't helpful any more. In Fargate we sometimes just get a random IP address.from
+    # The envname information should get us what we need.
+    # -kmp 14-Jul-2022
+    #
+    # # If a request is passed and stage-mirroring is enabled, we can tell from the URL if we're staging
+    # # then for anything that is a stg or prd, return its 'public name' token.
+    # # TODO: Find a simpler way to write this block of code? It's not very abstract. -kmp 23-May-2022
+    # if request and EnvUtils.STAGE_MIRRORING_ENABLED and EnvUtils.STG_ENV_NAME:
+    #     classification = classify_server_url(request if isinstance(request, str) else request.domain)
+    #     if classification[c.IS_STG_OR_PRD]:
+    #         public_name = classification[c.PUBLIC_NAME]
+    #         if public_name:
+    #             return public_name
 
     entry = (find_association(EnvUtils.PUBLIC_URL_TABLE, name=envname) or
              find_association(EnvUtils.PUBLIC_URL_TABLE, environment=full_env_name(envname)) or

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -333,6 +333,10 @@ class EnvUtils:
 
     @classmethod
     def set_declared_data(cls, data):
+
+        if data.get(e.IS_LEGACY) and not LegacyController.LEGACY_DISPATCH_ENABLED:
+            raise LegacyDispatchDisabled(operation='set_declared_data', mode='load-env')
+
         cls._DECLARED_DATA = data
         for var, key in EnvNames.__dict__.items():
             if var.isupper():

--- a/dcicutils/env_utils_legacy.py
+++ b/dcicutils/env_utils_legacy.py
@@ -392,6 +392,16 @@ def public_url_mappings(envname: EnvName):
     return CGAP_PUBLIC_URLS if is_cgap_env(envname) else FF_PUBLIC_URLS
 
 
+def get_env_real_url(envname):
+    if 'cgap' in envname:
+        # For CGAP, everything has to be 'https'. Part of our security model.
+        return f"https://{short_env_name(envname)}.hms.harvard.edu"
+    else:  # presumably Fourfront
+        # For Fourfront, we're a little more flexible on the security (for now).
+        protocol = 'https' if is_stg_or_prd_env(envname) else 'http'
+        return f"{protocol}://{short_env_name(envname)}.4dnucleome.org"
+
+
 def is_cgap_server(server, allow_localhost=False):
     """
     Returns True if the given string looks like a CGAP server name. Otherwise returns False.
@@ -556,8 +566,8 @@ CGAP_FOURSIGHT_URL_PREFIX = "https://u9feld4va7.execute-api.us-east-1.amazonaws.
 FF_FOURSIGHT_URL_PREFIX = "https://foursight.4dnucleome.org/view/"
 
 
-def infer_foursight_url_from_env(request, envname: Optional[EnvName]):
-    token = infer_foursight_from_env(request, envname)
+def infer_foursight_url_from_env(*, request=None, envname: Optional[EnvName] = None):
+    token = infer_foursight_from_env(request=request, envname=envname)
     if token is not None:
         prefix = CGAP_FOURSIGHT_URL_PREFIX if is_cgap_env(envname) else FF_FOURSIGHT_URL_PREFIX
         return prefix + token
@@ -565,7 +575,7 @@ def infer_foursight_url_from_env(request, envname: Optional[EnvName]):
         return None
 
 
-def infer_foursight_from_env(request, envname: Optional[EnvName]):
+def infer_foursight_from_env(*, request=None, envname: Optional[EnvName] = None):
     """  Infers the Foursight environment to view based on the given envname and request context
 
     :param request: the current request (or an object that has member 'domain')

--- a/dcicutils/env_utils_legacy.py
+++ b/dcicutils/env_utils_legacy.py
@@ -497,6 +497,7 @@ ALLOW_ENVIRON_BY_DEFAULT = True
 
 
 def get_env_from_context(settings, allow_environ=ALLOW_ENVIRON_BY_DEFAULT):
+    """Look for an env in settings or in an environemnt variable."""
     return get_setting_from_context(settings, ini_var='env.name', env_var=None if allow_environ else False)
 
 

--- a/dcicutils/exceptions.py
+++ b/dcicutils/exceptions.py
@@ -237,5 +237,16 @@ class NotBeanstalkEnvironment(Exception):
 class BeanstalkOperationNotImplemented(NotImplementedError):
     def __init__(self, operation, message=None):
         self.operation = operation
-        super().__init__(f"Attempt to use an obsolete beanstalk operation {operation} in a container environment."
-                         or message)
+        super().__init__(message
+                         or f"Attempt to use an obsolete beanstalk operation {operation} in a container environment.")
+
+
+class LegacyDispatchDisabled(Exception):
+    def __init__(self, operation, call_args=None, call_kwargs=None, mode='dispatch', message=None):
+        self.operation = operation
+        self.call_args = call_args
+        self.call_kwargs = call_kwargs
+        self.mode = mode
+        super().__init__(message
+                         or f"Attempt to use legacy operation {operation}"
+                            f" with args={call_args} kwargs={call_kwargs} mode={mode}.")

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -8,7 +8,7 @@ import re
 import requests
 import time
 
-from dcicutils.env_utils import EnvUtils, short_env_name, full_env_name, is_stg_or_prd_env
+from dcicutils.env_utils import EnvUtils, full_env_name, is_stg_or_prd_env
 from dcicutils.ff_utils import authorized_request
 from dcicutils.lang_utils import disjoined_list, conjoined_list
 from dcicutils.misc_utils import ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool
@@ -156,7 +156,8 @@ def mocked_s3utils(environments=None, require_sse=False, other_access_key_names=
                                     if m:
                                         env_name = m.group(1)  # we found it with a fourfront-prefix, so use as is
                                         return make_mock_health_page(env_name)
-                                    m = re.match(r'(?:https?://)?([a-z0-9-]+)(?:[.](4dnucleome[.]org|hms.harvard.edu)([/].*)|$)', url)
+                                    m = re.match(r'(?:https?://)?([a-z0-9-]+)'
+                                                 r'(?:[.](4dnucleome[.]org|hms.harvard.edu)([/].*)|$)', url)
                                     if m:
                                         env_name = full_env_name(m.group(1))  # no fourfront- prefix, so add one
                                         return make_mock_health_page(env_name)

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -61,8 +61,19 @@ def print_error_message(exception, full=False):
     With full=True, the error-type can be made to use dcicutils.misc_utils.full_class_name to get a module name, so:
       <module-qualified-error-type>: <error-message>
     """
+    PRINT(get_error_message(exception, full=full))
+
+
+def get_error_message(exception, full=False):
+    """
+    Returns an error message (using dcicutils.misc_utils.PRINT) formatted in the conventional way, as:
+      "<error-type>: <error-message>"
+    With full=True, the error-type can be made to use dcicutils.misc_utils.full_class_name to get a module name, so:
+      "<module-qualified-error-type>: <error-message>"
+    """
     exception_type_name = full_class_name(exception) if full else exception.__class__.__name__
-    PRINT(f"{exception_type_name}: {exception}")
+    error_message = f"{exception_type_name}: {exception}"
+    return error_message
 
 
 absolute_uri_validator = (

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -54,6 +54,17 @@ PRINT = _PRINT()
 PRINT.__name__ = 'PRINT'
 
 
+def print_error_message(exception, full=False):
+    """
+    Prints an error message (using dcicutils.misc_utils.PRINT) in the conventional way, as:
+      <error-type>: <error-message>
+    With full=True, the error-type can be made to use dcicutils.misc_utils.full_class_name to get a module name, so:
+      <module-qualified-error-type>: <error-message>
+    """
+    exception_type_name = full_class_name(exception) if full else exception.__class__.__name__
+    PRINT(f"{exception_type_name}: {exception}")
+
+
 absolute_uri_validator = (
     rfc3986.validators.Validator()
     # Validation qualifiers
@@ -1506,7 +1517,7 @@ def json_leaf_subst(exp, substitutions):
     return exp
 
 
-class SingletonManager():
+class SingletonManager:
 
     def __init__(self, singleton_class, *singleton_args, **singleton_kwargs):
         self._singleton = None

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -24,6 +24,7 @@ from botocore.credentials import Credentials as Boto3Credentials
 from botocore.exceptions import ClientError
 from json import dumps as json_dumps, loads as json_loads
 from unittest import mock
+from .env_utils import short_env_name
 from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix
 from .misc_utils import (
     PRINT, ignored, Retry, CustomizableProperty, getattr_customized, remove_prefix, REF_TZ,
@@ -1585,7 +1586,7 @@ class MockBotoS3Client:
             # I would need to research what specific error is needed here and hwen,
             # since it might be a 404 (not found) or a 403 (permissions), depending on various details.
             # For now, just fail in any way since maybe our code doesn't care.
-            raise Exception(f"Mock File Not Found: {pseudo_filename}")
+            raise Exception(f"Mock File Not Found: {pseudo_filename}. Existing files: {list(self.s3_files.files.keys())}")
 
     def head_bucket(self, Bucket):  # noQA - AWS argument naming style
         bucket_prefix = Bucket + "/"
@@ -2134,7 +2135,8 @@ class MockBotoElasticBeanstalkClient:
 
 
 def make_mock_beanstalk_cname(env_name):
-    return f"{env_name}.9wzadzju3p.us-east-1.elasticbeanstalk.com"
+    # return f"{env_name}.9wzadzju3p.us-east-1.elasticbeanstalk.com"
+    return f"{short_env_name(env_name)}.4dnucleome.org"
 
 
 def make_mock_beanstalk(env_name, cname=None):

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -14,6 +14,7 @@ import os
 import pytest
 import pytz
 import re
+import sys
 import time
 import toml
 from typing import Any, Optional
@@ -22,7 +23,9 @@ import warnings
 
 from botocore.credentials import Credentials as Boto3Credentials
 from botocore.exceptions import ClientError
+from collections import defaultdict
 from json import dumps as json_dumps, loads as json_loads
+from typing import Optional, List, DefaultDict
 from unittest import mock
 from .env_utils import short_env_name
 from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix
@@ -574,16 +577,39 @@ class _PrintCapturer:
     """
 
     def __init__(self):
-        self.lines = []
-        self.last = None
+        self.reset()
 
     def mock_print_handler(self, *args, **kwargs):
+        """
+        For the simple case of stdout, .last has the last line and .lines contains all lines.
+        For all cases, even stdout, .file_lines[fp] and .lines[fp] contain it.
+        Notes:
+            * If None is the fp value, sys.stdout is used instead. so that None and the current
+              value of sys.stdout are synonyms.
+            * This mock ignores 'end=' and will treat all calls to PRINT as if they were separate lines.
+        """
         text = " ".join(map(str, args))
         print(text, **kwargs)
         # This only captures non-file output output.
-        if kwargs.get('file') is None:
-            self.last = text
+        file = kwargs.get('file')
+        if file is None:
+            file = sys.stdout
+        if file is sys.stdout:
+            # Easy access to stdout
             self.lines.append(text)
+            self.last = text
+            # Every output to stdout is implicitly like output to no file (None)
+            self.file_lines[None].append(text)
+            self.file_last[None] = text
+        # All accesses of any file/fp, including stdout, get associated with that destination
+        self.file_lines[file].append(text)
+        self.file_last[file] = text
+
+    def reset(self):
+        self.lines: List[str] = []
+        self.last: Optional[str] = None
+        self.file_lines: DefaultDict[Optional[str], List[str]] = defaultdict(lambda: [])
+        self.file_last: DefaultDict[Optional[str], Optional[str]] = defaultdict(lambda: None)
 
 
 @contextlib.contextmanager

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -193,6 +193,9 @@ class ControlledTime:  # This will move to dcicutils -kmp 7-May-2020
         """
         return self._just_now
 
+    def just_utcnow(self):
+        return self.just_now().astimezone(pytz.UTC).replace(tzinfo=None)
+
     def now(self) -> datetime.datetime:
         """
         This advances time by one tick and returns the new time.

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -17,7 +17,6 @@ import re
 import sys
 import time
 import toml
-from typing import Any, Optional
 import uuid
 import warnings
 
@@ -25,7 +24,7 @@ from botocore.credentials import Credentials as Boto3Credentials
 from botocore.exceptions import ClientError
 from collections import defaultdict
 from json import dumps as json_dumps, loads as json_loads
-from typing import Optional, List, DefaultDict
+from typing import Any, Optional, List, DefaultDict
 from unittest import mock
 from .env_utils import short_env_name
 from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -790,6 +790,9 @@ class MockBoto3Session:
         except Exception:
             return None, None, None,
 
+    MISSING_ACCESS_KEY = 'missing access key'
+    MISSING_SECRET_KEY = 'missing secret key'
+
     def get_credentials(self) -> Optional[Boto3Credentials]:
         """
         Returns the AWS credentials (Boto3Credentials) from the aws_access_key_id and aws_secret_access_key values,
@@ -830,7 +833,7 @@ class MockBoto3Session:
         aws_access_key_id, aws_secret_access_key, _ = self._read_aws_credentials_from_file(aws_credentials_file)
         if aws_access_key_id and aws_secret_access_key:
             return Boto3Credentials(access_key=aws_access_key_id, secret_key=aws_secret_access_key)
-        return Boto3Credentials(access_key=None, secret_key=None)
+        return Boto3Credentials(access_key=self.MISSING_ACCESS_KEY, secret_key=self.MISSING_SECRET_KEY)
 
     @property
     def region_name(self) -> Optional[str]:
@@ -976,7 +979,7 @@ class MockBoto3Iam:
             shared_data = shared_reality[self._SHARED_DATA_MARKER] = {}
         return shared_data
 
-    def _mocked_users(self) -> object:
+    def _mocked_users(self):
         mocked_shared_data = self._mocked_shared_data()
         mocked_users = mocked_shared_data.get("users")
         if not mocked_users:
@@ -1586,7 +1589,8 @@ class MockBotoS3Client:
             # I would need to research what specific error is needed here and hwen,
             # since it might be a 404 (not found) or a 403 (permissions), depending on various details.
             # For now, just fail in any way since maybe our code doesn't care.
-            raise Exception(f"Mock File Not Found: {pseudo_filename}. Existing files: {list(self.s3_files.files.keys())}")
+            raise Exception(f"Mock File Not Found: {pseudo_filename}."
+                            f" Existing files: {list(self.s3_files.files.keys())}")
 
     def head_bucket(self, Bucket):  # noQA - AWS argument naming style
         bucket_prefix = Bucket + "/"

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -736,11 +736,11 @@ class MockBoto3Session:
                 else:
                     del os.environ[environ_name]
 
-    def put_credentials_for_testing(self, *,
+    def put_credentials_for_testing(self,
                                     aws_access_key_id: str = None,
                                     aws_secret_access_key: str = None,
                                     region_name: str = None,
-                                    aws_credentials_dir: str = None, **kwargs) -> None:
+                                    aws_credentials_dir: str = None) -> None:
         """
         Sets AWS credentials for testing.
 
@@ -748,7 +748,6 @@ class MockBoto3Session:
         :param aws_secret_access_key: AWS secret access key.
         :param region_name: AWS region name.
         :param aws_credentials_dir: Full path to AWS credentials directory.
-        :param kwargs: Other arguments; none currently used.
 
         NOTE: Use unset_environ_credentials_for_testing() to clear these environment variables beforehand.
         NOTE: AWS session token not currently handled.
@@ -762,7 +761,8 @@ class MockBoto3Session:
         # These is specific for testing.
         self._aws_credentials_dir = aws_credentials_dir
 
-    def _read_aws_credentials_from_file(self, aws_credentials_file: str) -> (str, str, str):
+    @staticmethod
+    def _read_aws_credentials_from_file(aws_credentials_file: str) -> (str, str, str):
         """
         Returns from the given AWS credentials file the values of the following properties;
         and returns a tuple with these values, in this listed order:
@@ -884,6 +884,90 @@ class MockBoto3Session:
         return aws_region
 
 
+class MockBoto3IamUserAccessKeyPair:
+    def __init__(self) -> None:
+        self._id = str(uuid.uuid4())
+        self._secret = str(uuid.uuid4())
+        self._create_date = datetime.datetime.now()
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def secret(self) -> str:
+        return self._secret
+
+    def get(self, key: str) -> Any:
+        if key == "AccessKeyId":
+            return self._id
+        elif key == "CreateDate":
+            return self._create_date
+        return None
+
+    def __getitem__(self, key: str) -> Any:
+        return self.get(key)
+
+
+class MockBoto3IamUserAccessKeyPairCollection:
+    def __init__(self) -> None:
+        self._access_key_pairs = []
+
+    def add(self, access_key_pair: object) -> None:
+        self._access_key_pairs.append(access_key_pair)
+
+    def get(self, key: str) -> Any:
+        if key == "AccessKeyMetadata":
+            return self._access_key_pairs
+        return None
+
+    def __getitem__(self, key: str) -> Any:
+        return self.get(key)
+
+
+class MockBoto3IamUser:
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self.mocked_access_keys = MockBoto3IamUserAccessKeyPairCollection()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def create_access_key_pair(self) -> object:
+        access_key_pair = MockBoto3IamUserAccessKeyPair()
+        self.mocked_access_keys.add(access_key_pair)
+        return access_key_pair
+
+
+class MockBoto3IamUserCollection:
+    def __init__(self) -> None:
+        self._users = []
+
+    def all(self) -> list:
+        return self._users
+
+
+class MockBoto3IamRoleCollection:
+    def __init__(self) -> None:
+        self._roles = []
+
+    def __getitem__(self, key: str) -> Any:
+        if key == "Roles":
+            return self._roles
+        return None
+
+
+class MockBoto3IamRole:
+    def __init__(self, arn: str) -> None:
+        self._arn = arn
+
+    def __getitem__(self, key: str) -> Any:
+        if key == "Arn":
+            return self._arn
+        return None
+
+
 # This MockBoto3Iam class is a minimal implementation, just enough to support the
 # original usage by 4dn-cloud-infra/setup-remaining-secrets unit tests (June 2022).
 @MockBoto3.register_client(kind='iam')
@@ -891,86 +975,8 @@ class MockBoto3Iam:
 
     _SHARED_DATA_MARKER = "_IAM_SHARED_DATA_MARKER"
 
-    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
+    def __init__(self, *, boto3=None) -> None:
         self.boto3 = boto3 or MockBoto3()
-
-    class _UserAccessKeyPair:
-        def __init__(self) -> None:
-            self._id = str(uuid.uuid4())
-            self._secret = str(uuid.uuid4())
-            self._create_date = datetime.datetime.now()
-
-        @property
-        def id(self) -> str:
-            return self._id
-
-        @property
-        def secret(self) -> str:
-            return self._secret
-
-        def get(self, key: str) -> Any:
-            if key == "AccessKeyId":
-                return self._id
-            elif key == "CreateDate":
-                return self._create_date
-            return None
-
-        def __getitem__(self, key: str) -> Any:
-            return self.get(key)
-
-    class _UserAccessKeyPairCollection:
-        def __init__(self) -> None:
-            self._access_key_pairs = []
-
-        def add(self, access_key_pair: object) -> None:
-            self._access_key_pairs.append(access_key_pair)
-
-        def get(self, key: str) -> Any:
-            if key == "AccessKeyMetadata":
-                return self._access_key_pairs
-            return None
-
-        def __getitem__(self, key: str) -> Any:
-            return self.get(key)
-
-    class _User:
-        def __init__(self, name: str) -> None:
-            self._name = name
-            self._access_keys = MockBoto3Iam._UserAccessKeyPairCollection()
-
-        @property
-        def name(self) -> str:
-            return self._name
-
-        def create_access_key_pair(self) -> object:
-            access_key_pair = MockBoto3Iam._UserAccessKeyPair()
-            self._access_keys.add(access_key_pair)
-            return access_key_pair
-
-    class _UserCollection:
-        def __init__(self) -> None:
-            self._users = []
-
-        def all(self) -> list:
-            return self._users
-
-    class _RoleCollection:
-        def __init__(self) -> None:
-            self._roles = []
-
-        def __getitem__(self, key: str) -> Any:
-            if key == "Roles":
-                return self._roles
-            return None
-
-    class _Role:
-        def __init__(self, arn: str) -> None:
-            self._arn = arn
-
-        def __getitem__(self, key: str) -> Any:
-            if key == "Arn":
-                return self._arn
-            return None
 
     def _mocked_shared_data(self) -> dict:
         shared_reality = self.boto3.shared_reality
@@ -979,18 +985,18 @@ class MockBoto3Iam:
             shared_data = shared_reality[self._SHARED_DATA_MARKER] = {}
         return shared_data
 
-    def _mocked_users(self):
+    def _mocked_users(self) -> MockBoto3IamUserCollection:
         mocked_shared_data = self._mocked_shared_data()
         mocked_users = mocked_shared_data.get("users")
         if not mocked_users:
-            mocked_shared_data["users"] = mocked_users = MockBoto3Iam._UserCollection()
+            mocked_shared_data["users"] = mocked_users = MockBoto3IamUserCollection()
         return mocked_users
 
-    def _mocked_roles(self) -> Any:
+    def _mocked_roles(self) -> MockBoto3IamRoleCollection:
         mocked_shared_data = self._mocked_shared_data()
         mocked_roles = mocked_shared_data.get("roles")
         if not mocked_roles:
-            mocked_shared_data["roles"] = mocked_roles = MockBoto3Iam._RoleCollection()
+            mocked_shared_data["roles"] = mocked_roles = MockBoto3IamRoleCollection()
         return mocked_roles
 
     def put_users_for_testing(self, users: list) -> None:
@@ -998,14 +1004,14 @@ class MockBoto3Iam:
             existing_users = self._mocked_users().all()
             for user in users:
                 if user not in existing_users:
-                    existing_users.append(MockBoto3Iam._User(user))
+                    existing_users.append(MockBoto3IamUser(user))
 
     def put_roles_for_testing(self, roles: list) -> None:
         if isinstance(roles, list) and len(roles) > 0:
             existing_roles = self._mocked_roles()["Roles"]
             for role in roles:
                 if role not in existing_roles:
-                    existing_roles.append(MockBoto3Iam._Role(role))
+                    existing_roles.append(MockBoto3IamRole(role))
 
     @property
     def users(self) -> object:
@@ -1014,11 +1020,45 @@ class MockBoto3Iam:
     def list_roles(self) -> object:
         return self._mocked_roles()
 
-    def list_access_keys(self, UserName: str) -> Optional[object]:
+    def list_access_keys(self, UserName: str) -> Optional[MockBoto3IamUserAccessKeyPairCollection]:  # noQA - Argument names chosen for AWS consistency
         existing_users = self._mocked_users().all()
         for existing_user in existing_users:
             if existing_user.name == UserName:
-                return existing_user._access_keys
+                return existing_user.mocked_access_keys
+        return None
+
+
+class MockBoto3OpenSearchDomain:
+    def __init__(self, domain_name: str, domain_endpoint_vpc: str, domain_endpoint_https: bool) -> None:
+        self._domain_name = domain_name
+        self._domain_endpoint_vpc = domain_endpoint_vpc
+        self._domain_endpoint_https = domain_endpoint_https
+
+    def __getitem__(self, key: str) -> Any:
+        if key == "DomainName":
+            return self._domain_name
+        elif key == "DomainStatus":
+            return {
+                "Endpoints": {
+                    "vpc": self._domain_endpoint_vpc
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": self._domain_endpoint_https
+                }
+            }
+        return None
+
+
+class MockBoto3OpenSearchDomains:
+    def __init__(self) -> None:
+        self._domains = []
+
+    def add(self, domain: object) -> None:
+        self._domains.append(domain)
+
+    def __getitem__(self, key: str) -> Any:
+        if key == "DomainNames":
+            return self._domains
         return None
 
 
@@ -1029,39 +1069,7 @@ class MockBoto3OpenSearch:
 
     _SHARED_DATA_MARKER = '_OPENSEARCH_SHARED_DATA_MARKER'
 
-    class _Domain:
-        def __init__(self, domain_name: str, domain_endpoint_vpc: str, domain_endpoint_https: bool) -> None:
-            self._domain_name = domain_name
-            self._domain_endpoint_vpc = domain_endpoint_vpc
-            self._domain_endpoint_https = domain_endpoint_https
-
-        def __getitem__(self, key: str) -> Any:
-            if key == "DomainName":
-                return self._domain_name
-            elif key == "DomainStatus":
-                return {
-                    "Endpoints": {
-                        "vpc": self._domain_endpoint_vpc
-                    },
-                    "DomainEndpointOptions": {
-                        "EnforceHTTPS": self._domain_endpoint_https
-                    }
-                }
-            return None
-
-    class _Domains:
-        def __init__(self) -> None:
-            self._domains = []
-
-        def add(self, domain: object) -> None:
-            self._domains.append(domain)
-
-        def __getitem__(self, key: str) -> Any:
-            if key == "DomainNames":
-                return self._domains
-            return None
-
-    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
+    def __init__(self, boto3=None) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     def _mocked_shared_data(self) -> dict:
@@ -1071,21 +1079,21 @@ class MockBoto3OpenSearch:
             shared_data = shared_reality[self._SHARED_DATA_MARKER] = {}
         return shared_data
 
-    def _mocked_domains(self) -> dict:
+    def _mocked_domains(self) -> MockBoto3OpenSearchDomains:
         mocked_shared_data = self._mocked_shared_data()
         mocked_domains = mocked_shared_data.get("domains")
         if not mocked_domains:
-            mocked_shared_data["domains"] = mocked_domains = MockBoto3OpenSearch._Domains()
+            mocked_shared_data["domains"] = mocked_domains = MockBoto3OpenSearchDomains()
         return mocked_domains
 
     def put_domain_for_testing(self, domain_name: str, domain_endpoint_vpc: str, domain_endpoint_https: bool) -> None:
         domains = self._mocked_domains()
-        domains.add(MockBoto3OpenSearch._Domain(domain_name, domain_endpoint_vpc, domain_endpoint_https))
+        domains.add(MockBoto3OpenSearchDomain(domain_name, domain_endpoint_vpc, domain_endpoint_https))
 
-    def list_domain_names(self) -> dict:
+    def list_domain_names(self) -> MockBoto3OpenSearchDomains:
         return self._mocked_domains()
 
-    def describe_domain(self, DomainName: str) -> Optional[dict]:
+    def describe_domain(self, DomainName: str) -> Optional[dict]:  # noQA - Argument names chosen for AWS consistency
         domains = self._mocked_domains()["DomainNames"]
         if domains:
             for domain in domains:
@@ -1101,7 +1109,7 @@ class MockBoto3Sts:
 
     _SHARED_DATA_MARKER = '_STS_SHARED_DATA_MARKER'
 
-    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
+    def __init__(self, boto3=None) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     def _mocked_shared_data(self) -> dict:
@@ -1127,6 +1135,29 @@ class MockBoto3Sts:
         return self._mocked_caller_identity()
 
 
+class MockBoto3KmsKey:
+    def __init__(self, key_id: str):
+        self._key_id = key_id
+
+    def __getitem__(self, key: str) -> Any:
+        if key == "KeyId":
+            return self._key_id
+        return None
+
+
+class MockBoto3KmsKeys:
+    def __init__(self):
+        self._keys = []
+
+    def add(self, key: object) -> None:
+        self._keys.append(key)
+
+    def __getitem__(self, key: str):
+        if key == "Keys":
+            return self._keys
+        return None
+
+
 # This MockBoto3Kms class is a minimal implementation, just enough to support the
 # original usage by 4dn-cloud-infra/setup-remaining-secrets unit tests (June 2022).
 @MockBoto3.register_client(kind='kms')
@@ -1134,28 +1165,7 @@ class MockBoto3Kms:
 
     _SHARED_DATA_MARKER = '_KMS_SHARED_DATA_MARKER'
 
-    class _Key:
-        def __init__(self, key_id: str):
-            self._key_id = key_id
-
-        def __getitem__(self, key: str) -> Any:
-            if key == "KeyId":
-                return self._key_id
-            return None
-
-    class _Keys:
-        def __init__(self):
-            self._keys = []
-
-        def add(self, key: object) -> None:
-            self._keys.append(key)
-
-        def __getitem__(self, key: str):
-            if key == "Keys":
-                return self._keys
-            return None
-
-    def __init__(self, *, region_name=None, boto3=None, **kwargs) -> None:
+    def __init__(self, *, boto3=None) -> None:
         self.boto3 = boto3 or MockBoto3()
 
     def _mocked_shared_data(self) -> dict:
@@ -1165,11 +1175,11 @@ class MockBoto3Kms:
             shared_data = shared_reality[self._SHARED_DATA_MARKER] = {}
         return shared_data
 
-    def _mocked_keys(self) -> dict:
+    def _mocked_keys(self) -> MockBoto3KmsKeys:
         mocked_shared_data = self._mocked_shared_data()
         mocked_keys = mocked_shared_data.get("keys")
         if not mocked_keys:
-            mocked_shared_data["keys"] = mocked_keys = MockBoto3Kms._Keys()
+            mocked_shared_data["keys"] = mocked_keys = MockBoto3KmsKeys()
         return mocked_keys
 
     def _mocked_key_policies(self) -> dict:
@@ -1179,14 +1189,20 @@ class MockBoto3Kms:
             mocked_shared_data["key_policies"] = mocked_key_policies = {}
         return mocked_key_policies
 
-    def put_key_for_testing(self, KeyId: str) -> None:
+    def put_key_for_testing(self, key_id: str) -> None:
         keys = self._mocked_keys()
-        keys.add(MockBoto3Kms._Key(KeyId))
+        keys.add(MockBoto3KmsKey(key_id))
 
-    def put_key_policy_for_testing(self, KeyId: str, Policy: dict) -> None:
-        self.put_key_policy(KeyId, Policy, PolicyName="default")
+    def put_key_policy_for_testing(self, key_id: str, key_policy: dict) -> None:
+        if isinstance(key_policy, dict):
+            key_policy_string = json_dumps(key_policy)
+        elif isinstance(key_policy, str):
+            key_policy_string = key_policy
+        else:
+            raise ValueError("Policy must but dictionary or string.")
+        self.put_key_policy(KeyId=key_id, Policy=key_policy_string, PolicyName="default")
 
-    def list_keys(self) -> dict:
+    def list_keys(self) -> MockBoto3KmsKeys:
         return self._mocked_keys()
 
     def describe_key(self, KeyId: str) -> Optional[dict]:  # noQA - Argument names chosen for AWS consistency
@@ -1201,19 +1217,15 @@ class MockBoto3Kms:
                     }
         return None
 
-    def put_key_policy(self, KeyId: str, Policy: str, PolicyName: str) -> None:
+    def put_key_policy(self, KeyId: str, Policy: str, PolicyName: str) -> None:  # noQA - Argument names chosen for AWS consistency
         if not KeyId:
             raise ValueError(f"KeyId value must be set for kms.put_key_policy.")
         if PolicyName != "default":
             raise ValueError(f"PolicyName value must be 'default' for kms.put_key_policy.")
-        if isinstance(Policy, dict):
-            key_policy_string = json_dumps(Policy)
-        elif isinstance(Policy, str):
-            key_policy_string = Policy
         key_policies = self._mocked_key_policies()
-        key_policies[KeyId] = {"Policy": key_policy_string}
+        key_policies[KeyId] = {"Policy": Policy}
 
-    def get_key_policy(self, KeyId: str, PolicyName: str) -> Optional[dict]:
+    def get_key_policy(self, KeyId: str, PolicyName: str) -> Optional[dict]:  # noQA - Argument names chosen for AWS consistency
         if not KeyId:
             raise ValueError(f"KeyId value must be set for kms.get_key_policy.")
         if PolicyName != "default":
@@ -1371,7 +1383,7 @@ class MockBoto3SecretsManager:
         # This really returns dictionaries with lots more things, but we'll start slow. :) -kmp 17-Feb-2022
         return {'SecretList': [{'Name': key} for key, _ in secrets.items()]}
 
-    def update_secret(self, SecretId: str, SecretString: str) -> None:
+    def update_secret(self, SecretId: str, SecretString: str) -> None:  # noQA - Argument names chosen for AWS consistency
         secrets = self._mocked_secrets()
         secrets[SecretId] = SecretString
 

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from typing import Any
 from zipfile import ZipFile
 from .base import get_beanstalk_real_url
+from .env_base import s3Base
 from .env_manager import EnvManager
 from .env_utils import is_stg_or_prd_env, prod_bucket_env, full_env_name, get_env_real_url, EnvUtils
 from .exceptions import InferredBucketConflict
@@ -59,42 +60,9 @@ class HealthPageKey:  # This is moving here from cgap-portal.
     UTILS_VERSION = 'utils_version'
 
 
-class s3Utils(object):  # NOQA - This class name violates style rules, but a lot of things might break if we change it.
-
-    # Some extra variables used in setup here so that other modules can be consistent with chosen values.
-
-    SYS_BUCKET_SUFFIX = "system"
-    OUTFILE_BUCKET_SUFFIX = "wfoutput"
-    RAW_BUCKET_SUFFIX = "files"
-    BLOB_BUCKET_SUFFIX = "blobs"
-    METADATA_BUCKET_SUFFIX = "metadata-bundles"
-    TIBANNA_OUTPUT_BUCKET_SUFFIX = 'tibanna-output'
-    TIBANNA_CWLS_BUCKET_SUFFIX = 'tibanna-cwls'
+class s3Utils(s3Base):  # NOQA - This class name violates style rules, but a lot of things might break if we change it.
 
     s3_encrypt_key_id = None  # default. might be overridden based on health page in various places below
-
-    EB_PREFIX = "elasticbeanstalk"
-    EB_AND_ENV_PREFIX = EB_PREFIX + "-%s-"  # = "elasticbeanstalk-%s-"
-
-    SYS_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + SYS_BUCKET_SUFFIX            # = "elasticbeanstalk-%s-system"
-    OUTFILE_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + OUTFILE_BUCKET_SUFFIX    # = "elasticbeanstalk-%s-wfoutput"
-    RAW_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + RAW_BUCKET_SUFFIX            # = "elasticbeanstalk-%s-files"
-    BLOB_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + BLOB_BUCKET_SUFFIX          # = "elasticbeanstalk-%s-blobs"
-    METADATA_BUCKET_TEMPLATE = EB_AND_ENV_PREFIX + METADATA_BUCKET_SUFFIX  # = "elasticbeanstalk-%s-metadata-bundles"
-    TIBANNA_OUTPUT_BUCKET_TEMPLATE = TIBANNA_OUTPUT_BUCKET_SUFFIX          # = "tibanna-output" (no prefix)
-    TIBANNA_CWLS_BUCKET_TEMPLATE = TIBANNA_CWLS_BUCKET_SUFFIX              # = "tibanna-cwls" (no prefix)
-
-    # NOTE: These were deprecated and retained for compatibility in dcicutils 2.
-    #       For dcicutils 3.0, please rewrite uses as HealthPageKey.xyz names.
-    # SYS_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.SYSTEM_BUCKET                     # = 'system_bucket'
-    # OUTFILE_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.PROCESSED_FILE_BUCKET         # = 'processed_file_bucket'
-    # RAW_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.FILE_UPLOAD_BUCKET                # = 'file_upload_bucket'
-    # BLOB_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.BLOB_BUCKET                      # = 'blob_bucket'
-    # METADATA_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.METADATA_BUNDLES_BUCKET      # = 'metadata_bundles_bucket'
-    # TIBANNA_CWLS_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.TIBANNA_CWLS_BUCKET      # = 'tibanna_cwls_bucket'
-    # TIBANNA_OUTPUT_BUCKET_HEALTH_PAGE_KEY = HealthPageKey.TIBANNA_OUTPUT_BUCKET  # = 'tibanna_output_bucket'
-    # This is also deprecated, even though not a bucket name. Use HealthPageKey.ELASTICSEARCH.
-    # ELASTICSEARCH_HEALTH_PAGE_KEY = HealthPageKey.ELASTICSEARCH                  # = 'elasticsearch'
 
     @staticmethod  # backward compatibility in case other repositories are using this
     def verify_and_get_env_config(s3_client, global_bucket: str, env):

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -39,6 +39,7 @@ class HealthPageKey:  # This is moving here from cgap-portal.
     FILE_UPLOAD_BUCKET = 'file_upload_bucket'                # = s3Utils.RAW_BUCKET_HEALTH_PAGE_KEY
     FOURSIGHT = 'foursight'
     FOURSIGHT_BUCKET_PREFIX = 'foursight_bucket_prefix'
+    HIGLASS = 'higlass'
     IDENTITY = 'identity'
     INDEXER = 'indexer'
     INDEX_SERVER = 'index_server'
@@ -136,20 +137,20 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
                 self.url = portal_url
                 es_url = self._infer_es_url()
                 self.env_manager = EnvManager.compose(portal_url=self.url, es_url=es_url, env_name=env, s3=self.s3)
-                self.s3_encrypt_key_id = self._health_json_get(HealthPageKey.S3_ENCRYPT_KEY_ID, default=None)
-                sys_bucket_from_health_page = self._health_json_get(HealthPageKey.SYSTEM_BUCKET)
-                outfile_bucket_from_health_page = self._health_json_get(HealthPageKey.PROCESSED_FILE_BUCKET)
-                raw_file_bucket_from_health_page = self._health_json_get(HealthPageKey.FILE_UPLOAD_BUCKET)
-                blob_bucket_from_health_page = self._health_json_get(HealthPageKey.BLOB_BUCKET)
-                metadata_bucket_from_health_page = self._health_json_get(HealthPageKey.METADATA_BUNDLES_BUCKET,
-                                                                         # N/A for 4DN
-                                                                         default=None)
-                tibanna_cwls_bucket_from_health_page = self._health_json_get(HealthPageKey.TIBANNA_CWLS_BUCKET,
-                                                                             # new, so it may be missing
-                                                                             default=None)
-                tibanna_output_bucket_from_health_page = self._health_json_get(HealthPageKey.TIBANNA_OUTPUT_BUCKET,
-                                                                               # new, so it may be missing
-                                                                               default=None)
+                self.s3_encrypt_key_id = self.health_json_get(HealthPageKey.S3_ENCRYPT_KEY_ID, default=None)
+                sys_bucket_from_health_page = self.health_json_get(HealthPageKey.SYSTEM_BUCKET)
+                outfile_bucket_from_health_page = self.health_json_get(HealthPageKey.PROCESSED_FILE_BUCKET)
+                raw_file_bucket_from_health_page = self.health_json_get(HealthPageKey.FILE_UPLOAD_BUCKET)
+                blob_bucket_from_health_page = self.health_json_get(HealthPageKey.BLOB_BUCKET)
+                metadata_bucket_from_health_page = self.health_json_get(HealthPageKey.METADATA_BUNDLES_BUCKET,
+                                                                        # N/A for 4DN
+                                                                        default=None)
+                tibanna_cwls_bucket_from_health_page = self.health_json_get(HealthPageKey.TIBANNA_CWLS_BUCKET,
+                                                                            # new, so it may be missing
+                                                                            default=None)
+                tibanna_output_bucket_from_health_page = self.health_json_get(HealthPageKey.TIBANNA_OUTPUT_BUCKET,
+                                                                              # new, so it may be missing
+                                                                              default=None)
                 sys_bucket = sys_bucket_from_health_page  # OK to overwrite because we checked it's None above
                 if outfile_bucket and outfile_bucket != outfile_bucket_from_health_page:
                     raise InferredBucketConflict(kind="outfile", specified=outfile_bucket,
@@ -206,7 +207,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
 
                     es_url = self._infer_es_url()
                     self.env_manager = EnvManager.compose(portal_url=self.url, es_url=es_url, env_name=env, s3=self.s3)
-                    self.s3_encrypt_key_id = self._health_json_get(HealthPageKey.S3_ENCRYPT_KEY_ID, default=None)
+                    self.s3_encrypt_key_id = self.health_json_get(HealthPageKey.S3_ENCRYPT_KEY_ID, default=None)
 
                 # TODO: This branch is not setting self.global_env_bucket_manager, but it _could_ do that from the
                 #       description. -kmp 21-Aug-2021
@@ -237,12 +238,19 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
 
     def _infer_es_url(self):
         """Obtains the es URL from the health page, on a theory that the """
-        es_url = self._health_json_get(HealthPageKey.ELASTICSEARCH)
-        if not es_url.startswith("http"):  # will match http: and https:
+        es_url = self.health_json_get(HealthPageKey.ELASTICSEARCH)
+        if es_url is not None and not es_url.startswith("http"):  # will match http: and https:
             es_url = f"https://{es_url}"
         return es_url
 
-    def _health_json_get(self, health_page_key, default=None):
+    def _infer_higlass_url(self):  # Not used yet. Need to figure out where this value would go. -kmp 12-Jul-2022
+        """Obtains the es URL from the health page, on a theory that the """
+        higlass_url = self.health_json_get(HealthPageKey.HIGLASS)
+        if higlass_url is not None and not higlass_url.startswith("http"):  # will match http: and https:
+            higlass_url = f"https://{higlass_url}"
+        return higlass_url
+
+    def health_json_get(self, health_page_key, default=None):
         health_json_url = self._health_json_url or f"{self.url}/health?format=json"
         logger.warning('health json url: {}'.format(health_json_url))
         self._health_json_url = health_json_url

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -8,8 +8,8 @@ from io import BytesIO
 from zipfile import ZipFile
 from .base import get_beanstalk_real_url
 from .env_manager import EnvManager
-from .env_utils import is_stg_or_prd_env, prod_bucket_env, full_env_name, infer_foursight_from_env, get_env_real_url, EnvUtils
-from .exceptions import InferredBucketConflict, BeanstalkOperationNotImplemented
+from .env_utils import is_stg_or_prd_env, prod_bucket_env, full_env_name, get_env_real_url, EnvUtils
+from .exceptions import InferredBucketConflict
 from .misc_utils import PRINT, exported, merge_key_value_dict_lists, key_value_dict
 
 
@@ -131,7 +131,7 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
                 # env_config = self.verify_and_get_env_config(s3_client=self.s3, global_bucket=global_bucket, env=env)
                 # ff_url = env_config['fourfront']
                 # self.env_manager = global_manager = EnvManager(env_name=env, s3=self.s3)
-                portal_url = get_env_real_url(env)  # self.env_manager.portal_url.rstrip('/')  # TO DO: LOOK UP FROM EnvUtils
+                portal_url = get_env_real_url(env)  # self.env_manager.portal_url.rstrip('/')
                 env = full_env_name(env)
                 self.url = portal_url
                 es_url = self._infer_es_url()
@@ -197,7 +197,9 @@ class s3Utils(object):  # NOQA - This class name violates style rules, but a lot
                 if env:
                     if is_stg_or_prd_env(env):
                         self.url = get_beanstalk_real_url(env)  # done BEFORE prod_bucket_env blurring stg/prd
-                        env = prod_bucket_env(env)  # used to return fourfront-webprod for BOTH staging and data
+                        # this used to return fourfront-webprod for BOTH staging and data
+                        # now in fact this doesn't even return, it throws an error.
+                        env = prod_bucket_env(env)  # noQA - raises error if called
                     else:
                         env = full_env_name(env)
                         self.url = get_beanstalk_real_url(env)  # done AFTER maybe prepending cgap- or foursight-.

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -5,7 +5,7 @@ import re
 import structlog
 
 from botocore.exceptions import ClientError
-from .ecr_utils import CGAP_ECR_REGION
+from .common import REGION as COMMON_REGION
 from .misc_utils import PRINT, full_class_name
 
 
@@ -28,7 +28,7 @@ def assume_identity():
         name of the environment.
     """
     secret_name = os.environ.get(GLOBAL_APPLICATION_CONFIGURATION, 'dev/beanstalk/cgap-dev')
-    region_name = CGAP_ECR_REGION  # us-east-1, must match ECR/ECS Region
+    region_name = COMMON_REGION  # us-east-1, must match ECR/ECS Region, which also imports its default from .common
     session = boto3.session.Session(region_name=region_name)
     client = session.client(
         service_name='secretsmanager',
@@ -80,7 +80,10 @@ class SecretsTable:
     NOTE: We could later extend this to allow creating or modifying the table as well,
     but that might involve extra permissions and be less broadly useful.
     """
-    def __init__(self, name, secretsmanager_client=None, stage=None):
+
+    REGION = COMMON_REGION
+
+    def __init__(self, name, secretsmanager_client=None, stage=None, region=None):
         """
         :param name: The SecretId of the secret to help with.
         :param secretsmanager_client: A Boto3 Secrets Manager client to use. If unsupplied, one is created.
@@ -88,7 +91,7 @@ class SecretsTable:
         if not str or not isinstance(name, str):
             raise ValueError(f"Bad secret name: {name}")
         self.secretsmanager_client = (secretsmanager_client
-                                      or boto3.client('secretsmanager', region_name=CGAP_ECR_REGION))
+                                      or boto3.client('secretsmanager', region_name=region or self.REGION))
         self.name = name
         self.stage = stage
 

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import boto3
 import json
@@ -5,8 +6,10 @@ import re
 import structlog
 
 from botocore.exceptions import ClientError
+from typing import Optional
 from .common import REGION as COMMON_REGION
-from .misc_utils import PRINT, full_class_name
+from .lang_utils import a_or_an
+from .misc_utils import PRINT, full_class_name, override_environ
 
 
 logger = structlog.getLogger(__name__)
@@ -20,14 +23,27 @@ logger = structlog.getLogger(__name__)
 GLOBAL_APPLICATION_CONFIGURATION = 'IDENTITY'
 
 
-def assume_identity():
+# TODO: Rethink whether this should be a constant. Maybe it should be a function of the identity_kind?
+#       Maybe the caller should pass a default and this function should have none. -kmp 18-Jul-2022
+LEGACY_DEFAULT_IDENTITY_NAME = 'dev/beanstalk/cgap-dev'
+
+
+def get_identity_name(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION):
+    return os.environ.get(identity_kind, LEGACY_DEFAULT_IDENTITY_NAME)
+
+
+def identity_is_defined(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> bool:
+    return bool(os.environ.get(identity_kind))
+
+
+def get_identity_secrets(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> dict:
     """ Grabs application identity from the secrets manager.
         Looks for environment variable IDENTITY, which should contain the name of
         a secret in secretsmanager that is a JSON blob of core configuration information.
         Default value is current value in the test account. This name should be the
         name of the environment.
     """
-    secret_name = os.environ.get(GLOBAL_APPLICATION_CONFIGURATION, 'dev/beanstalk/cgap-dev')
+    secret_name = get_identity_name(identity_kind)
     region_name = COMMON_REGION  # us-east-1, must match ECR/ECS Region, which also imports its default from .common
     session = boto3.session.Session(region_name=region_name)
     client = session.client(
@@ -53,12 +69,109 @@ def assume_identity():
         # Decrypts secret using the associated KMS CMK.
         # Depending on whether the secret is a string or binary, one of these fields will be populated.
         if 'SecretString' in get_secret_value_response:
-            identity = json.loads(get_secret_value_response['SecretString'])
+            identity_secrets = json.loads(get_secret_value_response['SecretString'])
         else:
             raise Exception('Got unexpected response structure from boto3')
-    if not identity:
+    if not identity_secrets:
         raise Exception('Identity could not be found! Check the secret name.')
-    return identity
+    elif not isinstance(identity_secrets, dict):
+        raise Exception("Identity was not in expected dictionary form.")
+    return identity_secrets
+
+
+assume_identity = get_identity_secrets  # assume_identity is deprecated. Please rewrite
+
+
+def apply_overrides(*, secrets: dict, rename_keys: Optional[dict] = None,
+                    override_values: Optional[dict] = None) -> dict:
+    if rename_keys:
+        secrets = secrets.copy()
+        for key, new_name in rename_keys.items():
+            if new_name in secrets:
+                raise ValueError(f"Cannot rename {key} to {new_name}"
+                                 f" because {a_or_an(new_name)} attribute already exists.")
+            if key not in secrets:
+                raise ValueError(f"Cannot rename {key} to {new_name} because the secrets has no {key} attribute.")
+            secrets[new_name] = secrets.pop(key)
+    if override_values:
+        secrets = dict(secrets, **override_values)
+    return secrets
+
+
+@contextlib.contextmanager
+def assumed_identity_if(only_if: bool, *,
+                        identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION,
+                        only_if_missing: Optional[str] = None,
+                        require_identity: bool = False,
+                        rename_keys: Optional[dict] = None,
+                        override_values: Optional[dict] = None):
+    with assumed_identity(identity_kind=identity_kind, only_if=only_if, only_if_missing=only_if_missing,
+                          require_identity=require_identity, rename_keys=rename_keys, override_values=override_values):
+        yield
+
+
+@contextlib.contextmanager
+def assumed_identity(*,
+                     identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION,
+                     only_if: bool = True,
+                     only_if_missing: Optional[str] = None,
+                     require_identity: bool = False,
+                     rename_keys: Optional[dict] = None,
+                     override_values: Optional[dict] = None):
+    """
+    Assumes a given identity in a context.
+
+    The rename_keys happen before the override_values.
+
+    >>> apply_overrides(secrets={'x': 1, 'y': 2}, rename_keys={'x': 'ex', 'y': 'why'}, override_values={'x': 3, 'z': 9})
+    {'ex': 1, 'why': 2, 'z': 9, 'x': 3}
+
+    NOTE: This assumes that global_env_bucket is in the GAC and not otherwise,
+          so it tests
+
+    :param identity_kind: The name of the identity to assume (default 'IDENTITY')
+    :param only_if: Whether to try assuming identity at all (default True)
+    :param only_if_missing: The name of an environment variable that would only be in the GAC.
+       Load the GAC only if this variable is not set. Default is None, meaning load unconditionally.
+    :param require_identity: Whether to raise an error if the identity_kind environment variable is not bound.
+    :param rename_keys: If present, a dictionary mapping keys to override keys. Default None.
+    :param override_values: If present, a dictionary mapping keys to override values. Default None.
+
+    """
+    if only_if and (not only_if_missing or not os.environ.get(only_if_missing)):
+        identity_name = get_identity_name(identity_kind=identity_kind)
+        if identity_name:
+            secrets = get_identity_secrets(identity_kind=identity_kind)
+            secrets = apply_overrides(secrets=secrets, rename_keys=rename_keys, override_values=override_values)
+            if only_if_missing and only_if_missing not in secrets:
+                raise RuntimeError(f"No {only_if_missing} was found where expected"
+                                   f" in {identity_kind} secrets at {identity_name}.")
+            with override_environ(**secrets):
+                yield
+                return  # Nothing to do after that
+
+        elif require_identity:
+            raise RuntimeError(f"An identity was not defined in environment variable {identity_kind}.")
+
+    yield
+
+
+def apply_identity(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION,
+                   rename_keys: Optional[dict] = None, override_values: Optional[dict] = None):
+    """
+    Assumes an identity globally by assigning environment variables.
+
+    Since this is assumed to be an initial startup action, we assume it's not already been done and don't
+    offer the only_if_missing mechanism that the assumed_identity context manager offers.
+
+    """
+    if identity_is_defined(identity_kind):
+        secrets = get_identity_secrets(identity_kind=identity_kind)
+        secrets = apply_overrides(secrets=secrets, rename_keys=rename_keys, override_values=override_values)
+        for var, val in secrets.items():
+            os.environ[var] = val
+    else:
+        raise RuntimeError(f"An identity was not defined in environment variable {identity_kind}.")
 
 
 # Some hints about how to manipulate secrets are here:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.2.3b57"  # originally based on 3.6.0, but merges 3.15.0, eventually to be "4.0.0"
+version = "3.15.0.3b57"  # originally based on 3.6.0, but merges 3.15.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b50"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.1.3b51"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.15.0.3b57"  # originally based on 3.6.0, but merges 3.15.0, eventually to be "4.0.0"
+version = "3.16.0.3b58"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.16.0.3b62"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
+version = "3.16.0.3b63"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.16.0.3b59"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
+version = "3.16.0.3b61"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b48"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.1.3b49"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b47"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.1.3b48"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.16.0.3b61"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
+version = "3.16.0.3b62"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b51"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.2.3b52"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b45"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.1.3b46"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.2.3b56"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
+version = "3.14.2.3b57"  # originally based on 3.6.0, but merges 3.15.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.2.3b54"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
+version = "3.14.2.3b55"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b46"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.1.3b47"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.2.3b53"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
+version = "3.14.2.3b54"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.16.0.3b58"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
+version = "3.16.0.3b59"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.1.3b49"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
+version = "3.14.1.3b50"  # originally based on 3.6.0, but merges 3.14.1, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.16.0.3b63"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
+version = "3.16.0.3b64"  # originally based on 3.6.0, but merges 3.16.0, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.2.3b55"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
+version = "3.14.2.3b56"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "3.14.2.3b52"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
+version = "3.14.2.3b53"  # originally based on 3.6.0, but merges 3.14.2, eventually to be "4.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import requests
 
 from dcicutils.common import LEGACY_GLOBAL_ENV_BUCKET
-from dcicutils.env_utils import EnvUtils
+from dcicutils.env_utils import LegacyController, EnvUtils
 from dcicutils.ff_mocks import IntegratedFixture
 from .conftest_settings import TEST_DIR, INTEGRATED_ENV
 
@@ -15,6 +15,30 @@ def _portal_health_get(namespace, portal_url, key):
     assert health_json['namespace'] == namespace  # check we're talking to proper host
     return health_json[key]
 
+
+# When we've rewritten these tests:
+# we can
+# (a) disable tests in test_env_utils_legacy.py and test_env_utils_orchestrated_legacy_compatibility.py
+#     perhaps by just renaming those to .py.DISABLED
+# (b) fix these tests:
+#         test/test_ff_utils.py::test_unified_authentication_unit FAILED
+#         test/test_ff_utils.py::test_get_authentication_with_server_unit FAILED
+#         test/test_ff_utils.py::test_are_counts_even_unit[True-sample_counts0] FAILED
+#         test/test_ff_utils.py::test_are_counts_even_unit[False-sample_counts1] FAILED
+#         test/test_s3_utils.py::test_read_s3_unit FAILED
+#         test/test_s3_utils.py::test_get_file_size_unit FAILED
+#         test/test_s3_utils.py::test_size_unit FAILED
+#         test/test_s3_utils.py::test_get_file_size_in_gb_unit FAILED
+#         test/test_s3_utils.py::test_read_s3_zip_unit FAILED
+#         test/test_s3_utils.py::test_unzip_s3_to_s3_unit[-fastqc_report.html] FAILED
+#         test/test_s3_utils.py::test_unzip_s3_to_s3_unit[2-qc_report.html] FAILED
+#         test/test_s3_utils.py::test_unzip_s3_to_s3_store_results_unit FAILED
+#         test/test_s3_utils.py::test_s3_utils_buckets_modern FAILED
+#         test/test_s3_utils.py::test_env_manager FAILED
+#         test/test_s3_utils.py::test_env_manager_verify_and_get_env_config FAILED
+#         test/test_s3_utils.py::test_env_manager_compose FAILED
+# (c) comment out the next line:
+LegacyController.LEGACY_DISPATCH_ENABLED = True
 
 os.environ['GLOBAL_ENV_BUCKET'] = LEGACY_GLOBAL_ENV_BUCKET
 os.environ['ENV_NAME'] = INTEGRATED_ENV

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -74,7 +74,9 @@ def integrated_s3_info(integrated_names):
                           Key=integrated_names['zip_filename2'])
 
     return {
+        'ffenv': INTEGRATED_ENV,
         's3Obj': s3_obj,
+        'bucket': s3_obj.outfile_bucket,
         'filename': test_filename,
         'zip_filename': integrated_names['zip_filename'],
         'zip_filename2': integrated_names['zip_filename2'],

--- a/test/data_files/foursight-prod-envs/blue.ecosystem
+++ b/test/data_files/foursight-prod-envs/blue.ecosystem
@@ -1,0 +1,67 @@
+{
+    "full_env_prefix": "fourfront-",
+    "foursight_url_prefix": "https://foursight.4dnucleome.org/view/",
+    "orchestrated_app": "fourfront",
+    "prd_env_name": "fourfront-production-blue",
+    "stg_env_name": "fourfront-production-green",
+    "test_envs": ["fourfront-mastertest", "fourfront-hotseat", "fourfront-webdev"],
+    "hotseat_envs": ["fourfront-hotseat"],
+    "stage_mirroring_enabled": true,
+    "webprod_pseudo_env": "fourfront-webprod",
+    "production_ecr_repository": "fourfront-production",
+    "default_workflow_env": "fourfront-webdev",
+    "public_url_table": [
+        {
+            "name": "data",
+            "url": "https://data.4dnucleome.org",
+            "host": "data.4dnucleome.org",
+            "environment": "fourfront-production-blue"
+        },
+        {
+            "name": "staging",
+            "url": "http://staging.4dnucleome.org",
+            "host": "staging.4dnucleome.org",
+            "environment": "fourfront-production-green"
+        },
+        {
+            "name": "mastertest",
+            "url": "https://mastertest.4dnucleome.org",
+            "host": "mastertest.4dnucleome.org",
+            "environment": "fourfront-mastertest"
+        },
+        {
+            "name": "hotseat",
+            "url": "http://fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com:80",
+            "host": "fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com",
+            "environment": "fourfront-hotseat"
+        },
+        {
+            "name": "webdev",
+            "url": "http://fourfront-webdev-1726959209.us-east-1.elb.amazonaws.com:80",
+            "host": "fourfront-webdev-1726959209.us-east-1.elb.amazonaws.com",
+            "environment": "fourfront-webdev"
+        }
+    ],
+    "foursight_bucket_prefix": "foursight",
+    "foursight_bucket_table": {
+        "data": {
+            "dev": "foursight-dev-data",
+            "prod": "foursight-prod-data"
+        },
+        "staging": {
+            "dev": "foursight-dev-staging", "prod": "foursight-prod-staging"
+        },
+        "mastertest": {
+            "dev": "foursight-dev-mastertest",
+            "prod": "foursight-prod-mastertest"
+        },
+        "hotseat": {
+            "dev": "foursight-dev-hotseat",
+            "prod": "foursight-prod-hotseat"
+        },
+        "webdev": {
+            "dev": "foursight-dev-webdev",
+            "prod": "foursight-prod-webdev"
+        }
+    }
+}

--- a/test/data_files/foursight-prod-envs/blue.ecosystem
+++ b/test/data_files/foursight-prod-envs/blue.ecosystem
@@ -7,7 +7,6 @@
     "test_envs": ["fourfront-mastertest", "fourfront-hotseat", "fourfront-webdev"],
     "hotseat_envs": ["fourfront-hotseat"],
     "stage_mirroring_enabled": true,
-    "webprod_pseudo_env": "fourfront-webprod",
     "production_ecr_repository": "fourfront-production",
     "default_workflow_env": "fourfront-webdev",
     "public_url_table": [

--- a/test/data_files/foursight-prod-envs/fourfront-hotseat
+++ b/test/data_files/foursight-prod-envs/fourfront-hotseat
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-prod-envs/fourfront-mastertest
+++ b/test/data_files/foursight-prod-envs/fourfront-mastertest
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-prod-envs/fourfront-production-blue
+++ b/test/data_files/foursight-prod-envs/fourfront-production-blue
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-prod-envs/fourfront-production-green
+++ b/test/data_files/foursight-prod-envs/fourfront-production-green
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-prod-envs/fourfront-webdev
+++ b/test/data_files/foursight-prod-envs/fourfront-webdev
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-prod-envs/green.ecosystem
+++ b/test/data_files/foursight-prod-envs/green.ecosystem
@@ -1,0 +1,67 @@
+{
+    "full_env_prefix": "fourfront-",
+    "foursight_url_prefix": "https://foursight.4dnucleome.org/view/",
+    "orchestrated_app": "fourfront",
+    "prd_env_name": "fourfront-production-green",
+    "stg_env_name": "fourfront-production-blue",
+    "test_envs": ["fourfront-mastertest", "fourfront-hotseat", "fourfront-webdev"],
+    "hotseat_envs": ["fourfront-hotseat"],
+    "stage_mirroring_enabled": true,
+    "webprod_pseudo_env": "fourfront-webprod",
+    "production_ecr_repository": "fourfront-production",
+    "default_workflow_env": "fourfront-webdev",
+    "public_url_table": [
+        {
+            "name": "data",
+            "url": "https://data.4dnucleome.org",
+            "host": "data.4dnucleome.org",
+            "environment": "fourfront-production-green"
+        },
+        {
+            "name": "staging",
+            "url": "http://staging.4dnucleome.org",
+            "host": "staging.4dnucleome.org",
+            "environment": "fourfront-production-blue"
+        },
+        {
+            "name": "mastertest",
+            "url": "https://mastertest.4dnucleome.org",
+            "host": "mastertest.4dnucleome.org",
+            "environment": "fourfront-mastertest"
+        },
+        {
+            "name": "hotseat",
+            "url": "http://fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com:80",
+            "host": "fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com",
+            "environment": "fourfront-hotseat"
+        },
+        {
+            "name": "webdev",
+            "url": "http://fourfront-webdev-1726959209.us-east-1.elb.amazonaws.com:80",
+            "host": "fourfront-webdev-1726959209.us-east-1.elb.amazonaws.com",
+            "environment": "fourfront-webdev"
+        }
+    ],
+    "foursight_bucket_prefix": "foursight",
+    "foursight_bucket_table": {
+        "data": {
+            "dev": "foursight-dev-data",
+            "prod": "foursight-prod-data"
+        },
+        "staging": {
+            "dev": "foursight-dev-staging", "prod": "foursight-prod-staging"
+        },
+        "mastertest": {
+            "dev": "foursight-dev-mastertest",
+            "prod": "foursight-prod-mastertest"
+        },
+        "hotseat": {
+            "dev": "foursight-dev-hotseat",
+            "prod": "foursight-prod-hotseat"
+        },
+        "webdev": {
+            "dev": "foursight-dev-webdev",
+            "prod": "foursight-prod-webdev"
+        }
+    }
+}

--- a/test/data_files/foursight-prod-envs/green.ecosystem
+++ b/test/data_files/foursight-prod-envs/green.ecosystem
@@ -7,7 +7,6 @@
     "test_envs": ["fourfront-mastertest", "fourfront-hotseat", "fourfront-webdev"],
     "hotseat_envs": ["fourfront-hotseat"],
     "stage_mirroring_enabled": true,
-    "webprod_pseudo_env": "fourfront-webprod",
     "production_ecr_repository": "fourfront-production",
     "default_workflow_env": "fourfront-webdev",
     "public_url_table": [

--- a/test/data_files/foursight-prod-envs/main.ecosystem
+++ b/test/data_files/foursight-prod-envs/main.ecosystem
@@ -1,0 +1,1 @@
+{"ecosystem": "green"}

--- a/test/data_files/foursight-test-envs/fourfront-hotseat
+++ b/test/data_files/foursight-test-envs/fourfront-hotseat
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-test-envs/fourfront-mastertest
+++ b/test/data_files/foursight-test-envs/fourfront-mastertest
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-test-envs/fourfront-prd
+++ b/test/data_files/foursight-test-envs/fourfront-prd
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-test-envs/fourfront-stg
+++ b/test/data_files/foursight-test-envs/fourfront-stg
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-test-envs/fourfront-webdev
+++ b/test/data_files/foursight-test-envs/fourfront-webdev
@@ -1,0 +1,1 @@
+{"ecosystem": "main"}

--- a/test/data_files/foursight-test-envs/main.ecosystem
+++ b/test/data_files/foursight-test-envs/main.ecosystem
@@ -1,0 +1,67 @@
+{
+    "full_env_prefix": "fourfront-",
+    "foursight_url_prefix": "https://foursight.4dnucleome.org/view/",
+    "orchestrated_app": "fourfront",
+    "prd_env_name": "fourfront-prd",
+    "stg_env_name": "fourfront-stg",
+    "test_envs": ["fourfront-mastertest", "fourfront-hotseat", "fourfront-webdev"],
+    "hotseat_envs": ["fourfront-hotseat"],
+    "stage_mirroring_enabled": true,
+    "webprod_pseudo_env": "fourfront-webprod",
+    "production_ecr_repository": "fourfront-production",
+    "default_workflow_env": "fourfront-webdev",
+    "public_url_table": [
+        {
+            "name": "data",
+            "url": "https://data.4dnucleome.org",
+            "host": "data.4dnucleome.org",
+            "environment": "fourfront-prd"
+        },
+        {
+            "name": "staging",
+            "url": "http://staging.4dnucleome.org",
+            "host": "staging.4dnucleome.org",
+            "environment": "fourfront-stg"
+        },
+        {
+            "name": "mastertest",
+            "url": "https://mastertest.4dnucleome.org",
+            "host": "mastertest.4dnucleome.org",
+            "environment": "fourfront-mastertest"
+        },
+        {
+            "name": "hotseat",
+            "url": "http://fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com:80",
+            "host": "fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com",
+            "environment": "fourfront-hotseat"
+        },
+        {
+            "name": "webdev",
+            "url": "http://fourfront-webdev-1726959209.us-east-1.elb.amazonaws.com:80",
+            "host": "fourfront-webdev-1726959209.us-east-1.elb.amazonaws.com",
+            "environment": "fourfront-webdev"
+        }
+    ],
+    "foursight_bucket_prefix": "foursight",
+    "foursight_bucket_table": {
+        "data": {
+            "dev": "foursight-dev-data",
+            "prod": "foursight-prod-data"
+        },
+        "staging": {
+            "dev": "foursight-dev-staging", "prod": "foursight-prod-staging"
+        },
+        "mastertest": {
+            "dev": "foursight-dev-mastertest",
+            "prod": "foursight-prod-mastertest"
+        },
+        "hotseat": {
+            "dev": "foursight-dev-hotseat",
+            "prod": "foursight-prod-hotseat"
+        },
+        "webdev": {
+            "dev": "foursight-dev-webdev",
+            "prod": "foursight-prod-webdev"
+        }
+    }
+}

--- a/test/data_files/foursight-test-envs/main.ecosystem
+++ b/test/data_files/foursight-test-envs/main.ecosystem
@@ -7,7 +7,6 @@
     "test_envs": ["fourfront-mastertest", "fourfront-hotseat", "fourfront-webdev"],
     "hotseat_envs": ["fourfront-hotseat"],
     "stage_mirroring_enabled": true,
-    "webprod_pseudo_env": "fourfront-webprod",
     "production_ecr_repository": "fourfront-production",
     "default_workflow_env": "fourfront-webdev",
     "public_url_table": [

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -75,3 +75,25 @@ def using_fresh_ff_state():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap
+
+
+@decorator()
+def using_fresh_cgap_deployed_state():
+    def wrap(function):
+        @functools.wraps(function)
+        def _wrapped(*args, **kwargs):
+            with fresh_cgap_deployed_state():
+                return function(*args, **kwargs)
+        return _wrapped
+    return wrap
+
+
+@decorator()
+def using_fresh_ff_deployed_state():
+    def wrap(function):
+        @functools.wraps(function)
+        def _wrapped(*args, **kwargs):
+            with fresh_ff_deployed_state():
+                return function(*args, **kwargs)
+        return _wrapped
+    return wrap

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -13,87 +13,87 @@ TEST_FF_ECOSYSTEM_DECLARATION = os.path.join(TEST_DIR, "data_files/foursight-tes
 
 
 @contextlib.contextmanager
-def fresh_legacy_state():
-    with EnvUtils.fresh_state_from(data={'is_legacy': True}):
+def fresh_legacy_state_for_testing():
+    with EnvUtils.fresh_testing_state_from(data={'is_legacy': True}):
         yield
 
 
 @contextlib.contextmanager
-def fresh_cgap_state():
+def fresh_cgap_state_for_testing():
     cgap_declaration = json.loads(file_contents(TEST_CGAP_ECOSYSTEM_DECLARATION))
-    with EnvUtils.fresh_state_from(data=cgap_declaration, global_bucket=EnvUtils.CGAP_BUCKET):
+    with EnvUtils.fresh_testing_state_from(data=cgap_declaration, global_bucket=EnvUtils.CGAP_BUCKET):
         yield
 
 
 @contextlib.contextmanager
-def fresh_ff_state():
+def fresh_ff_state_for_testing():
     ff_declaration = json.loads(file_contents(TEST_FF_ECOSYSTEM_DECLARATION))
-    with EnvUtils.fresh_state_from(data=ff_declaration, global_bucket=EnvUtils.FF_BUCKET):
+    with EnvUtils.fresh_testing_state_from(data=ff_declaration, global_bucket=EnvUtils.FF_BUCKET):
         yield
 
 
 @contextlib.contextmanager
-def fresh_cgap_deployed_state():
-    with EnvUtils.fresh_cgap_deployed_state():
+def fresh_cgap_deployed_state_for_testing():
+    with EnvUtils.fresh_cgap_deployed_state_for_testing():
         yield
 
 
 @contextlib.contextmanager
-def fresh_ff_deployed_state():
-    with EnvUtils.fresh_ff_deployed_state():
+def fresh_ff_deployed_state_for_testing():
+    with EnvUtils.fresh_ff_deployed_state_for_testing():
         yield
 
 
 @decorator()
-def using_fresh_legacy_state():
+def using_fresh_legacy_state_for_testing():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with fresh_legacy_state():
+            with fresh_legacy_state_for_testing():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap
 
 
 @decorator()
-def using_fresh_cgap_state():
+def using_fresh_cgap_state_for_testing():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with fresh_cgap_state():
+            with fresh_cgap_state_for_testing():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap
 
 
 @decorator()
-def using_fresh_ff_state():
+def using_fresh_ff_state_for_testing():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with fresh_ff_state():
+            with fresh_ff_state_for_testing():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap
 
 
 @decorator()
-def using_fresh_cgap_deployed_state():
+def using_fresh_cgap_deployed_state_for_testing():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with fresh_cgap_deployed_state():
+            with fresh_cgap_deployed_state_for_testing():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap
 
 
 @decorator()
-def using_fresh_ff_deployed_state():
+def using_fresh_ff_deployed_state_for_testing():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with fresh_ff_deployed_state():
+            with fresh_ff_deployed_state_for_testing():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -8,6 +8,10 @@ from dcicutils.misc_utils import file_contents, decorator
 from .conftest_settings import TEST_DIR
 
 
+TEST_CGAP_ECOSYSTEM_DECLARATION = os.path.join(TEST_DIR, "data_files/foursight-cgap-envs/main.ecosystem")
+TEST_FF_ECOSYSTEM_DECLARATION = os.path.join(TEST_DIR, "data_files/foursight-test-envs/main.ecosystem")
+
+
 @contextlib.contextmanager
 def fresh_legacy_state():
     with EnvUtils.fresh_state_from(data={'is_legacy': True}):
@@ -16,15 +20,27 @@ def fresh_legacy_state():
 
 @contextlib.contextmanager
 def fresh_cgap_state():
-    cgap_declaration = json.loads(file_contents(os.path.join(TEST_DIR,
-                                                             'data_files/foursight-cgap-envs/main.ecosystem')))
-    with EnvUtils.fresh_state_from(data=cgap_declaration):
+    cgap_declaration = json.loads(file_contents(TEST_CGAP_ECOSYSTEM_DECLARATION))
+    with EnvUtils.fresh_state_from(data=cgap_declaration, global_bucket=EnvUtils.CGAP_BUCKET):
         yield
 
 
 @contextlib.contextmanager
 def fresh_ff_state():
-    with EnvUtils.fresh_ff_state():
+    ff_declaration = json.loads(file_contents(TEST_FF_ECOSYSTEM_DECLARATION))
+    with EnvUtils.fresh_state_from(data=ff_declaration, global_bucket=EnvUtils.FF_BUCKET):
+        yield
+
+
+@contextlib.contextmanager
+def fresh_cgap_deployed_state():
+    with EnvUtils.fresh_cgap_deployed_state():
+        yield
+
+
+@contextlib.contextmanager
+def fresh_ff_deployed_state():
+    with EnvUtils.fresh_ff_deployed_state():
         yield
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -9,10 +9,22 @@ from .conftest_settings import TEST_DIR
 
 
 @contextlib.contextmanager
+def fresh_legacy_state():
+    with EnvUtils.fresh_state_from(data={'is_legacy': True}):
+        yield
+
+
+@contextlib.contextmanager
 def fresh_cgap_state():
     cgap_declaration = json.loads(file_contents(os.path.join(TEST_DIR,
                                                              'data_files/foursight-cgap-envs/main.ecosystem')))
     with EnvUtils.fresh_state_from(data=cgap_declaration):
+        yield
+
+
+@contextlib.contextmanager
+def fresh_ff_state():
+    with EnvUtils.fresh_ff_state():
         yield
 
 
@@ -21,7 +33,7 @@ def using_fresh_legacy_state():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with EnvUtils.fresh_state_from(data={'is_legacy': True}):
+            with fresh_legacy_state():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap
@@ -43,7 +55,7 @@ def using_fresh_ff_state():
     def wrap(function):
         @functools.wraps(function)
         def _wrapped(*args, **kwargs):
-            with EnvUtils.fresh_ff_state():
+            with fresh_ff_state():
                 return function(*args, **kwargs)
         return _wrapped
     return wrap

--- a/test/ini_files/blue.ini
+++ b/test/ini_files/blue.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-webprod-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/cg_any.ini
+++ b/test/ini_files/cg_any.ini
@@ -17,6 +17,7 @@ app_deployment = ${APP_DEPLOYMENT}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = ${ES_SERVER}
+higlass.server = ${HIGLASS_SERVER}
 snovault.app_version = ask-pip
 env.bucket = ${ENV_BUCKET}
 env.ecosystem = ${ENV_ECOSYSTEM}

--- a/test/ini_files/cg_any_alpha.ini
+++ b/test/ini_files/cg_any_alpha.ini
@@ -19,6 +19,7 @@ s3_encrypt_key_id = ${S3_ENCRYPT_KEY_ID}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = ${ES_SERVER}
+higlass.server = ${HIGLASS_SERVER}
 snovault.app_version = ask-pip
 env.bucket = ${ENV_BUCKET}
 env.ecosystem = ${ENV_ECOSYSTEM}

--- a/test/ini_files/cgap.ini
+++ b/test/ini_files/cgap.ini
@@ -17,6 +17,7 @@ app_deployment = beanstalk
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/cgap_alfa.ini
+++ b/test/ini_files/cgap_alfa.ini
@@ -19,6 +19,7 @@ s3_encrypt_key_id = ${S3_ENCRYPT_KEY_ID}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/cgap_alpha.ini
+++ b/test/ini_files/cgap_alpha.ini
@@ -19,6 +19,7 @@ s3_encrypt_key_id = ${S3_ENCRYPT_KEY_ID}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.us-east-1.es.amazonaws.com:80
+higlass.server = ${HIGLASS_SERVER}
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/cgapdev.ini
+++ b/test/ini_files/cgapdev.ini
@@ -17,6 +17,7 @@ app_deployment = ${APP_DEPLOYMENT}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/cgaptest.ini
+++ b/test/ini_files/cgaptest.ini
@@ -17,6 +17,7 @@ app_deployment = ${APP_DEPLOYMENT}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/cgapwolf.ini
+++ b/test/ini_files/cgapwolf.ini
@@ -17,6 +17,7 @@ app_deployment = ${APP_DEPLOYMENT}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/ff_any.ini
+++ b/test/ini_files/ff_any.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-${S3_BUCKET_ENV}-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = ${ES_SERVER}
+higlass.server = ${HIGLASS_SERVER}
 snovault.app_version = ask-pip
 env.bucket = ${ENV_BUCKET}
 env.ecosystem = ${ENV_ECOSYSTEM}

--- a/test/ini_files/green.ini
+++ b/test/ini_files/green.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-webprod-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-green-cghpezl64x4uma3etijfknh7ja.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/hotseat.ini
+++ b/test/ini_files/hotseat.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-hotseat-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-hotseat-f3oxd2wjxw3h2wsxxbcmzhhd4i.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/mastertest.ini
+++ b/test/ini_files/mastertest.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-mastertest-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/webdev.ini
+++ b/test/ini_files/webdev.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-webdev-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/webprod.ini
+++ b/test/ini_files/webprod.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-webprod-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/ini_files/webprod2.ini
+++ b/test/ini_files/webprod2.ini
@@ -8,6 +8,7 @@ system_bucket = elasticbeanstalk-fourfront-webprod-system
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.enc_accession
 elasticsearch.server = search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.us-east-1.es.amazonaws.com:80
+higlass.server = http://some-higlass-server
 snovault.app_version = ask-pip
 env.bucket = foursight-envs
 env.ecosystem = main

--- a/test/test_cloudformation_utils.py
+++ b/test/test_cloudformation_utils.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from dcicutils import cloudformation_utils
+from dcicutils.common import LEGACY_GLOBAL_ENV_BUCKET
 from dcicutils.ff_mocks import mocked_s3utils
 from dcicutils.env_base import EnvBase
 from dcicutils.misc_utils import override_environ
@@ -404,7 +405,7 @@ MOCKED_LAMBDA_NAMES = [
 
 def test_abstract_orchestration_manager_discover_foursight_check_runner_name():
 
-    with EnvBase.global_env_bucket_named('foursight-envs'):
+    with EnvBase.global_env_bucket_named(LEGACY_GLOBAL_ENV_BUCKET):
         with mocked_s3utils(environments=['fourfront-mastertest']) as b3:
             with mock.patch.object(cloudformation_utils, "boto3", b3):
 

--- a/test/test_cloudformation_utils.py
+++ b/test/test_cloudformation_utils.py
@@ -40,6 +40,13 @@ def test_hyphenify():
     assert cloudformation_utils.hyphenify('_foo123-bar7baz__quux----') == '-foo123-bar7baz--quux----'
 
 
+def test_tokenify():
+
+    assert cloudformation_utils.tokenify('foo') == 'foo'
+    assert cloudformation_utils.tokenify('abc123') == 'abc123'
+    assert cloudformation_utils.tokenify('abc-123-bar17_19') == 'abc123bar1719'
+
+
 def test_make_key_for_ecs_application_url():
 
     expected = 'ECSApplicationURLcgapanytest'

--- a/test/test_creds_utils.py
+++ b/test/test_creds_utils.py
@@ -5,7 +5,8 @@ import pytest
 
 from dcicutils.creds_utils import KeyManager, CGAPKeyManager, FourfrontKeyManager
 from dcicutils.exceptions import AppEnvKeyMissing, AppServerKeyMissing  # , AppKeyMissing
-from dcicutils.qa_utils import override_environ, MockFileSystem
+from dcicutils.misc_utils import override_environ
+from dcicutils.qa_utils import MockFileSystem
 
 
 SAMPLE_CGAP_DEFAULT_ENV = 'cgap-sample'

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -574,7 +574,8 @@ def test_deployment_utils_transitional_equivalence():
         # TODO: Once this mechanism is in place, the files cgap.ini, cgapdev.ini, cgaptest.ini, and cgapwolf.ini
         #       can either be removed (and these transitional tests removed) or transitioned to be test data.
 
-        def tester(ref_ini, env_name, data_set, es_server, *, any_ini=None, es_namespace=None, line_checker=None,
+        def tester(ref_ini, env_name, data_set, es_server, *,
+                   higlass_server=None, any_ini=None, es_namespace=None, line_checker=None,
                    use_ini_file_manager_kind=None, **others):
             """
             This common tester program checks that the any.ini does the same thing as a given ref ini,
@@ -760,6 +761,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="cgap.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default))
 
@@ -771,6 +773,7 @@ def test_deployment_utils_transitional_equivalence():
                         tester(ref_ini="cgap_alpha.ini", any_ini="cg_any_alpha.ini", env_name=bs_env, data_set=data_set,
                                use_ini_file_manager_kind="orchestrated-cgap",
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default,
                                                             expected_values={
@@ -784,6 +787,7 @@ def test_deployment_utils_transitional_equivalence():
                         tester(ref_ini="cgap_alpha.ini", any_ini="cg_any_alpha.ini", env_name=bs_env, data_set=data_set,
                                use_ini_file_manager_kind="legacy-cgap",
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default,
                                                             expected_values={
@@ -797,6 +801,7 @@ def test_deployment_utils_transitional_equivalence():
                         tester(ref_ini="cgap_alpha.ini", any_ini="cg_any_alpha.ini", env_name=bs_env, data_set=data_set,
                                use_ini_file_manager_kind='orchestrated-cgap',
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default,
                                                             expected_values={
@@ -808,6 +813,7 @@ def test_deployment_utils_transitional_equivalence():
                         tester(ref_ini="cgap_alpha.ini", any_ini="cg_any_alpha.ini", env_name=bs_env, data_set=data_set,
                                use_ini_file_manager_kind="orchestrated-cgap",
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default,
                                                             expected_values={
@@ -822,6 +828,7 @@ def test_deployment_utils_transitional_equivalence():
                         tester(ref_ini="cgap_alpha.ini", any_ini="cg_any_alpha.ini", env_name=bs_env, data_set=data_set,
                                use_ini_file_manager_kind='orchestrated-cgap',
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default,
                                                             expected_values={
@@ -836,6 +843,7 @@ def test_deployment_utils_transitional_equivalence():
                         bs_env = "cgap-alfa"
                         tester(ref_ini="cgap_alfa.ini", any_ini="cg_any_alpha.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                use_ini_file_manager_kind='orchestrated-cgap',
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server=index_server_default,
@@ -881,6 +889,7 @@ def test_deployment_utils_transitional_equivalence():
                             tester(ref_ini="cgap_alfa.ini", any_ini="cg_any_alpha.ini", env_name=bs_env,
                                    data_set=data_set, use_ini_file_manager_kind="orchestrated-cgap",
                                    es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                                 expect_index_server=index_server_default,
                                                                 expected_values={
@@ -921,6 +930,7 @@ def test_deployment_utils_transitional_equivalence():
                             tester(ref_ini="cgap_alfa.ini", any_ini="cg_any_alpha.ini", env_name=bs_env,
                                    data_set=data_set, use_ini_file_manager_kind="orchestrated-cgap",
                                    es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                                 expect_index_server=index_server_default,
                                                                 expected_values={
@@ -940,6 +950,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="cgapdev.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-cgapdev-gnv2sgdngkjbcemdadmaoxcsae.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server=index_server_default))
 
@@ -947,6 +958,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="cgaptest.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-cgaptest-dxiczz2zv7f3nshshvevcvmpmy.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server=index_server_default))
 
@@ -956,6 +968,7 @@ def test_deployment_utils_transitional_equivalence():
                                # This ini file will have 'app_kind = ccgap' rather than 'app_kind = unknown'.
                                use_ini_file_manager_kind='legacy-cgap',
                                es_server="search-fourfront-cgapwolf-r5kkbokabymtguuwjzspt2kiqa.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server=index_server_default))
 
@@ -966,6 +979,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="blue.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=FFProdChecker(expect_indexer=index_default,
                                                           expect_index_server=index_server_default))
 
@@ -973,6 +987,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="green.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-green-cghpezl64x4uma3etijfknh7ja.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=FFProdChecker(expect_indexer=index_default,
                                                           expect_index_server=index_server_default))
 
@@ -980,6 +995,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="hotseat.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-hotseat-f3oxd2wjxw3h2wsxxbcmzhhd4i.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server=index_server_default))
 
@@ -987,6 +1003,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="mastertest.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-mastertest-wusehbixktyxtbagz5wzefffp4.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server=index_server_default))
 
@@ -994,6 +1011,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="webdev.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server=index_server_default))
 
@@ -1001,6 +1019,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="webprod.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-webprod-hmrrlalm4ifyhl4bzbvl73hwv4.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=FFProdChecker(expect_indexer=index_default,
                                                           expect_index_server=index_server_default))
 
@@ -1008,6 +1027,7 @@ def test_deployment_utils_transitional_equivalence():
                         data_set = data_set_for_env(bs_env)
                         tester(ref_ini="webprod2.ini", env_name=bs_env, data_set=data_set,
                                es_server="search-fourfront-webprod2-fkav4x4wjvhgejtcg6ilrmczpe.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=FFProdChecker(expect_indexer=index_default,
                                                           expect_index_server=index_server_default))
 
@@ -1015,16 +1035,19 @@ def test_deployment_utils_transitional_equivalence():
 
                             tester(ref_ini="cgap.ini", env_name="fourfront-cgap", data_set="prod",
                                    es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=CGAPProdChecker(expect_indexer=None,
                                                                 expect_index_server="true"))
 
                             tester(ref_ini="blue.ini", env_name="fourfront-blue", data_set="prod",
                                    es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=FFProdChecker(expect_indexer=None,
                                                               expect_index_server="true"))
 
                             tester(ref_ini="webdev.ini", env_name="fourfront-webdev", data_set="prod",
                                    es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=Checker(expect_indexer=None,
                                                         expect_index_server="true"))
 
@@ -1042,16 +1065,19 @@ def test_deployment_utils_transitional_equivalence():
 
                         tester(ref_ini="cgap.ini", env_name="fourfront-cgap", data_set="prod",
                                es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                             expect_index_server="true"))
 
                         tester(ref_ini="blue.ini", env_name="fourfront-blue", data_set="prod",
                                es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=FFProdChecker(expect_indexer=index_default,
                                                           expect_index_server="true"))
 
                         tester(ref_ini="webdev.ini", env_name="fourfront-webdev", data_set="prod",
                                es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.%s" % us_east,
+                               higlass_server="http://some-higlass-server",
                                line_checker=Checker(expect_indexer=index_default,
                                                     expect_index_server="true"))
 
@@ -1063,16 +1089,19 @@ def test_deployment_utils_transitional_equivalence():
 
                             tester(ref_ini="cgap.ini", env_name="fourfront-cgap", data_set="prod",
                                    es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                                 expect_index_server=None))
 
                             tester(ref_ini="blue.ini", env_name="fourfront-blue", data_set="prod",
                                    es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=FFProdChecker(expect_indexer=index_default,
                                                               expect_index_server=None))
 
                             tester(ref_ini="webdev.ini", env_name="fourfront-webdev", data_set="prod",
                                    es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=Checker(expect_indexer=index_default,
                                                         expect_index_server=None))
 
@@ -1083,16 +1112,19 @@ def test_deployment_utils_transitional_equivalence():
 
                             tester(ref_ini="cgap.ini", env_name="fourfront-cgap", data_set="prod",
                                    es_server="search-fourfront-cgap-ewf7r7u2nq3xkgyozdhns4bkni.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=CGAPProdChecker(expect_indexer=index_default,
                                                                 expect_index_server="true"))
 
                             tester(ref_ini="blue.ini", env_name="fourfront-blue", data_set="prod",
                                    es_server="search-fourfront-blue-xkkzdrxkrunz35shbemkgrmhku.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=FFProdChecker(expect_indexer=index_default,
                                                               expect_index_server="true"))
 
                             tester(ref_ini="webdev.ini", env_name="fourfront-webdev", data_set="prod",
                                    es_server="search-fourfront-webdev-5uqlmdvvshqew46o46kcc2lxmy.%s" % us_east,
+                                   higlass_server="http://some-higlass-server",
                                    line_checker=Checker(expect_indexer=index_default,
                                                         expect_index_server="true"))
 
@@ -1151,6 +1183,7 @@ def test_deployment_utils_main():
                             'env_name': None,
                             'es_namespace': None,
                             'es_server': None,
+                            'higlass_server': None,
                             'identity': None,
                             'index_server': None,
                             'indexer': None,
@@ -1184,6 +1217,7 @@ def test_deployment_utils_main():
                             'env_name': None,
                             'es_namespace': None,
                             'es_server': None,
+                            'higlass_server': None,
                             'identity': None,
                             'index_server': 'true',
                             'indexer': 'false',
@@ -1215,6 +1249,7 @@ def test_deployment_utils_main():
                                 'env_name': None,
                                 'es_namespace': None,
                                 'es_server': None,
+                                'higlass_server': None,
                                 'identity': None,
                                 'index_server': 'true',
                                 'indexer': 'false',

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -21,9 +21,8 @@ from dcicutils.deployment_utils import (
 )
 from dcicutils.env_utils import is_cgap_env, is_hotseat_env, is_test_env, data_set_for_env, EnvUtils, full_env_name
 from dcicutils.exceptions import InvalidParameterError
-from dcicutils.qa_utils import MockFileSystem, printed_output, MockedCommandArgs
-from dcicutils.misc_utils import ignored, file_contents
-from dcicutils.qa_utils import override_environ
+from dcicutils.misc_utils import ignored, file_contents, override_environ
+from dcicutils.qa_utils import MockFileSystem, MockedCommandArgs, printed_output
 from .helpers import (
     fresh_cgap_state, fresh_ff_state,  # fresh_legacy_state,
     using_fresh_ff_state,  # using_fresh_legacy_state, using_fresh_cgap_state,

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -24,8 +24,8 @@ from dcicutils.exceptions import InvalidParameterError
 from dcicutils.misc_utils import ignored, file_contents, override_environ
 from dcicutils.qa_utils import MockFileSystem, MockedCommandArgs, printed_output
 from .helpers import (
-    fresh_cgap_state, fresh_ff_state,  # fresh_legacy_state,
-    using_fresh_ff_state,  # using_fresh_legacy_state, using_fresh_cgap_state,
+    fresh_cgap_state_for_testing, fresh_ff_state_for_testing,  # fresh_legacy_state,
+    using_fresh_ff_state_for_testing,  # using_fresh_legacy_state, using_fresh_cgap_state,
 )
 
 
@@ -1311,7 +1311,7 @@ def _get_deploy_config(*, env, args=None, log=None, allow_other_prod=False):
 @pytest.mark.integrated
 def test_get_deployment_config_cgap_stg_orchestrated():
     """ Tests get_deployment_config in a fourfront staging situation. """
-    with fresh_cgap_state():
+    with fresh_cgap_state_for_testing():
         if EnvUtils.STG_ENV_NAME is not None:
             my_log = MockedInfoLog()
             cfg = _get_deploy_config(env=EnvUtils.STG_ENV_NAME, log=my_log)
@@ -1326,7 +1326,7 @@ def test_get_deployment_config_cgap_stg_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_stg_orchestrated():
     """ Tests get_deployment_config in a fourfront staging situation. """
-    with fresh_ff_state():
+    with fresh_ff_state_for_testing():
         my_log = MockedInfoLog()
         cfg = _get_deploy_config(env=EnvUtils.STG_ENV_NAME, log=my_log)
         assert cfg['ENV_NAME'] == EnvUtils.STG_ENV_NAME  # sanity
@@ -1340,7 +1340,7 @@ def test_get_deployment_config_ff_stg_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_cgap_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
-    with fresh_cgap_state():
+    with fresh_cgap_state_for_testing():
         my_log = MockedInfoLog()
         cfg = _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
         assert cfg['ENV_NAME'] == EnvUtils.PRD_ENV_NAME  # sanity
@@ -1354,7 +1354,7 @@ def test_get_deployment_config_cgap_prd_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
-    with fresh_ff_state():
+    with fresh_ff_state_for_testing():
         my_log = MockedInfoLog()
         cfg = _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
         assert cfg['ENV_NAME'] == EnvUtils.PRD_ENV_NAME  # sanity
@@ -1368,7 +1368,7 @@ def test_get_deployment_config_ff_prd_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_cgap_uncorrelated_stg_or_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
-    with fresh_cgap_state():
+    with fresh_cgap_state_for_testing():
         # In the new world, this actually never happens because only EnvUtils.PRD_ENV_NAME and EnvUtils.STG_ENV_NAME
         # are possible stg-or-prd envs, but the control flow is there, so this tests it.
         with mock.patch('dcicutils.deployment_utils.is_stg_or_prd_env', return_value=True):
@@ -1384,7 +1384,7 @@ def test_get_deployment_config_cgap_uncorrelated_stg_or_prd_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_uncorrelated_stg_or_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
-    with fresh_ff_state():
+    with fresh_ff_state_for_testing():
         # In the new world, this actually never happens because only EnvUtils.PRD_ENV_NAME and EnvUtils.STG_ENV_NAME
         # are possible stg-or-prd envs, but the control flow is there, so this tests it.
         with mock.patch('dcicutils.deployment_utils.is_stg_or_prd_env', return_value=True):
@@ -1400,7 +1400,7 @@ def test_get_deployment_config_ff_uncorrelated_stg_or_prd_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_cgap_test_envs_orchestrated():
     """ Tests get_deployment_config in the cgap-test case with an orchestrated ecosystem. """
-    with fresh_cgap_state():
+    with fresh_cgap_state_for_testing():
         for my_env in EnvUtils.TEST_ENVS:
             if not is_hotseat_env(my_env):
                 print(f"Testing {my_env}...")
@@ -1417,7 +1417,7 @@ def test_get_deployment_config_cgap_test_envs_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_test_envs_orchestrated():
     """ Tests get_deployment_config in the mastertest case with an orchestrated ecosystem. """
-    with fresh_ff_state():
+    with fresh_ff_state_for_testing():
         for my_env in EnvUtils.TEST_ENVS:
             if not is_hotseat_env(my_env):
                 print(f"Testing {my_env}...")
@@ -1434,7 +1434,7 @@ def test_get_deployment_config_ff_test_envs_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_cgap_hotseat_orchestrated():
     """ Tests get_deployment_config in the hotseat case with an orchestrated ecosystem. """
-    with fresh_cgap_state():
+    with fresh_cgap_state_for_testing():
         for my_env in EnvUtils.HOTSEAT_ENVS:
             print(f"Testing {my_env}...")
             my_log = MockedInfoLog()
@@ -1464,7 +1464,7 @@ def test_get_deployment_config_cgap_hotseat_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_hotseat_orchestrated():
     """ Tests get_deployment_config in the hotseat case with an orchestrated ecosystem. """
-    with fresh_ff_state():
+    with fresh_ff_state_for_testing():
         for my_env in EnvUtils.HOTSEAT_ENVS:
             print(f"Testing {my_env}...")
             my_log = MockedInfoLog()
@@ -1491,7 +1491,7 @@ def test_get_deployment_config_ff_hotseat_orchestrated():
                                            f' Processing mode: default')
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 @mock.patch.object(deployment_utils_module, "compute_ff_prd_env")
 @mock.patch.object(deployment_utils_module, "compute_cgap_prd_env")
 def test_actual_env_settings(mock_compute_cgap_prd_env, mock_compute_ff_prd_env):

--- a/test/test_deployment_utils.py
+++ b/test/test_deployment_utils.py
@@ -11,6 +11,7 @@ import sys
 from io import StringIO
 from unittest import mock
 
+from dcicutils import deployment_utils as deployment_utils_module
 from dcicutils.deployment_utils import (
     IniFileManager, boolean_setting, CreateMappingOnDeployManager,
     BasicOrchestratedCGAPIniFileManager, BasicLegacyCGAPIniFileManager,
@@ -18,12 +19,15 @@ from dcicutils.deployment_utils import (
     # TODO: This isn't yet tested.
     # EBDeployer,
 )
-from dcicutils.env_utils import is_cgap_env, is_hotseat_env, is_test_env, data_set_for_env, EnvUtils
+from dcicutils.env_utils import is_cgap_env, is_hotseat_env, is_test_env, data_set_for_env, EnvUtils, full_env_name
 from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import MockFileSystem, printed_output, MockedCommandArgs
 from dcicutils.misc_utils import ignored, file_contents
 from dcicutils.qa_utils import override_environ
-from .helpers import fresh_cgap_state
+from .helpers import (
+    fresh_cgap_state, fresh_ff_state,  # fresh_legacy_state,
+    using_fresh_ff_state,  # using_fresh_legacy_state, using_fresh_cgap_state,
+)
 
 
 _MY_DIR = os.path.dirname(__file__)
@@ -1274,20 +1278,21 @@ def _get_deploy_config(*, env, args=None, log=None, allow_other_prod=False):
 def test_get_deployment_config_cgap_stg_orchestrated():
     """ Tests get_deployment_config in a fourfront staging situation. """
     with fresh_cgap_state():
-        my_log = MockedInfoLog()
-        cfg = _get_deploy_config(env=EnvUtils.STG_ENV_NAME, log=my_log)
-        assert cfg['ENV_NAME'] == EnvUtils.STG_ENV_NAME  # sanity
-        assert cfg['SKIP'] is False
-        assert cfg['WIPE_ES'] is True
-        assert cfg['STRICT'] is True
-        assert my_log.last_msg == (f"Environment {EnvUtils.STG_ENV_NAME} is currently the staging environment."
-                                   f" Processing mode: STRICT,WIPE_ES")
+        if EnvUtils.STG_ENV_NAME is not None:
+            my_log = MockedInfoLog()
+            cfg = _get_deploy_config(env=EnvUtils.STG_ENV_NAME, log=my_log)
+            assert cfg['ENV_NAME'] == EnvUtils.STG_ENV_NAME  # sanity
+            assert cfg['SKIP'] is False
+            assert cfg['WIPE_ES'] is True
+            assert cfg['STRICT'] is True
+            assert my_log.last_msg == (f"Environment {EnvUtils.STG_ENV_NAME} is currently the staging environment."
+                                       f" Processing mode: STRICT,WIPE_ES")
 
 
 @pytest.mark.integrated
 def test_get_deployment_config_ff_stg_orchestrated():
     """ Tests get_deployment_config in a fourfront staging situation. """
-    with EnvUtils.fresh_ff_state():
+    with fresh_ff_state():
         my_log = MockedInfoLog()
         cfg = _get_deploy_config(env=EnvUtils.STG_ENV_NAME, log=my_log)
         assert cfg['ENV_NAME'] == EnvUtils.STG_ENV_NAME  # sanity
@@ -1315,7 +1320,7 @@ def test_get_deployment_config_cgap_prd_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
-    with EnvUtils.fresh_ff_state():
+    with fresh_ff_state():
         my_log = MockedInfoLog()
         cfg = _get_deploy_config(env=EnvUtils.PRD_ENV_NAME, log=my_log)
         assert cfg['ENV_NAME'] == EnvUtils.PRD_ENV_NAME  # sanity
@@ -1333,7 +1338,7 @@ def test_get_deployment_config_cgap_uncorrelated_stg_or_prd_orchestrated():
         # In the new world, this actually never happens because only EnvUtils.PRD_ENV_NAME and EnvUtils.STG_ENV_NAME
         # are possible stg-or-prd envs, but the control flow is there, so this tests it.
         with mock.patch('dcicutils.deployment_utils.is_stg_or_prd_env', return_value=True):
-            my_env = 'fourfront-prd-other'
+            my_env = 'cgap-prd-other'
             my_log = MockedInfoLog()
             with pytest.raises(RuntimeError):
                 _get_deploy_config(env=my_env, log=my_log)
@@ -1345,7 +1350,7 @@ def test_get_deployment_config_cgap_uncorrelated_stg_or_prd_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_uncorrelated_stg_or_prd_orchestrated():
     """ Tests get_deployment_config in the new production case """
-    with EnvUtils.fresh_ff_state():
+    with fresh_ff_state():
         # In the new world, this actually never happens because only EnvUtils.PRD_ENV_NAME and EnvUtils.STG_ENV_NAME
         # are possible stg-or-prd envs, but the control flow is there, so this tests it.
         with mock.patch('dcicutils.deployment_utils.is_stg_or_prd_env', return_value=True):
@@ -1378,7 +1383,7 @@ def test_get_deployment_config_cgap_test_envs_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_test_envs_orchestrated():
     """ Tests get_deployment_config in the mastertest case with an orchestrated ecosystem. """
-    with EnvUtils.fresh_ff_state():
+    with fresh_ff_state():
         for my_env in EnvUtils.TEST_ENVS:
             if not is_hotseat_env(my_env):
                 print(f"Testing {my_env}...")
@@ -1425,7 +1430,7 @@ def test_get_deployment_config_cgap_hotseat_orchestrated():
 @pytest.mark.integrated
 def test_get_deployment_config_ff_hotseat_orchestrated():
     """ Tests get_deployment_config in the hotseat case with an orchestrated ecosystem. """
-    with EnvUtils.fresh_ff_state():
+    with fresh_ff_state():
         for my_env in EnvUtils.HOTSEAT_ENVS:
             print(f"Testing {my_env}...")
             my_log = MockedInfoLog()
@@ -1450,6 +1455,71 @@ def test_get_deployment_config_ff_hotseat_orchestrated():
                 assert cfg['STRICT'] is False
                 assert my_log.last_msg == (f'Environment {my_env} is an unrecognized environment.'
                                            f' Processing mode: default')
+
+
+@using_fresh_ff_state()
+@mock.patch.object(deployment_utils_module, "compute_ff_prd_env")
+@mock.patch.object(deployment_utils_module, "compute_cgap_prd_env")
+def test_actual_env_settings(mock_compute_cgap_prd_env, mock_compute_ff_prd_env):
+    def dont_compute_cagp(*args, **kwargs):
+        ignored(args, kwargs)
+        raise AssertionError("Should not be trying to call compute_cgap_prd_env")
+    mock_compute_cgap_prd_env.side_effect = dont_compute_cagp
+    mock_compute_ff_prd_env.return_value = 'fourfront-prd'
+
+    assert EnvUtils.PRD_ENV_NAME == 'fourfront-prd'
+    assert EnvUtils.STG_ENV_NAME == 'fourfront-stg'
+
+    def describe(config):
+        return ('SKIP'
+                if config['SKIP'] else
+                ",".join((['WIPE_ES'] if config['WIPE_ES'] else []) +
+                         (['STRICT'] if config['STRICT'] else [])))
+
+    class MyCommandArgs(MockedCommandArgs):
+        VALID_ARGS = ['skip', 'wipe_es', 'strict']
+
+    def compute_and_show(kind, env, wipe_es=False):
+        info = "-------------------------"
+        try:
+            config = _get_deploy_config(env=env, args=MyCommandArgs(wipe_es=wipe_es))
+            info = describe(config).ljust(14)
+        finally:  # show even if we err
+            print(f"{info} env={env.ljust(20)} wipe_es={'Y' if wipe_es else 'N'}"
+                  f" full={full_env_name(env).ljust(20)} kind={kind}")
+        return config
+
+    print()  # Start on a fresh line
+    for wipe_es in [False, True]:
+        print(f"wipe_es={wipe_es}")
+        for kind_and_envs in [['production', ['fourfront-prd', 'prd', 'data']],
+                              ['staging', ['fourfront-stg', 'stg', 'staging']],
+                              ['hotseat', ['fourfront-hotseat', 'hotseat']],
+                              ['test', ['fourfront-mastertest', 'mastertest', 'fourfront-webdev', 'webdev']],
+                              ['other', ['fourfront-other', 'other']]]:
+            [kind, envs] = kind_and_envs
+            for env in envs:
+
+                config = compute_and_show(kind=kind, env=env, wipe_es=wipe_es)
+
+                if kind == 'production':
+                    assert config['SKIP'] is False
+                    assert config['WIPE_ES'] is False
+                    assert config['STRICT'] is True
+                elif kind == 'staging':
+                    assert config['SKIP'] is False
+                    assert config['WIPE_ES'] is True
+                    assert config['STRICT'] is True
+                elif kind == 'hotseat':
+                    assert config['SKIP'] is True
+                elif kind == 'test':
+                    assert config['SKIP'] is False
+                    assert config['WIPE_ES'] is True
+                    assert config['STRICT'] is False
+                else:  # other
+                    assert config['SKIP'] is False
+                    assert config['WIPE_ES'] is wipe_es
+                    assert config['STRICT'] is False
 
 
 def test_create_file_from_template():

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -4,7 +4,7 @@ from unittest import mock
 from dcicutils.ecr_utils import ECRUtils
 from dcicutils.docker_utils import DockerUtils
 from dcicutils.misc_utils import ignored
-from .helpers import using_fresh_cgap_state
+from .helpers import using_fresh_cgap_state_for_testing
 
 
 REPO_URL = '123456789.dkr.ecr.us-east-2.amazonaws.com/cgap-mastertest'  # dummy URL
@@ -22,7 +22,7 @@ def mocked_ecr_login(*, username, password, registry):
     return
 
 
-@using_fresh_cgap_state()
+@using_fresh_cgap_state_for_testing()
 def test_ecr_utils_basic():
     """ Tests something simple for now, more tests to be added later. """
     # init args no longer default. -kmp 14-Jul-2022
@@ -33,7 +33,7 @@ def test_ecr_utils_basic():
 
 
 @pytest.mark.skipif(not DockerUtils.docker_is_running(), reason="Docker is not running.")
-@using_fresh_cgap_state()
+@using_fresh_cgap_state_for_testing()
 def test_ecr_utils_workflow():
     """ Tests URL + Login via Docker_cli"""
     # init args no longer default. -kmp 14-Jul-2022

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -25,7 +25,8 @@ def mocked_ecr_login(*, username, password, registry):
 @using_fresh_cgap_state()
 def test_ecr_utils_basic():
     """ Tests something simple for now, more tests to be added later. """
-    cli = ECRUtils()  # default args ok
+    # init args no longer default. -kmp 14-Jul-2022
+    cli = ECRUtils(env_name='cgap-mastertest', local_repository='cgap-wsgi')
     with mock.patch.object(cli.client, 'describe_repositories', mocked_describe_respositories):
         url = cli.resolve_repository_uri()
         assert url == REPO_URL
@@ -35,7 +36,8 @@ def test_ecr_utils_basic():
 @using_fresh_cgap_state()
 def test_ecr_utils_workflow():
     """ Tests URL + Login via Docker_cli"""
-    ecr_cli = ECRUtils()
+    # init args no longer default. -kmp 14-Jul-2022
+    ecr_cli = ECRUtils(env_name='cgap-mastertest', local_repository='cgap-wsgi')
     docker_cli = DockerUtils()
     with mock.patch.object(ecr_cli.client, 'describe_repositories', mocked_describe_respositories):
         ecr_cli.resolve_repository_uri()

--- a/test/test_ecs_utils.py
+++ b/test/test_ecs_utils.py
@@ -55,6 +55,73 @@ def mock_list_ecs_tasks():
     }
 
 
+def mock_describe_services_completed_deployment(*, cluster, services):
+    """ Mocks the (important) structure of ecs.describe_services to simulate a completed
+        deployment state.
+    """
+    ignored(cluster), ignored(services)
+    return {
+        'services': [
+            {
+                'serviceArn': 'dummy-arn',
+                'deployments': [
+                    {'id': 'ecs-svc/3239640454637807340', 'status': 'PRIMARY',
+                     'taskDefinition': 'dummy-task-definition',
+                     'desiredCount': 4, 'pendingCount': 0, 'runningCount': 4, 'failedTasks': 0,
+                     'capacityProviderStrategy': [{'capacityProvider': 'FARGATE', 'weight': 0, 'base': 0},
+                                                  {'capacityProvider': 'FARGATE_SPOT', 'weight': 1, 'base': 8}],
+                     'platformVersion': '1.4.0', 'networkConfiguration': {
+                        'awsvpcConfiguration': {'subnets': ['dummy-subnet1', 'dummy-subnet2'],
+                                                'securityGroups': ['dummy-sg'],
+                                                'assignPublicIp': 'DISABLED'}}, 'rolloutState': 'COMPLETED',
+                     'rolloutStateReason': 'ECS deployment ecs-svc/3239640454637807340 completed.'}
+                ]
+            }
+        ]
+    }
+
+
+def mock_describe_services_active_deployment(*, cluster, services):
+    """ Mocks the (important) structure of ecs.describe_services to simulate an active
+        deployment state. Must match signature of API as it is called in the method.
+    """
+    ignored(cluster), ignored(services)
+    return {
+        'services': [
+            {
+                'serviceArn': 'dummy-arn',
+                'deployments': [
+                    {'id': 'ecs-svc/3239640454637807340', 'status': 'PRIMARY',
+                     'taskDefinition': 'dummy-task-definition',
+                     'desiredCount': 4, 'pendingCount': 4, 'runningCount': 0, 'failedTasks': 0,
+                     'capacityProviderStrategy': [{'capacityProvider': 'FARGATE', 'weight': 0, 'base': 0},
+                                                  {'capacityProvider': 'FARGATE_SPOT', 'weight': 1, 'base': 8}],
+                     'platformVersion': '1.4.0', 'networkConfiguration': {
+                        'awsvpcConfiguration': {'subnets': ['dummy-subnet1', 'dummy-subnet2'],
+                                                'securityGroups': ['dummy-sg'],
+                                                'assignPublicIp': 'DISABLED'}}, 'rolloutState': 'Active',
+                     'rolloutStateReason': 'ECS deployment ecs-svc/3239640454637807340 in progress.'}
+                ]
+            },
+            {
+                'serviceArn': 'dummy-arn',
+                'deployments': [
+                    {'id': 'ecs-svc/3239640454637807340', 'status': 'PRIMARY',
+                     'taskDefinition': 'dummy-task-definition',
+                     'desiredCount': 4, 'pendingCount': 0, 'runningCount': 4, 'failedTasks': 0,
+                     'capacityProviderStrategy': [{'capacityProvider': 'FARGATE', 'weight': 0, 'base': 0},
+                                                  {'capacityProvider': 'FARGATE_SPOT', 'weight': 1, 'base': 8}],
+                     'platformVersion': '1.4.0', 'networkConfiguration': {
+                        'awsvpcConfiguration': {'subnets': ['dummy-subnet1', 'dummy-subnet2'],
+                                                'securityGroups': ['dummy-sg'],
+                                                'assignPublicIp': 'DISABLED'}}, 'rolloutState': 'COMPLETED',
+                     'rolloutStateReason': 'ECS deployment ecs-svc/3239640454637807340 completed.'}
+                ]
+            }
+        ]
+    }
+
+
 def mock_update_service(*, cluster, service, forceNewDeployment):  # noQA - AWS chose mixed case argument name
     """ Mock matching the relevant API signature for below (we don't actually want
         to trigger an ECS deploy in unit testing.
@@ -68,3 +135,15 @@ def test_ecs_utils_will_update_services(ecs_utils):
     with mock.patch.object(ecs_utils.client, 'list_services', mock_list_ecs_services):
         with mock.patch.object(ecs_utils.client, 'update_service', mock_update_service):
             ecs_utils.update_all_services(cluster_name='unused')
+
+
+@pytest.mark.parametrize('mock_response,result', [
+    (mock_describe_services_active_deployment, True),
+    (mock_describe_services_completed_deployment, False)
+])
+def test_ecs_utils_active_deployment(ecs_utils, mock_response, result):
+    """ Tests processing a mock responses from boto3 for an active deployment """
+    with mock.patch.object(ecs_utils.client, 'describe_services', mock_response):
+        assert ecs_utils.service_has_active_deployment(
+            cluster_name='dummy-cluster',
+            services=['dummy-service']) == result

--- a/test/test_env_utils_legacy.py
+++ b/test/test_env_utils_legacy.py
@@ -740,7 +740,7 @@ def test_infer_foursight_from_env():
 
     def check(token_in, token_out, request=None):
         request = request or mock_request()
-        assert infer_foursight_from_env(request, token_in) == token_out
+        assert infer_foursight_from_env(request=request, envname=token_in) == token_out
 
     # (active) fourfront testing environments
     check(FF_ENV_MASTERTEST, 'mastertest')
@@ -802,7 +802,7 @@ def test_infer_foursight_url_from_env():
         request = request or mock_request()
         prefix = cg_foursight_prefix if cgap else ff_foursight_prefix
         expected = prefix + token_out if token_out else None
-        assert infer_foursight_url_from_env(request, token_in) == expected
+        assert infer_foursight_url_from_env(request=request, envname=token_in) == expected
 
     # (active) fourfront testing environments
     check(FF_ENV_MASTERTEST, 'mastertest')

--- a/test/test_env_utils_legacy.py
+++ b/test/test_env_utils_legacy.py
@@ -25,10 +25,10 @@ from dcicutils.env_utils_legacy import (
 from dcicutils.exceptions import InvalidParameterError
 from dcicutils.qa_utils import raises_regexp
 from unittest import mock
-from .helpers import using_fresh_legacy_state
+from .helpers import using_fresh_legacy_state_for_testing
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_default_workflow_env():
 
     assert (default_workflow_env('fourfront')
@@ -44,7 +44,7 @@ def test_default_workflow_env():
         default_workflow_env('foo')  # noQA - we expect this error
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_ecr_repository_for_env():
 
     # All CGAP values just return their arguments.
@@ -60,7 +60,7 @@ def test_ecr_repository_for_env():
         assert ecr_repository_for_env(env) == env
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_get_bucket_env():
 
     # Fourfront tests
@@ -86,7 +86,7 @@ def test_get_bucket_env():
 
 
 @pytest.mark.skip(reason="Beanstalk functionality no longer supported.")
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_prod_bucket_env_for_app():
 
     assert prod_bucket_env_for_app('fourfront') == FF_PROD_BUCKET_ENV
@@ -100,7 +100,7 @@ def test_prod_bucket_env_for_app():
 
 
 @pytest.mark.skip(reason="Beanstalk functionality no longer supported.")
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_prod_bucket_env():
 
     # Fourfront tests
@@ -125,7 +125,7 @@ def test_prod_bucket_env():
     assert prod_bucket_env('fourfront-cgapwolf') is None
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_permit_load_data():
 
     # Fourfront envs
@@ -203,7 +203,7 @@ def test_permit_load_data():
     assert permit_load_data('cgap-wolf', allow_prod=False, orchestrated_app='cgap') is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_data_set_for_env():
 
     assert data_set_for_env('fourfront-blue') == 'prod'
@@ -226,7 +226,7 @@ def test_data_set_for_env():
     assert data_set_for_env('cgap-wolf') == 'prod'  # see above
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_public_url_mappings():
 
     assert public_url_mappings('fourfront-webprod') == FF_PUBLIC_URLS
@@ -241,7 +241,7 @@ def test_public_url_mappings():
     assert public_url_mappings('cgap-green') == CGAP_PUBLIC_URLS
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_public_url_for_app():
 
     assert public_url_for_app('cgap') == _CGAP_MGB_PUBLIC_URL_PRD
@@ -251,7 +251,7 @@ def test_public_url_for_app():
         public_url_for_app('foo')  # noQA - we expect this error
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_blue_green_mirror_env():
 
     # Should work for basic fourfront
@@ -281,7 +281,7 @@ def test_blue_green_mirror_env():
         blue_green_mirror_env('green-blue')  # needs to be one or the other
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_cgap_server():
 
     with pytest.raises(ValueError):
@@ -315,7 +315,7 @@ def test_is_cgap_server():
     assert is_cgap_server("www.google.com") is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_fourfront_server():
     with pytest.raises(ValueError):
         is_fourfront_server(None)
@@ -348,7 +348,7 @@ def test_is_fourfront_server():
     assert is_fourfront_server("www.google.com") is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_cgap_env():
 
     assert is_cgap_env(None) is False
@@ -358,7 +358,7 @@ def test_is_cgap_env():
     assert is_cgap_env('fourfront-blue') is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_fourfront_env():
 
     assert is_fourfront_env('fourfront-cgap') is False
@@ -368,7 +368,7 @@ def test_is_fourfront_env():
     assert is_fourfront_env(None) is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_beanstalk_env():
 
     assert is_beanstalk_env('fourfront-webprod') is True
@@ -409,7 +409,7 @@ def test_is_beanstalk_env():
     assert is_beanstalk_env('anything-at-all') is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_stg_or_prd_env():
 
     assert is_stg_or_prd_env("fourfront-green") is True
@@ -465,7 +465,7 @@ def test_is_stg_or_prd_env():
     assert is_stg_or_prd_env(None) is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_test_env():
 
     assert is_test_env(FF_ENV_PRODUCTION_BLUE) is False
@@ -495,7 +495,7 @@ def test_is_test_env():
     assert is_test_env(None) is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_hotseat_env():
 
     assert is_hotseat_env(FF_ENV_PRODUCTION_BLUE) is False
@@ -530,7 +530,7 @@ def test_is_hotseat_env():
     assert is_hotseat_env(None) is False
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_get_mirror_env_from_context_without_environ():
     """ Tests that when getting mirror env on various envs returns the correct mirror """
 
@@ -580,7 +580,7 @@ def test_get_mirror_env_from_context_without_environ():
             assert mirror is None
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_get_mirror_env_from_context_with_environ_has_env():
     """ Tests override of env name from os.environ when getting mirror env on various envs """
 
@@ -626,7 +626,7 @@ def test_get_mirror_env_from_context_with_environ_has_env():
         assert mirror is None  # env name explicitly declared, but guessing disallowed (but no CGAP mirror)
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_get_mirror_env_from_context_with_environ_has_mirror_env():
     """ Tests override of mirror env name from os.environ when getting mirror env on various envs """
 
@@ -636,7 +636,7 @@ def test_get_mirror_env_from_context_with_environ_has_mirror_env():
         assert mirror == 'bar'  # explicitly declared, even if nothing else ise
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_get_mirror_env_from_context_with_environ_has_env_and_mirror_env():
     """ Tests override of env name and mirror env name from os.environ when getting mirror env on various envs """
 
@@ -646,7 +646,7 @@ def test_get_mirror_env_from_context_with_environ_has_env_and_mirror_env():
         assert mirror == 'bar'  # mirror explicitly declared, ignoring env name
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_get_standard_mirror_env():
 
     def assert_prod_mirrors(env, expected_mirror_env):
@@ -689,7 +689,7 @@ def test_get_standard_mirror_env():
     assert_prod_mirrors('cgap', None)
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_infer_repo_from_env():
 
     assert infer_repo_from_env(FF_ENV_PRODUCTION_BLUE) == 'fourfront'
@@ -725,7 +725,7 @@ def test_infer_repo_from_env():
     assert infer_repo_from_env('who-knows') is None
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_infer_foursight_from_env():
 
     class MockedRequest:
@@ -782,7 +782,7 @@ def test_infer_foursight_from_env():
     check(None, None)
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_infer_foursight_url_from_env():
 
     class MockedRequest:
@@ -844,7 +844,7 @@ def test_infer_foursight_url_from_env():
     check(None, None, cgap=True)
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_indexer_env_for_env():
 
     assert indexer_env_for_env('fourfront-mastertest') == FF_ENV_INDEXER
@@ -863,7 +863,7 @@ def test_indexer_env_for_env():
     assert indexer_env_for_env('blah-env') is None
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_is_indexer_env():
 
     assert is_indexer_env('fourfront-indexer')
@@ -880,7 +880,7 @@ def test_is_indexer_env():
     assert not is_indexer_env('fourfront-cgapwolf')
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_short_env_name():
 
     assert short_env_name('cgapdev') == 'cgapdev'
@@ -903,7 +903,7 @@ def test_short_env_name():
     assert short_env_name('fourfront_mastertest') == 'fourfront_mastertest'
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_full_env_name():
 
     assert full_env_name('cgapdev') == 'fourfront-cgapdev'
@@ -926,7 +926,7 @@ def test_full_env_name():
         full_env_name('data')
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_full_cgap_env_name():
     assert full_cgap_env_name('cgapdev') == 'fourfront-cgapdev'
     assert full_cgap_env_name('fourfront-cgapdev') == 'fourfront-cgapdev'
@@ -954,7 +954,7 @@ def test_full_cgap_env_name():
         full_cgap_env_name('data')
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_full_fourfront_env_name():
 
     assert full_fourfront_env_name('mastertest') == 'fourfront-mastertest'
@@ -982,7 +982,7 @@ def test_full_fourfront_env_name():
         full_fourfront_env_name('data')
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_classify_server_url_localhost():
 
     assert classify_server_url("http://localhost/foo/bar") == {
@@ -1010,7 +1010,7 @@ def test_classify_server_url_localhost():
     }
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_classify_server_url_cgap():
 
     assert classify_server_url("https://cgap.hms.harvard.edu/foo/bar") == {
@@ -1038,7 +1038,7 @@ def test_classify_server_url_cgap():
     }
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_classify_server_url_fourfront():
 
     assert classify_server_url("https://data.4dnucleome.org/foo/bar") == {
@@ -1072,7 +1072,7 @@ def test_classify_server_url_fourfront():
     }
 
 
-@using_fresh_legacy_state()
+@using_fresh_legacy_state_for_testing()
 def test_classify_server_url_other():
 
     with raises_regexp(RuntimeError, "not a Fourfront or CGAP server"):

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -1765,7 +1765,7 @@ def test_orchestrated_is_indexer_env_disabled():
 def test_orchestrated_short_env_name():
 
     assert short_env_name(None) is None
-    assert short_env_name('demo') == 'demo'
+    assert short_env_name('demo') == 'pubdemo'
     assert short_env_name('anything') == 'anything'
     assert short_env_name('acme-anything') == 'anything'
     assert short_env_name('cgap-anything') == 'cgap-anything'

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -222,27 +222,27 @@ def test_orchestrated_prod_bucket_env_for_app():
 @using_orchestrated_behavior()
 def test_orchestrated_infer_foursight_url_from_env():
 
-    assert (infer_foursight_url_from_env('ignored-request', 'demo')
+    assert (infer_foursight_url_from_env(request='ignored-request', envname='demo')
             == 'https://foursight.genetics.example.com/api/view/demo')
-    assert (infer_foursight_url_from_env('ignored-request', 'acme-foo')
+    assert (infer_foursight_url_from_env(request='ignored-request', envname='acme-foo')
             == 'https://foursight.genetics.example.com/api/view/foo')
-    assert (infer_foursight_url_from_env('ignored-request', 'fourfront-cgapwolf')
+    assert (infer_foursight_url_from_env(request='ignored-request', envname='fourfront-cgapwolf')
             == 'https://foursight.genetics.example.com/api/view/fourfront-cgapwolf')
 
     with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):
-        assert (infer_foursight_url_from_env('ignored-request', 'data')
+        assert (infer_foursight_url_from_env(request='ignored-request', envname='data')
                 == 'https://foursight.4dnucleome.org/api/view/data')
-        assert (infer_foursight_url_from_env('ignored-request', 'acme-foo')
+        assert (infer_foursight_url_from_env(request='ignored-request', envname='acme-foo')
                 == 'https://foursight.4dnucleome.org/api/view/acme-foo')
-        assert (infer_foursight_url_from_env('ignored-request', 'fourfront-cgapwolf')
+        assert (infer_foursight_url_from_env(request='ignored-request', envname='fourfront-cgapwolf')
                 == 'https://foursight.4dnucleome.org/api/view/cgapwolf')
 
     with local_attrs(EnvUtils, **CGAP_SETTINGS_FOR_TESTING):
-        assert (infer_foursight_url_from_env('ignored-request', 'data')
+        assert (infer_foursight_url_from_env(request='ignored-request', envname='data')
                 == 'https://u9feld4va7.execute-api.us-east-1.amazonaws.com/api/view/data')
-        assert (infer_foursight_url_from_env('ignored-request', 'acme-foo')
+        assert (infer_foursight_url_from_env(request='ignored-request', envname='acme-foo')
                 == 'https://u9feld4va7.execute-api.us-east-1.amazonaws.com/api/view/acme-foo')
-        assert (infer_foursight_url_from_env('ignored-request', 'fourfront-cgapwolf')
+        assert (infer_foursight_url_from_env(request='ignored-request', envname='fourfront-cgapwolf')
                 == 'https://u9feld4va7.execute-api.us-east-1.amazonaws.com/api/view/cgapwolf')
 
 
@@ -1626,74 +1626,74 @@ def test_orchestrated_infer_foursight_from_env():
     def mock_request(domain):  # build a dummy request with the 'domain' member, checked in the method
         return MockedRequest(domain)
 
-    assert infer_foursight_from_env(mock_request('acme-prd' + dev_suffix), 'acme-prd') == 'cgap'
-    assert infer_foursight_from_env(mock_request('acme-mastertest' + dev_suffix), 'acme-mastertest') == 'mastertest'
-    assert infer_foursight_from_env(mock_request('acme-webdev' + dev_suffix), 'acme-webdev') == 'webdev'
-    assert infer_foursight_from_env(mock_request('acme-hotseat' + dev_suffix), 'acme-hotseat') == 'hotseat'
+    assert infer_foursight_from_env(request=mock_request('acme-prd' + dev_suffix), envname='acme-prd') == 'cgap'
+    assert infer_foursight_from_env(request=mock_request('acme-mastertest' + dev_suffix), envname='acme-mastertest') == 'mastertest'
+    assert infer_foursight_from_env(request=mock_request('acme-webdev' + dev_suffix), envname='acme-webdev') == 'webdev'
+    assert infer_foursight_from_env(request=mock_request('acme-hotseat' + dev_suffix), envname='acme-hotseat') == 'hotseat'
 
     with stage_mirroring(enabled=True):
 
         with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):
 
             # (active) fourfront testing environments
-            assert infer_foursight_from_env(mock_request('fourfront-mastertest' + dev_suffix),
-                                            'fourfront-mastertest') == 'mastertest'
-            assert infer_foursight_from_env(mock_request('fourfront-webdev' + dev_suffix),
-                                            'fourfront-webdev') == 'webdev'
-            assert infer_foursight_from_env(mock_request('fourfront-hotseat' + dev_suffix),
-                                            'fourfront-hotseat') == 'hotseat'
+            assert infer_foursight_from_env(request=mock_request('fourfront-mastertest' + dev_suffix),
+                                            envname='fourfront-mastertest') == 'mastertest'
+            assert infer_foursight_from_env(request=mock_request('fourfront-webdev' + dev_suffix),
+                                            envname='fourfront-webdev') == 'webdev'
+            assert infer_foursight_from_env(request=mock_request('fourfront-hotseat' + dev_suffix),
+                                            envname='fourfront-hotseat') == 'hotseat'
 
             # (active) fourfront production environments
-            assert (infer_foursight_from_env(mock_request(domain='data.4dnucleome.org'), 'fourfront-blue')
+            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='fourfront-blue')
                     == 'data')
-            assert (infer_foursight_from_env(mock_request(domain='data.4dnucleome.org'), 'fourfront-green')
+            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='fourfront-green')
                     == 'data')
-            assert (infer_foursight_from_env(mock_request(domain='staging.4dnucleome.org'), 'fourfront-blue')
+            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='fourfront-blue')
                     == 'staging')
-            assert (infer_foursight_from_env(mock_request(domain='staging.4dnucleome.org'), 'fourfront-green')
+            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='fourfront-green')
                     == 'staging')
 
             # These next four are pathological and hopefully not used, but they illustrate that the domain dominates.
             # This does not illustrate intended use.
-            assert (infer_foursight_from_env(mock_request(domain='data.4dnucleome.org'), 'data')
+            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='data')
                     == 'data')
-            assert (infer_foursight_from_env(mock_request(domain='data.4dnucleome.org'), 'staging')
+            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='staging')
                     == 'data')
 
-            assert (infer_foursight_from_env(mock_request(domain='staging.4dnucleome.org'), 'data')
+            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='data')
                     == 'staging')
-            assert (infer_foursight_from_env(mock_request(domain='staging.4dnucleome.org'), 'staging')
+            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='staging')
                     == 'staging')
 
-            assert (infer_foursight_from_env('data.4dnucleome.org', 'data') == 'data')
-            assert (infer_foursight_from_env('data.4dnucleome.org', 'staging') == 'data')
+            assert (infer_foursight_from_env(request='data.4dnucleome.org', envname='data') == 'data')
+            assert (infer_foursight_from_env(request='data.4dnucleome.org', envname='staging') == 'data')
 
-            assert (infer_foursight_from_env('https://data.4dnucleome.org', 'data') == 'data')
-            assert (infer_foursight_from_env('https://data.4dnucleome.org', 'staging') == 'data')
+            assert (infer_foursight_from_env(request='https://data.4dnucleome.org', envname='data') == 'data')
+            assert (infer_foursight_from_env(request='https://data.4dnucleome.org', envname='staging') == 'data')
 
-            assert (infer_foursight_from_env('staging.4dnucleome.org', 'data') == 'staging')
-            assert (infer_foursight_from_env('staging.4dnucleome.org', 'staging') == 'staging')
+            assert (infer_foursight_from_env(request='staging.4dnucleome.org', envname='data') == 'staging')
+            assert (infer_foursight_from_env(request='staging.4dnucleome.org', envname='staging') == 'staging')
 
-            assert (infer_foursight_from_env('http://staging.4dnucleome.org', 'data') == 'staging')
-            assert (infer_foursight_from_env('http://staging.4dnucleome.org', 'staging') == 'staging')
+            assert (infer_foursight_from_env(request='http://staging.4dnucleome.org', envname='data') == 'staging')
+            assert (infer_foursight_from_env(request='http://staging.4dnucleome.org', envname='staging') == 'staging')
 
-            assert (infer_foursight_from_env(None, 'data') == 'data')
-            assert (infer_foursight_from_env(None, 'staging') == 'staging')
+            assert (infer_foursight_from_env(request=None, envname='data') == 'data')
+            assert (infer_foursight_from_env(request=None, envname='staging') == 'staging')
 
         # (active) cgap environments
         with local_attrs(EnvUtils, **CGAP_SETTINGS_FOR_TESTING):
 
-            assert infer_foursight_from_env(mock_request('fourfront-cgapdev' + dev_suffix),
-                                            'fourfront-cgapdev') == 'cgapdev'
-            assert infer_foursight_from_env(mock_request('fourfront-cgaptest' + dev_suffix),
-                                            'fourfront-cgaptest') == 'cgaptest'
-            assert infer_foursight_from_env(mock_request('fourfront-cgapwolf' + dev_suffix),
-                                            'fourfront-cgapwolf') == 'cgapwolf'
-            assert infer_foursight_from_env(mock_request('fourfront-cgap' + dev_suffix),
-                                            'fourfront-cgap') == 'cgap'
+            assert infer_foursight_from_env(request=mock_request('fourfront-cgapdev' + dev_suffix),
+                                            envname='fourfront-cgapdev') == 'cgapdev'
+            assert infer_foursight_from_env(request=mock_request('fourfront-cgaptest' + dev_suffix),
+                                            envname='fourfront-cgaptest') == 'cgaptest'
+            assert infer_foursight_from_env(request=mock_request('fourfront-cgapwolf' + dev_suffix),
+                                            envname='fourfront-cgapwolf') == 'cgapwolf'
+            assert infer_foursight_from_env(request=mock_request('fourfront-cgap' + dev_suffix),
+                                            envname='fourfront-cgap') == 'cgap'
 
-            assert infer_foursight_from_env(mock_request('cgap.hms.harvard.edu'), 'fourfront-cgap') == 'cgap'
-            assert infer_foursight_from_env(mock_request('cgap.hms.harvard.edu'), 'cgap') == 'cgap'
+            assert infer_foursight_from_env(request=mock_request('cgap.hms.harvard.edu'), envname='fourfront-cgap') == 'cgap'
+            assert infer_foursight_from_env(request=mock_request('cgap.hms.harvard.edu'), envname='cgap') == 'cgap'
 
 
 @pytest.mark.skip

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -1626,10 +1626,14 @@ def test_orchestrated_infer_foursight_from_env():
     def mock_request(domain):  # build a dummy request with the 'domain' member, checked in the method
         return MockedRequest(domain)
 
-    assert infer_foursight_from_env(request=mock_request('acme-prd' + dev_suffix), envname='acme-prd') == 'cgap'
-    assert infer_foursight_from_env(request=mock_request('acme-mastertest' + dev_suffix), envname='acme-mastertest') == 'mastertest'
-    assert infer_foursight_from_env(request=mock_request('acme-webdev' + dev_suffix), envname='acme-webdev') == 'webdev'
-    assert infer_foursight_from_env(request=mock_request('acme-hotseat' + dev_suffix), envname='acme-hotseat') == 'hotseat'
+    assert infer_foursight_from_env(request=mock_request('acme-prd' + dev_suffix),
+                                    envname='acme-prd') == 'cgap'
+    assert infer_foursight_from_env(request=mock_request('acme-mastertest' + dev_suffix),
+                                    envname='acme-mastertest') == 'mastertest'
+    assert infer_foursight_from_env(request=mock_request('acme-webdev' + dev_suffix),
+                                    envname='acme-webdev') == 'webdev'
+    assert infer_foursight_from_env(request=mock_request('acme-hotseat' + dev_suffix),
+                                    envname='acme-hotseat') == 'hotseat'
 
     with stage_mirroring(enabled=True):
 
@@ -1644,13 +1648,17 @@ def test_orchestrated_infer_foursight_from_env():
                                             envname='fourfront-hotseat') == 'hotseat'
 
             # (active) fourfront production environments
-            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='fourfront-blue')
+            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'),
+                                             envname='fourfront-blue')
                     == 'data')
-            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='fourfront-green')
+            assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'),
+                                             envname='fourfront-green')
                     == 'data')
-            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='fourfront-blue')
+            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'),
+                                             envname='fourfront-blue')
                     == 'staging')
-            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='fourfront-green')
+            assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'),
+                                             envname='fourfront-green')
                     == 'staging')
 
             # These next four are pathological and hopefully not used, but they illustrate that the domain dominates.
@@ -1692,8 +1700,10 @@ def test_orchestrated_infer_foursight_from_env():
             assert infer_foursight_from_env(request=mock_request('fourfront-cgap' + dev_suffix),
                                             envname='fourfront-cgap') == 'cgap'
 
-            assert infer_foursight_from_env(request=mock_request('cgap.hms.harvard.edu'), envname='fourfront-cgap') == 'cgap'
-            assert infer_foursight_from_env(request=mock_request('cgap.hms.harvard.edu'), envname='cgap') == 'cgap'
+            assert infer_foursight_from_env(request=mock_request('cgap.hms.harvard.edu'),
+                                            envname='fourfront-cgap') == 'cgap'
+            assert infer_foursight_from_env(request=mock_request('cgap.hms.harvard.edu'),
+                                            envname='cgap') == 'cgap'
 
 
 @pytest.mark.skip

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -1540,8 +1540,8 @@ def test_get_foursight_bucket():
             assert infer_foursight_from_env(envname='acme-foo') == 'foo'
             assert infer_foursight_from_env(envname='acme-stg') == 'stg'
 
-            assert get_foursight_bucket(envname='acme-foo', stage='prod') == 'alpha-omega-prod-foo'
-            assert get_foursight_bucket(envname='acme-stg', stage='dev') == 'alpha-omega-dev-stg'
+            assert get_foursight_bucket(envname='acme-foo', stage='prod') == 'alpha-omega-prod-acme-foo'
+            assert get_foursight_bucket(envname='acme-stg', stage='dev') == 'alpha-omega-dev-acme-stg'
 
         with pytest.raises(MissingFoursightBucketTable):
             get_foursight_bucket(envname='acme-foo', stage='prod')

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -493,609 +493,29 @@ def test_orchestrated_public_url_for_app():
 @using_orchestrated_behavior()
 def test_orchestrated_is_cgap_server_for_cgap():
 
-    assert is_cgap_server("localhost") is False
-    assert is_cgap_server("localhost", allow_localhost=True) is True
-
-    assert is_cgap_server("http://localhost") is False
-    assert is_cgap_server("http://localhost", allow_localhost=True) is True
-
-    assert is_cgap_server("https://localhost") is False
-    assert is_cgap_server("https://localhost", allow_localhost=True) is True
-
-    assert is_cgap_server("127.0.0.1") is False
-    assert is_cgap_server("127.0.0.1", allow_localhost=True) is True
-
-    assert is_cgap_server("http://127.0.0.1") is False
-    assert is_cgap_server("http://127.0.0.1", allow_localhost=True) is True
-
-    assert is_cgap_server("https://127.0.0.1") is False
-    assert is_cgap_server("https://127.0.0.1", allow_localhost=True) is True
-
-    assert is_cgap_server("cgap.genetics.example.com") is True
-
-    assert is_cgap_server("http://cgap.genetics.example.com") is True
-    assert is_cgap_server("http://cgap.genetics.example.com/") is True
-    assert is_cgap_server("http://cgap.genetics.example.com/me") is True
-
-    assert is_cgap_server("https://cgap.genetics.example.com") is True
-    assert is_cgap_server("https://cgap.genetics.example.com/") is True
-    assert is_cgap_server("https://cgap.genetics.example.com/me") is True
-
-    assert is_cgap_server("example.com") is False
-    assert is_cgap_server("https://example.com") is False
-
-    with pytest.raises(ValueError):
-        is_cgap_server(None)
-
-    assert is_cgap_server("data.4dnucleome.org") is False             # Fourfront needs a separate orchestration
-    assert is_cgap_server("http://data.4dnucleome.org") is False      # ditto
-    assert is_cgap_server("https://data.4dnucleome.org") is False     # ditto
-
-    assert is_cgap_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_cgap_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_cgap_server("https://staging.4dnucleome.org") is False  # ditto
-
-    assert is_cgap_server("cgap.hms.harvard.edu") is False
-
-    assert EnvUtils.DEV_ENV_DOMAIN_SUFFIX == ".abc123def456ghi789.us-east-1.rds.amazonaws.com"
-
-    # An environment plus the suffix we require is the easy case here.
-    assert is_cgap_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-
-    # Extra middle components are allowed as we've presently implemented it.
-    assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-
-    # Not all of the suffix is present here, so this will fail.
-    assert is_cgap_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-
-    # Of course a just-plain-wrong suffix will fail.
-    assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False  # wrong suffix
-
-    # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-    assert is_cgap_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-    # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_cgap_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".us-east-1.rds.amazonaws.com"):
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.us-east-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is True
-
-        # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".rds.amazonaws.com"):
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.us-east-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is True
-
-        # We're only requiring .rds.amazon.com, so even .us-west-1... will match.
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is True
-        assert is_cgap_server("acme-foo.us-west-1.rds.amazonaws.com") is True
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-        assert is_cgap_server("www.google.com") is False
-
-        # Make sure we don't recognize the non-orchestrated ones.
-        # It might seem like the cgap one should succeed, but really we're trying not to recognize "anything cgap-like"
-        # but anything in my own cgap ecosystem. These are outside.
+    assert is_cgap_server('anything') is True
+    assert is_cgap_server('anything', allow_localhost=True) is True
 
 
 @using_orchestrated_behavior(data=EnvUtils.SAMPLE_TEMPLATE_FOR_FOURFRONT_TESTING)
 def test_orchestrated_is_cgap_server_for_fourfront():
 
-    assert is_cgap_server("localhost") is False
-    assert is_cgap_server("localhost", allow_localhost=True) is False
-
-    assert is_cgap_server("http://localhost") is False
-    assert is_cgap_server("http://localhost", allow_localhost=True) is False
-
-    assert is_cgap_server("https://localhost") is False
-    assert is_cgap_server("https://localhost", allow_localhost=True) is False
-
-    assert is_cgap_server("127.0.0.1") is False
-    assert is_cgap_server("127.0.0.1", allow_localhost=True) is False
-
-    assert is_cgap_server("http://127.0.0.1") is False
-    assert is_cgap_server("http://127.0.0.1", allow_localhost=True) is False
-
-    assert is_cgap_server("https://127.0.0.1") is False
-    assert is_cgap_server("https://127.0.0.1", allow_localhost=True) is False
-
-    assert is_cgap_server("genetics.example.com") is False
-
-    assert is_cgap_server("https://genetics.example.com") is False
-
-    assert is_cgap_server("http://genetics.example.com") is False
-    assert is_cgap_server("http://genetics.example.com/") is False
-    assert is_cgap_server("http://genetics.example.com/me") is False
-
-    assert is_cgap_server("https://genetics.example.com") is False
-    assert is_cgap_server("https://genetics.example.com/") is False
-    assert is_cgap_server("https://genetics.example.com/me") is False
-
-    assert is_cgap_server("example.com") is False
-    assert is_cgap_server("https://example.com") is False
-
-    with pytest.raises(ValueError):
-        is_cgap_server(None)
-
-    assert is_cgap_server("data.4dnucleome.org") is False             # Legacy Fourfront is not the orchestrated one
-    assert is_cgap_server("http://data.4dnucleome.org") is False      # ditto
-    assert is_cgap_server("https://data.4dnucleome.org") is False     # ditto
-
-    assert is_cgap_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_cgap_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_cgap_server("https://staging.4dnucleome.org") is False  # ditto
-
-    # NOTE: This last is actually a bug, but included here for reference.
-    #       We're matching 'cgap' in part1 of the hostname, which is no worse than what used to happen in legacy cgap.
-    #       But the cgap it's matching is in another domain. We don't presently enforce a domain suffix.
-    #       -kmp 24-Jul-2021
-    assert is_cgap_server("cgap.hms.harvard.edu") is False  # TODO: Fix this bug. See explanation above.
-
-    assert EnvUtils.DEV_ENV_DOMAIN_SUFFIX == ".abc123def456ghi789.us-east-1.rds.amazonaws.com"
-
-    # An environment plus the suffix we require is the easy case here.
-    assert is_cgap_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-
-    # Extra middle components are allowed as we've presently implemented it.
-    assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-
-    # Not all of the suffix is present here, so this will fail.
-    assert is_cgap_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-
-    # Of course a just-plain-wrong suffix will fail.
-    assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False  # wrong suffix
-
-    # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-    assert is_cgap_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-    # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_cgap_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".us-east-1.rds.amazonaws.com"):
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".rds.amazonaws.com"):
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # We're only requiring .rds.amazon.com, so even .us-west-1... will match.
-
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_cgap_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_cgap_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-        assert is_cgap_server("www.google.com") is False
-
-        # Make sure we don't recognize the non-orchestrated ones.
-        # It might seem like the cgap one should succeed, but really we're trying not to recognize "anything cgap-like"
-        # but anything in my own cgap ecosystem. These are outside.
+    assert is_cgap_server('anything') is False
+    assert is_cgap_server('anything', allow_localhost=True) is False
 
 
 @using_orchestrated_behavior(data=EnvUtils.SAMPLE_TEMPLATE_FOR_FOURFRONT_TESTING)
 def test_orchestrated_is_fourfront_server_for_fourfront():
 
-    assert is_fourfront_server("localhost") is False
-    assert is_fourfront_server("localhost", allow_localhost=True) is True
-
-    assert is_fourfront_server("http://localhost") is False
-    assert is_fourfront_server("http://localhost", allow_localhost=True) is True
-
-    assert is_fourfront_server("https://localhost") is False
-    assert is_fourfront_server("https://localhost", allow_localhost=True) is True
-
-    assert is_fourfront_server("127.0.0.1") is False
-    assert is_fourfront_server("127.0.0.1", allow_localhost=True) is True
-
-    assert is_fourfront_server("http://127.0.0.1") is False
-    assert is_fourfront_server("http://127.0.0.1", allow_localhost=True) is True
-
-    assert is_fourfront_server("https://127.0.0.1") is False
-    assert is_fourfront_server("https://127.0.0.1", allow_localhost=True) is True
-
-    assert is_fourfront_server("genetics.example.com") is True
-
-    assert is_fourfront_server("https://genetics.example.com") is True
-
-    assert is_fourfront_server("http://genetics.example.com") is True
-    assert is_fourfront_server("http://genetics.example.com/") is True
-    assert is_fourfront_server("http://genetics.example.com/me") is True
-
-    assert is_fourfront_server("https://genetics.example.com") is True
-    assert is_fourfront_server("https://genetics.example.com/") is True
-    assert is_fourfront_server("https://genetics.example.com/me") is True
-
-    assert is_fourfront_server("example.com") is False
-    assert is_fourfront_server("https://example.com") is False
-
-    with pytest.raises(ValueError):
-        is_fourfront_server(None)
-
-    assert is_fourfront_server("data.4dnucleome.org") is False             # Fourfront needs a separate orchestration
-    assert is_fourfront_server("http://data.4dnucleome.org") is False      # ditto
-    assert is_fourfront_server("https://data.4dnucleome.org") is False     # ditto
-
-    # NOTE: These only "succeed" (returning False) because we don't have mirroring on.
-
-    assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-
-    with local_attrs(EnvUtils, STG_ENV_NAME='acme-stg'):
-
-        assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-        assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-        assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-
-        with stage_mirroring(enabled=True):
-
-            assert is_fourfront_server("https://staging.4dnucleome.org") is False
-            assert is_fourfront_server("https://staging.4dnucleome.org") is False
-            assert is_fourfront_server("https://staging.4dnucleome.org") is False
-
-    assert is_fourfront_server("cgap.hms.harvard.edu") is False
-
-    assert EnvUtils.DEV_ENV_DOMAIN_SUFFIX == ".abc123def456ghi789.us-east-1.rds.amazonaws.com"
-
-    # An environment plus the suffix we require is the easy case here.
-    assert is_fourfront_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-
-    # Extra middle components are allowed as we've presently implemented it.
-    assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-
-    # Not all of the suffix is present here, so this will fail.
-    assert is_fourfront_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-
-    # Of course a just-plain-wrong suffix will fail.
-    assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False  # wrong suffix
-
-    # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-    assert is_fourfront_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-    # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_fourfront_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".us-east-1.rds.amazonaws.com"):
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.us-east-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is True
-
-        # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".rds.amazonaws.com"):
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.us-east-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is True
-
-        # We're only requiring .rds.amazon.com, so even .us-west-1... will match.
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is True
-        assert is_fourfront_server("acme-foo.us-west-1.rds.amazonaws.com") is True
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-        assert is_fourfront_server("www.google.com") is False
-
-        # Make sure we don't recognize the non-orchestrated ones.
-        # It might seem like the cgap one should succeed, but really we're trying not to recognize "anything cgap-like"
-        # but anything in my own cgap ecosystem. These are outside.
+    assert is_fourfront_server('anything') is True
+    assert is_fourfront_server('anything', allow_localhost=True) is True
 
 
 @using_orchestrated_behavior()
 def test_orchestrated_is_fourfront_server_for_cgap():
 
-    assert is_fourfront_server("localhost") is False
-    assert is_fourfront_server("localhost", allow_localhost=True) is False
-
-    assert is_fourfront_server("http://localhost") is False
-    assert is_fourfront_server("http://localhost", allow_localhost=True) is False
-
-    assert is_fourfront_server("https://localhost") is False
-    assert is_fourfront_server("https://localhost", allow_localhost=True) is False
-
-    assert is_fourfront_server("127.0.0.1") is False
-    assert is_fourfront_server("127.0.0.1", allow_localhost=True) is False
-
-    assert is_fourfront_server("http://127.0.0.1") is False
-    assert is_fourfront_server("http://127.0.0.1", allow_localhost=True) is False
-
-    assert is_fourfront_server("https://127.0.0.1") is False
-    assert is_fourfront_server("https://127.0.0.1", allow_localhost=True) is False
-
-    assert is_fourfront_server("genetics.example.com") is False
-
-    assert is_fourfront_server("https://genetics.example.com") is False
-
-    assert is_fourfront_server("http://genetics.example.com") is False
-    assert is_fourfront_server("http://genetics.example.com/") is False
-    assert is_fourfront_server("http://genetics.example.com/me") is False
-
-    assert is_fourfront_server("https://genetics.example.com") is False
-    assert is_fourfront_server("https://genetics.example.com/") is False
-    assert is_fourfront_server("https://genetics.example.com/me") is False
-
-    assert is_fourfront_server("example.com") is False
-    assert is_fourfront_server("https://example.com") is False
-
-    with pytest.raises(ValueError):
-        is_fourfront_server(None)
-
-    assert is_fourfront_server("data.4dnucleome.org") is False             # Fourfront needs a separate orchestration
-    assert is_fourfront_server("http://data.4dnucleome.org") is False      # ditto
-    assert is_fourfront_server("https://data.4dnucleome.org") is False     # ditto
-
-    assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-    assert is_fourfront_server("https://staging.4dnucleome.org") is False  # ditto
-
-    # NOTE: This last is actually a bug, but included here for reference.
-    #       We're matching 'cgap' in part1 of the hostname, which is no worse than what used to happen in legacy cgap.
-    #       But the cgap it's matching is in another domain. We don't presently enforce a domain suffix.
-    #       -kmp 24-Jul-2021
-    assert is_fourfront_server("cgap.hms.harvard.edu") is False  # TODO: Fix this bug. See explanation above.
-
-    assert EnvUtils.DEV_ENV_DOMAIN_SUFFIX == ".abc123def456ghi789.us-east-1.rds.amazonaws.com"
-
-    # An environment plus the suffix we require is the easy case here.
-    assert is_fourfront_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-
-    # Extra middle components are allowed as we've presently implemented it.
-    assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-
-    # Not all of the suffix is present here, so this will fail.
-    assert is_fourfront_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-
-    # Of course a just-plain-wrong suffix will fail.
-    assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False  # wrong suffix
-
-    # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-    assert is_fourfront_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-    # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-    assert is_fourfront_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-    assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".us-east-1.rds.amazonaws.com"):
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # We're requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-    with local_attrs(EnvUtils, DEV_ENV_DOMAIN_SUFFIX=".rds.amazonaws.com"):
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # We're only requiring .rds.amazon.com, so even .us-west-1... will match.
-
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("acme-foo.us-west-1.rds.amazonaws.com") is False
-
-        # Matching on an environment name requires the prefix (here we've declared "acme-")
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-east-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-east-1.rds.amazonaws.com") is False
-
-        # Also, we're again requiring .us-east-1..., and these are .us-west-1..., so they will all fail.
-
-        assert is_fourfront_server("blah-foo.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.something.abc123def456ghi789.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.us-west-1.rds.amazonaws.com") is False
-        assert is_fourfront_server("blah-foo.xxx123xxx456xxx789.us-west-1.rds.amazonaws.com") is False
-
-        assert is_fourfront_server("www.google.com") is False
-
-        # Make sure we don't recognize the non-orchestrated ones.
-        # It might seem like the cgap one should succeed, but really we're trying not to recognize "anything cgap-like"
-        # but anything in my own cgap ecosystem. These are outside.
+    assert is_fourfront_server('anything') is False
+    assert is_fourfront_server('anything', allow_localhost=True) is False
 
 
 @using_orchestrated_behavior()
@@ -1637,7 +1057,7 @@ def test_orchestrated_infer_foursight_from_env():
 
     with stage_mirroring(enabled=True):
 
-        with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):
+        with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):  # PRD = Blue, STG = Green
 
             # (active) fourfront testing environments
             assert infer_foursight_from_env(request=mock_request('fourfront-mastertest' + dev_suffix),
@@ -1653,10 +1073,10 @@ def test_orchestrated_infer_foursight_from_env():
                     == 'data')
             assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'),
                                              envname='fourfront-green')
-                    == 'data')
+                    == 'staging')  # Inconsistent args. The envname is used in preference to the request
             assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'),
                                              envname='fourfront-blue')
-                    == 'staging')
+                    == 'data')  # Inconsistent args. The envname is used in preference to the request
             assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'),
                                              envname='fourfront-green')
                     == 'staging')
@@ -1666,23 +1086,27 @@ def test_orchestrated_infer_foursight_from_env():
             assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='data')
                     == 'data')
             assert (infer_foursight_from_env(request=mock_request(domain='data.4dnucleome.org'), envname='staging')
-                    == 'data')
+                    == 'staging')  # Inconsistent args. The envname is used in preference to the request
 
             assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='data')
-                    == 'staging')
+                    == 'data')  # Inconsistent args. The envname is used in preference to the request
             assert (infer_foursight_from_env(request=mock_request(domain='staging.4dnucleome.org'), envname='staging')
                     == 'staging')
 
             assert (infer_foursight_from_env(request='data.4dnucleome.org', envname='data') == 'data')
-            assert (infer_foursight_from_env(request='data.4dnucleome.org', envname='staging') == 'data')
+            # Inconsistent args. The envname is used in preference to the request
+            assert (infer_foursight_from_env(request='data.4dnucleome.org', envname='staging') == 'staging')
 
             assert (infer_foursight_from_env(request='https://data.4dnucleome.org', envname='data') == 'data')
-            assert (infer_foursight_from_env(request='https://data.4dnucleome.org', envname='staging') == 'data')
+            # Inconsistent args. The envname is used in preference to the request
+            assert (infer_foursight_from_env(request='https://data.4dnucleome.org', envname='staging') == 'staging')
 
-            assert (infer_foursight_from_env(request='staging.4dnucleome.org', envname='data') == 'staging')
+            # Inconsistent args. The envname is used in preference to the request
+            assert (infer_foursight_from_env(request='staging.4dnucleome.org', envname='data') == 'data')
             assert (infer_foursight_from_env(request='staging.4dnucleome.org', envname='staging') == 'staging')
 
-            assert (infer_foursight_from_env(request='http://staging.4dnucleome.org', envname='data') == 'staging')
+            # Inconsistent args. The envname is used in preference to the request
+            assert (infer_foursight_from_env(request='http://staging.4dnucleome.org', envname='data') == 'data')
             assert (infer_foursight_from_env(request='http://staging.4dnucleome.org', envname='staging') == 'staging')
 
             assert (infer_foursight_from_env(request=None, envname='data') == 'data')

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -29,7 +29,7 @@ from dcicutils.qa_utils import raises_regexp
 from typing import Optional
 from unittest import mock
 from urllib.parse import urlparse
-from .helpers import using_fresh_cgap_state, using_fresh_ff_state
+from .helpers import using_fresh_cgap_state_for_testing, using_fresh_ff_state_for_testing
 
 
 ignorable(BeanstalkOperationNotImplemented)  # Stuff that does or doesn't use this might come and go
@@ -246,7 +246,7 @@ def test_orchestrated_infer_foursight_url_from_env():
                 == 'https://u9feld4va7.execute-api.us-east-1.amazonaws.com/api/view/cgapwolf')
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_ff_default_workflow_env():
 
     assert (default_workflow_env('fourfront')
@@ -260,7 +260,7 @@ def test_ff_default_workflow_env():
         default_workflow_env(APP_CGAP)  # noQA - we expect this error
 
 
-@using_fresh_cgap_state()
+@using_fresh_cgap_state_for_testing()
 def test_cgap_default_workflow_env():
 
     assert (default_workflow_env('cgap')

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -4,7 +4,7 @@ import json
 import os
 import pytest
 
-from dcicutils.common import APP_CGAP, APP_FOURFRONT
+from dcicutils.common import APP_CGAP, APP_FOURFRONT  # , LEGACY_GLOBAL_ENV_BUCKET
 from dcicutils.env_manager import EnvManager
 from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env,

--- a/test/test_env_utils_orchestrated_legacy_compatibility.py
+++ b/test/test_env_utils_orchestrated_legacy_compatibility.py
@@ -716,7 +716,7 @@ def test_legacy_infer_foursight_from_env():
 
     def check(token_in, token_out, request=None):
         request = request or mock_request()
-        assert infer_foursight_from_env(request, token_in) == token_out
+        assert infer_foursight_from_env(request=request, envname=token_in) == token_out
 
     # (active) fourfront testing environments
     check(FF_ENV_MASTERTEST, 'mastertest')
@@ -778,7 +778,7 @@ def test_legacy_infer_foursight_url_from_env():
         request = request or mock_request()
         prefix = cg_foursight_prefix if cgap else ff_foursight_prefix
         expected = prefix + token_out if token_out else None
-        assert infer_foursight_url_from_env(request, token_in) == expected
+        assert infer_foursight_url_from_env(request=request, envname=token_in) == expected
 
     # (active) fourfront testing environments
     check(FF_ENV_MASTERTEST, 'mastertest')

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -19,7 +19,7 @@ from dcicutils.qa_utils import (
 from types import GeneratorType
 from unittest import mock
 from urllib.parse import urlsplit, parse_qsl
-from .helpers import using_fresh_ff_state
+from .helpers import using_fresh_ff_state_for_testing
 
 
 pytestmark = pytest.mark.working
@@ -1226,7 +1226,7 @@ def test_get_es_search_generator(integrated_ff):
 
 @pytest.mark.integrated
 @pytest.mark.flaky
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_health_page(integrated_ff):
     health_res = ff_utils.get_health_page(key=integrated_ff['ff_key'])
     assert health_res and 'error' not in health_res
@@ -1707,7 +1707,7 @@ def test_convert_param():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_page(integrated_ff):
     ff_env = integrated_ff['ff_env']
     ff_env_index_namespace = integrated_ff['ff_env_index_namespace']

--- a/test/test_jh_utils.py
+++ b/test/test_jh_utils.py
@@ -7,7 +7,8 @@ import re
 import urllib.parse
 
 from dcicutils import s3_utils, ff_utils
-from dcicutils.qa_utils import override_environ, MockFileSystem
+from dcicutils.misc_utils import override_environ
+from dcicutils.qa_utils import MockFileSystem
 from unittest import mock
 from .helpers import using_fresh_ff_state
 

--- a/test/test_jh_utils.py
+++ b/test/test_jh_utils.py
@@ -10,7 +10,7 @@ from dcicutils import s3_utils, ff_utils
 from dcicutils.misc_utils import override_environ
 from dcicutils.qa_utils import MockFileSystem
 from unittest import mock
-from .helpers import using_fresh_ff_state
+from .helpers import using_fresh_ff_state_for_testing
 
 pytestmark = pytest.mark.working
 
@@ -39,7 +39,7 @@ def test_import_fails_without_initialization():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_proper_initialization(integrated_ff):
     test_server = integrated_ff['ff_key']['server']
     initialize_jh_env(test_server)
@@ -55,7 +55,7 @@ def test_proper_initialization(integrated_ff):
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_some_decorated_methods_work(integrated_ff):
     test_server = integrated_ff['ff_key']['server']
     initialize_jh_env(test_server)
@@ -151,7 +151,7 @@ class MockResponse:
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_find_valid_file_or_extra_file(integrated_ff):
 
     # This setup isn't good for a unit test, but right now we can't load jh_utils otherwise. -kmp 15-Feb-2021
@@ -223,7 +223,7 @@ def test_find_valid_file_or_extra_file(integrated_ff):
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_jh_open_4dn_file_unit(integrated_ff):
 
     # This setup isn't good for a unit test, but right now we can't load jh_utils otherwise. -kmp 15-Feb-2021
@@ -292,7 +292,7 @@ def test_jh_open_4dn_file_unit(integrated_ff):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_jh_open_4dn_file_integrated(integrated_ff):
     # this is tough because uploaded files don't actually exist on mastertest s3
     # so, this test pretty much assumes urllib will work for actually present
@@ -356,7 +356,7 @@ def test_add_mounted_file_to_session(integrated_ff):
     assert 'test' in res2.get('jupyterhub_session', {}).get('files_mounted', [])
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_mount_4dn_file(integrated_ff):
     """ Tests getting full filepath of test file on JH
         Needs an additional test (how to?)

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -25,7 +25,7 @@ from dcicutils.misc_utils import (
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
     capitalize1, local_attrs, dict_zip, json_leaf_subst,
     _is_function_of_exactly_one_required_arg,  # noQA
-    string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists,
+    string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists, print_error_message,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp
@@ -2064,6 +2064,47 @@ def test_customized_class():
                                                  % test_class_prefix):
             PRINT(getattr_customized(SampleClass2, 'FAVORITE_SONG'))
         assert printed.last is None
+
+
+class SampleException(Exception):  # Used for testing print_error_message
+    pass
+
+
+def test_print_error_message():
+
+    print()  # Start test output on a fresh line
+
+    with printed_output() as printed:
+
+        empty_dict = {}
+
+        try:
+            empty_dict['foo']  # NoQA - the x['foo'] will unconditonally err, so we don't need the value to get used
+        except Exception as e:
+            print_error_message(e)
+
+        assert printed.last == "KeyError: 'foo'"
+
+        try:
+            empty_dict['foo']  # NoQA - the x['foo'] will unconditonally err, so we don't need the value to get used
+        except Exception as e:
+            print_error_message(e, full=True)  # For KeyError, a built-in class, this won't do anything different.
+
+        assert printed.last == "KeyError: 'foo'"
+
+        try:
+            raise SampleException("Something happened.")
+        except Exception as e:
+            print_error_message(e)
+
+        assert printed.last == "SampleException: Something happened."
+
+        try:
+            raise SampleException("Something happened.")
+        except Exception as e:
+            print_error_message(e, full=True)
+
+        assert printed.last == "test.test_misc_utils.SampleException: Something happened."
 
 
 def test_url_path_join():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -2103,7 +2103,7 @@ def test_get_error_message_and_print_error_message():
 
     empty_dict = {}
 
-    test_error(# The empty_dict['foo'] will unconditonally err, so we don't need the value to get used
+    test_error(  # The empty_dict['foo'] will unconditonally err, so we don't need the value to get used
                error_descriptor=lambda: empty_dict['foo'],
                # There is no difference between short and long forms for primitive error classes that have no module id.
                expected="KeyError: 'foo'",

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -23,9 +23,9 @@ from dcicutils.misc_utils import (
     as_seconds, ref_now, in_datetime_interval, as_datetime, as_ref_datetime, as_utc_datetime, REF_TZ,
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
-    capitalize1, local_attrs, dict_zip, json_leaf_subst,
+    capitalize1, local_attrs, dict_zip, json_leaf_subst, print_error_message, get_error_message,
     _is_function_of_exactly_one_required_arg,  # noQA
-    string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists, print_error_message,
+    string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp
@@ -2070,41 +2070,48 @@ class SampleException(Exception):  # Used for testing print_error_message
     pass
 
 
-def test_print_error_message():
+def test_get_error_message_and_print_error_message():
 
     print()  # Start test output on a fresh line
 
-    with printed_output() as printed:
-
-        empty_dict = {}
+    def test_error(error_descriptor, expected, expected_full):
 
         try:
-            empty_dict['foo']  # NoQA - the x['foo'] will unconditonally err, so we don't need the value to get used
-        except Exception as e:
-            print_error_message(e)
+            # Allow either of two different ways to describe an error: as an exception or a function that raises one.
+            if isinstance(error_descriptor, Exception):
+                raise error_descriptor
+            else:
+                error_descriptor()
 
-        assert printed.last == "KeyError: 'foo'"
+        except Exception as exception:
 
-        try:
-            empty_dict['foo']  # NoQA - the x['foo'] will unconditonally err, so we don't need the value to get used
-        except Exception as e:
-            print_error_message(e, full=True)  # For KeyError, a built-in class, this won't do anything different.
+            # Test the ability to get or print the error message.
 
-        assert printed.last == "KeyError: 'foo'"
+            with printed_output() as printed:
 
-        try:
-            raise SampleException("Something happened.")
-        except Exception as e:
-            print_error_message(e)
+                assert get_error_message(exception, full=False) == expected
+                print_error_message(exception, full=False)
+                assert printed.last == expected
 
-        assert printed.last == "SampleException: Something happened."
+                assert get_error_message(exception, full=True) == expected_full
+                print_error_message(exception, full=True)
+                assert printed.last == expected_full
 
-        try:
-            raise SampleException("Something happened.")
-        except Exception as e:
-            print_error_message(e, full=True)
+            return
 
-        assert printed.last == "test.test_misc_utils.SampleException: Something happened."
+        raise AssertionError("The exception_amker did not raise an error.")
+
+    empty_dict = {}
+
+    test_error(# The empty_dict['foo'] will unconditonally err, so we don't need the value to get used
+               error_descriptor=lambda: empty_dict['foo'],
+               # There is no difference between short and long forms for primitive error classes that have no module id.
+               expected="KeyError: 'foo'",
+               expected_full="KeyError: 'foo'")
+
+    test_error(error_descriptor=SampleException("Something happened."),
+               expected="SampleException: Something happened.",
+               expected_full="test.test_misc_utils.SampleException: Something happened.")
 
 
 def test_url_path_join():

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -977,6 +977,58 @@ def test_uppercase_print_with_printed_output():
         assert printed.lines == ["foo", "bar"]
         assert printed.last == "bar"
 
+        printed.reset()
+
+        mfs = MockFileSystem()
+        with mfs.mock_exists_open_remove():
+
+            with io.open("some-file.txt", 'w') as fp:
+                PRINT("stuff to file", file=fp)
+                PRINT("stuff to console")
+                PRINT("more stuff to file", file=fp)
+                PRINT("more stuff to console")
+
+            assert printed.lines == ["stuff to console", "more stuff to console"]
+            assert printed.last == "more stuff to console"
+            assert printed.lines == printed.file_lines[None]
+            assert printed.last == printed.file_last[None]
+            assert printed.file_lines[None] == ["stuff to console", "more stuff to console"]
+            assert printed.file_last[None] == "more stuff to console"
+            assert printed.file_lines[fp] == ["stuff to file", "more stuff to file"]
+            assert printed.file_last[fp] == "more stuff to file"
+
+            PRINT("Done.")
+            assert printed.last == "Done."
+            assert printed.file_last[None] == "Done."
+            assert printed.lines == ["stuff to console", "more stuff to console", "Done."]
+            assert printed.file_lines[None] == ["stuff to console", "more stuff to console", "Done."]
+
+            PRINT("Done, too.", file=fp)
+            assert printed.file_last[fp] == "Done, too."
+            assert printed.file_lines[fp] == ["stuff to file", "more stuff to file", "Done, too."]
+
+            printed.reset()
+
+            with io.open("another-file.txt", 'w') as fp2:
+
+                assert printed.last is None
+                assert printed.file_last[None] is None
+                assert printed.file_last[sys.stdout] is None
+
+                assert printed.lines == []
+                assert printed.file_lines[None] == []
+                assert printed.file_lines[sys.stdout] == []
+
+                assert printed.file_last[fp2] is None
+                assert printed.file_lines[fp2] == []
+
+                PRINT("foo", file=fp2)
+
+                assert printed.last is None
+                assert printed.lines == []
+                assert printed.file_last[fp2] == "foo"
+                assert printed.file_lines[fp2] == ["foo"]
+
 
 def test_uppercase_print_with_time():
 

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -24,8 +24,8 @@ from dcicutils.env_utils_legacy import (
 )
 from dcicutils.exceptions import SynonymousEnvironmentVariablesMismatched, CannotInferEnvFromManyGlobalEnvs
 from dcicutils.ff_mocks import make_mock_es_url, make_mock_portal_url
-from dcicutils.misc_utils import ignored, ignorable
-from dcicutils.qa_utils import override_environ, MockBoto3, MockResponse, known_bug_expected
+from dcicutils.misc_utils import ignored, ignorable, override_environ
+from dcicutils.qa_utils import MockBoto3, MockResponse, known_bug_expected
 from dcicutils.s3_utils import s3Utils, HealthPageKey
 from requests.exceptions import ConnectionError
 from unittest import mock

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -29,7 +29,9 @@ from dcicutils.qa_utils import MockBoto3, MockResponse, known_bug_expected
 from dcicutils.s3_utils import s3Utils, HealthPageKey
 from requests.exceptions import ConnectionError
 from unittest import mock
-from .helpers import using_fresh_ff_state, using_fresh_cgap_state, using_fresh_ff_deployed_state
+from .helpers import (
+    using_fresh_ff_state_for_testing, using_fresh_cgap_state_for_testing, using_fresh_ff_deployed_state_for_testing,
+)
 from .test_ff_utils import mocked_s3utils_with_sse
 
 
@@ -94,7 +96,7 @@ def test_s3utils_constants():
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_regression_s3_utils_short_name_c4_706():
 
     # TODO: This test is broken because it calls beanstalk_info which calls describe_beanstalk_environments.
@@ -124,7 +126,7 @@ def _notice_health_page_connection_problem_for_test(env):
 
 @pytest.mark.integrated
 @pytest.mark.parametrize('ff_ordinary_envname', ['fourfront-mastertest', 'fourfront-webdev', 'fourfront-hotseat'])
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_creation_ff_ordinary(ff_ordinary_envname):
     with EnvUtils.local_env_utils_for_testing(global_env_bucket=LEGACY_GLOBAL_ENV_BUCKET, env_name=ff_ordinary_envname):
         problem = _notice_health_page_connection_problem_for_test(ff_ordinary_envname)
@@ -137,7 +139,7 @@ def test_s3utils_creation_ff_ordinary(ff_ordinary_envname):
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_creation_ff_stg():
     # TODO: I was never sure what this was testing, so it's fine if it doesn't run.
     #       The problem is that staging is not properly declared in foursight-envs for now, so this can't work.
@@ -171,7 +173,7 @@ def test_s3utils_creation_ff_stg():
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_creation_ff_prd():
     # TODO: I was never sure what this was testing, so it's fine if it doesn't run.
     #       The problem may be that data is not properly declared in foursight-envs for now.
@@ -218,7 +220,7 @@ def test_s3utils_creation_ff_prd():
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.integrated
-@using_fresh_cgap_state()
+@using_fresh_cgap_state_for_testing()
 def test_s3utils_creation_cgap_prd():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'data' implies the GA test environment has overbroad privilege.
@@ -251,7 +253,7 @@ def test_s3utils_creation_cgap_prd():
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.integrated
-@using_fresh_cgap_state()
+@using_fresh_cgap_state_for_testing()
 def test_s3utils_creation_cgap_stg():
     # Not sure why this is failing, but staging is declared wrong. -kmp 11-May-2022
     print("In test_s3Utils_creation_cgap_prd. It is now", str(datetime.datetime.now()))
@@ -260,7 +262,7 @@ def test_s3utils_creation_cgap_stg():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_keys_for_data():
     with EnvManager.global_env_bucket_named(LEGACY_GLOBAL_ENV_BUCKET):
         util = s3Utils(env='data')
@@ -276,7 +278,7 @@ def test_s3utils_get_keys_for_data():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_keys_for_staging():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'staging' implies the GA test environment has overbroad privilege.
@@ -289,7 +291,7 @@ def test_s3utils_get_keys_for_staging():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_jupyterhub_key():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'data' implies the GA test environment has overbroad privilege.
@@ -302,7 +304,7 @@ def test_s3utils_get_jupyterhub_key():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_higlass_key_integrated():
     # TODO: I'm not sure what this is testing, so it's hard to rewrite
     #   But I fear this use of env 'staging' implies the GA test environment has overbroad privilege.
@@ -315,7 +317,7 @@ def test_s3utils_get_higlass_key_integrated():
 
 
 @pytest.mark.integrated
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_google_key():
     util = s3Utils(env='staging')
     keys = util.get_google_key()
@@ -327,7 +329,7 @@ def test_s3utils_get_google_key():
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_access_keys_with_old_style_default():
     util = s3Utils(env='fourfront-mastertest')
     with mock.patch.object(util, "get_key") as mock_get_key:
@@ -344,7 +346,7 @@ def test_s3utils_get_access_keys_with_old_style_default():
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_get_key_non_json_data():
 
     util = s3Utils(env='fourfront-mastertest')
@@ -361,7 +363,7 @@ def test_s3utils_get_key_non_json_data():
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_delete_key():
 
     sample_key_name = "--- reserved_key_name_for_unit_testing ---"
@@ -396,7 +398,7 @@ def test_s3utils_delete_key():
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_s3_put():
 
     util = s3Utils(env='fourfront-mastertest')
@@ -427,7 +429,7 @@ def test_s3utils_s3_put():
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3utils_s3_put_secret():
 
     util = s3Utils(env='fourfront-mastertest')
@@ -467,7 +469,7 @@ def test_s3utils_s3_put_secret():
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_does_key_exist_integrated():
     """ Use staging to check for non-existant key """
     # TODO: One problem is that staging is not properly declared in foursight-envs for now.
@@ -478,7 +480,7 @@ def test_does_key_exist_integrated():
 
 @pytest.mark.beanstalk_failure
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_does_key_exist_unit(integrated_names):
     """ Use staging to check for non-existant key """
     # TODO: One problem is that staging is not properly declared in foursight-envs for now.
@@ -488,14 +490,14 @@ def test_does_key_exist_unit(integrated_names):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_read_s3_integrated(integrated_s3_info):
     read = integrated_s3_info['s3Obj'].read_s3(integrated_s3_info['filename'])
     assert read.strip() == b'thisisatest'
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_read_s3_unit(integrated_names):
     # This unit test needs work, but its corresponding integration test works.
     # with mocked_s3_integration(integrated_names=integrated_names) as s3_connection:
@@ -512,7 +514,7 @@ def test_read_s3_unit(integrated_names):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_file_size_integrated(integrated_s3_info):
     size = integrated_s3_info['s3Obj'].get_file_size(integrated_s3_info['filename'])
     assert size == 11
@@ -522,7 +524,7 @@ def test_get_file_size_integrated(integrated_s3_info):
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_file_size_unit(integrated_names):
 
     # This unit test needs work, but its corresponding integration test works.
@@ -544,7 +546,7 @@ def test_get_file_size_unit(integrated_names):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_size_integrated(integrated_s3_info):
     """ Get size of non-existent, real bucket """
     bucket = integrated_s3_info['s3Obj'].sys_bucket
@@ -556,7 +558,7 @@ def test_size_integrated(integrated_s3_info):
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_size_unit(integrated_names):
     """ Get size of non-existent, real bucket """
 
@@ -585,7 +587,7 @@ def test_size_unit(integrated_names):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_file_size_in_gb_integrated(integrated_s3_info):
 
     s3_connection = integrated_s3_info['s3Obj']
@@ -596,7 +598,7 @@ def test_get_file_size_in_gb_integrated(integrated_s3_info):
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_file_size_in_gb_unit(integrated_names):
 
     # This unit test needs work, but its corresponding integration test works.
@@ -616,7 +618,7 @@ def test_get_file_size_in_gb_unit(integrated_names):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_read_s3_zip_integrated(integrated_s3_info):
     filename = integrated_s3_info['zip_filename']
     files = integrated_s3_info['s3Obj'].read_s3_zipfile(filename, ['summary.txt', 'fastqc_data.txt'])
@@ -626,7 +628,7 @@ def test_read_s3_zip_integrated(integrated_s3_info):
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_read_s3_zip_unit(integrated_names):
 
     # with mocked_s3_integration(integrated_names=integrated_names) as s3_connection:
@@ -656,7 +658,7 @@ def test_read_s3_zip_unit(integrated_names):
 
 @pytest.mark.integratedx
 @pytest.mark.parametrize("suffix, expected_report", [("", "fastqc_report.html"), ("2", "qc_report.html")])
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_unzip_s3_to_s3_integrated(integrated_s3_info, suffix, expected_report):
     """test for unzip_s3_to_s3 with case where there is a basdir"""
 
@@ -685,7 +687,7 @@ def test_unzip_s3_to_s3_integrated(integrated_s3_info, suffix, expected_report):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("suffix, expected_report", [("", "fastqc_report.html"), ("2", "qc_report.html")])
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_unzip_s3_to_s3_unit(integrated_names, suffix, expected_report):
     """test for unzip_s3_to_s3 with case where there is no basdir"""
 
@@ -720,7 +722,7 @@ def test_unzip_s3_to_s3_unit(integrated_names, suffix, expected_report):
 
 
 @pytest.mark.integratedx
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_unzip_s3_to_s3_store_results_integrated(integrated_s3_info):
     """test for unzip_s3_to_s3 with case where there is a basdir and store_results=False"""
     prefix = '__test_data/extracted'
@@ -743,7 +745,7 @@ def test_unzip_s3_to_s3_store_results_integrated(integrated_s3_info):
 
 
 @pytest.mark.unit
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_unzip_s3_to_s3_store_results_unit(integrated_names):
     """test for unzip_s3_to_s3 with case where there is a basdir and store_results=False"""
 
@@ -776,7 +778,7 @@ def test_unzip_s3_to_s3_store_results_unit(integrated_names):
         assert objs.get('Contents')
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3_utils_legacy_behavior():
     # From https://hms-dbmi.atlassian.net/browse/C4-674
 
@@ -815,7 +817,7 @@ def test_s3_utils_legacy_behavior():
         test_it()
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3_utils_buckets_modern():
 
     env_name = 'fourfront-foo'
@@ -886,7 +888,7 @@ def test_s3_utils_buckets_modern():
             assert e.env_name == env_name
 
 
-@using_fresh_ff_deployed_state()
+@using_fresh_ff_deployed_state_for_testing()
 def test_s3_utils_buckets_ff_live_ecosystem_not_production():
 
     print()  # Start on fresh line
@@ -931,7 +933,7 @@ def test_s3_utils_buckets_ff_live_ecosystem_not_production():
         assert s3u.env_manager.env_name == full_env
 
 
-@using_fresh_ff_deployed_state()
+@using_fresh_ff_deployed_state_for_testing()
 def test_s3_utils_buckets_ff_live_ecosystem_production():
 
     print()  # Start on fresh line
@@ -976,7 +978,7 @@ def test_s3_utils_buckets_ff_live_ecosystem_production():
         assert is_stg_or_prd_env(s3u.env_manager.env_name)
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3_utils_environment_variable_use():
 
     with pytest.raises(SynonymousEnvironmentVariablesMismatched):
@@ -993,7 +995,7 @@ def test_s3_utils_environment_variable_use():
                 s3Utils()
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3_utils_verify_and_get_env_config():
 
     with mock.patch.object(EnvManager, "verify_and_get_env_config") as mock_implementation:
@@ -1010,7 +1012,7 @@ def test_s3_utils_verify_and_get_env_config():
         s3Utils.verify_and_get_env_config('dummy-s3', 'dummy-bucket', 'dummy-env')
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_s3_utils_fetch_health_page_json():
 
     with mock.patch.object(EnvManager, "fetch_health_page_json") as mock_implementation:
@@ -1026,7 +1028,7 @@ def test_s3_utils_fetch_health_page_json():
         s3Utils.fetch_health_page_json('dummy-url', 'dummy-use-urllib')
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_env_manager_fetch_health_page_json():
 
     sample_health_page = {"mocked": "health-page"}
@@ -1071,7 +1073,7 @@ def test_env_manager_fetch_health_page_json():
             assert helper.used_mocked_urlopen is True
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_env_manager():
 
     test_env = 'fourfront-foo'
@@ -1125,7 +1127,7 @@ def test_env_manager():
         assert env_mgr.env_name == test_env2
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_env_manager_verify_and_get_env_config():
 
     test_env = 'fourfront-foo'
@@ -1151,7 +1153,7 @@ def test_env_manager_verify_and_get_env_config():
         assert config['ff_env'] == test_env
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_env_manager_compose():
 
     test_env = 'fourfront-foo'
@@ -1179,7 +1181,7 @@ def test_env_manager_compose():
         assert env_manager_from_desc.env_description['es'] == test_es
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_env_manager_global_env_bucket_name():
 
     # Now that we're containerized, there is always something in GLOBAL_ENV_BUCKET
@@ -1233,7 +1235,7 @@ def test_env_manager_global_env_bucket_name():
                 assert EnvManager.global_env_bucket_name() == 'bar'
 
 
-@using_fresh_ff_state()
+@using_fresh_ff_state_for_testing()
 def test_get_and_set_object_tags():
 
     mock_boto3 = MockBoto3()

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -14,7 +14,7 @@ from dcicutils.beanstalk_utils import compute_ff_prd_env, compute_cgap_prd_env, 
 from dcicutils.common import LEGACY_GLOBAL_ENV_BUCKET
 from dcicutils.env_manager import EnvManager
 from dcicutils.env_utils import (
-    get_standard_mirror_env, EnvUtils, short_env_name, full_env_name, infer_foursight_from_env
+    get_standard_mirror_env, EnvUtils, short_env_name
 )
 from dcicutils.env_utils_legacy import (
     FF_PUBLIC_URL_STG, FF_PUBLIC_URL_PRD,

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -260,16 +260,17 @@ def test_s3utils_creation_cgap_stg():
 @pytest.mark.integrated
 @using_fresh_ff_state()
 def test_s3utils_get_keys_for_data():
-    util = s3Utils(env='data')
-    keys = util.get_access_keys()
-    assert keys['server'] == 'https://data.4dnucleome.org'
-    # make sure we have keys for foursight and tibanna as well
-    keys_tb = util.get_access_keys('access_key_tibanna')
-    assert keys_tb['key'] != keys['key']
-    assert keys_tb['server'] == keys['server']
-    keys_fs = util.get_access_keys('access_key_foursight')
-    assert keys_fs['key'] != keys_tb['key'] != keys['key']
-    assert keys_fs['server'] == keys['server']
+    with EnvManager.global_env_bucket_named(LEGACY_GLOBAL_ENV_BUCKET):
+        util = s3Utils(env='data')
+        keys = util.get_access_keys()
+        assert keys['server'] == 'https://data.4dnucleome.org'
+        # make sure we have keys for foursight and tibanna as well
+        keys_tb = util.get_access_keys('access_key_tibanna')
+        assert keys_tb['key'] != keys['key']
+        assert keys_tb['server'] == keys['server']
+        keys_fs = util.get_access_keys('access_key_foursight')
+        assert keys_fs['key'] != keys_tb['key'] != keys['key']
+        assert keys_fs['server'] == keys['server']
 
 
 @pytest.mark.integrated

--- a/test/test_secrets_utils.py
+++ b/test/test_secrets_utils.py
@@ -1,15 +1,30 @@
 import json
+import os
+
 import pytest
 
 from dcicutils import secrets_utils as secrets_utils_module
 from dcicutils.misc_utils import override_environ, ignored
 from dcicutils.qa_utils import MockBoto3
-from dcicutils.secrets_utils import assume_identity, SecretsTable
+from dcicutils.secrets_utils import (
+    GLOBAL_APPLICATION_CONFIGURATION, LEGACY_DEFAULT_IDENTITY_NAME,
+    get_identity_name, identity_is_defined, apply_overrides,
+    assumed_identity, assumed_identity_if, apply_identity,
+    get_identity_secrets, assume_identity, SecretsTable,
+)
 from unittest import mock
 
 
-some_secret_names = ['foo', 'bar']
+some_secret_name_1 = 'foo12345'
+some_secret_name_2 = 'bar67890'
+
+some_secret_names = [some_secret_name_1, some_secret_name_2]
+
 some_secret_values = ['the {item} thing' for item in some_secret_names]
+
+some_secret_value_1 = some_secret_values[0]
+some_secret_value_2 = some_secret_values[1]
+
 # in other words, some_secret_table = {"foo": "the foo thing", "bar": "the bar thing"}
 some_secret_table = dict(zip(some_secret_names, some_secret_values))
 some_secret_string = json.dumps(some_secret_table)
@@ -36,6 +51,62 @@ some_secret_identities_with_common_pattern = [some_secret_identity, decoy_1_iden
 some_secret_identities = [some_secret_identity, decoy_1_identity, decoy_2_identity]
 
 
+def test_get_identity_name():
+
+    with override_environ(**{GLOBAL_APPLICATION_CONFIGURATION: None}):
+        assert get_identity_name() == LEGACY_DEFAULT_IDENTITY_NAME
+        assert get_identity_name('MY_IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
+
+    some_name = 'SomeIdentityForTesting'
+    with override_environ(**{GLOBAL_APPLICATION_CONFIGURATION: some_name}):
+        assert get_identity_name() == some_name
+        assert get_identity_name('MY_IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
+
+
+def test_identity_is_defined():
+
+    with override_environ(**{GLOBAL_APPLICATION_CONFIGURATION: None}):
+        assert identity_is_defined() is False
+        assert identity_is_defined('IDENTITY') is False
+        assert identity_is_defined('MY_IDENTITY') is False
+
+    some_name = 'SomeIdentityForTesting'
+    with override_environ(**{GLOBAL_APPLICATION_CONFIGURATION: some_name}):
+        assert identity_is_defined() is True
+        assert identity_is_defined('IDENTITY') is True
+        assert identity_is_defined('MY_IDENTITY') is False
+
+    with override_environ(MY_IDENTITY='SomeOtherIdentity'):
+        assert identity_is_defined('MY_IDENTITY') is True
+
+
+def test_apply_overrides():
+
+    secrets = {'x': 1, 'y': 2}
+
+    assert apply_overrides(secrets=secrets, override_values=None) == secrets
+    assert apply_overrides(secrets=secrets, override_values={}) == secrets
+    assert apply_overrides(secrets=secrets) == secrets
+
+    assert apply_overrides(secrets=secrets, rename_keys={'x': 'ex'}) == {'ex': 1, 'y': 2}
+    assert apply_overrides(secrets=secrets, rename_keys={'x': 'ex', 'y': 'why'}) == {'ex': 1, 'why': 2}
+
+    with pytest.raises(ValueError):
+        apply_overrides(secrets=secrets, rename_keys={'z': 'zee'})
+
+    with pytest.raises(ValueError):
+        apply_overrides(secrets=secrets, rename_keys={'x': 'y'})
+
+    assert apply_overrides(secrets=secrets, override_values={'x': 3}) == {'x': 3, 'y': 2}
+    assert apply_overrides(secrets=secrets, override_values={'x': 3, 'z': 9}) == {'x': 3, 'y': 2, 'z': 9}
+
+    assert (apply_overrides(secrets=secrets, rename_keys={'x': 'ex', 'y': 'why'}, override_values={'ex': 3, 'zee': 9})
+            == {'ex': 3, 'why': 2, 'zee': 9})
+
+    assert (apply_overrides(secrets=secrets, rename_keys={'x': 'ex', 'y': 'why'}, override_values={'x': 3, 'zee': 9})
+            == {'ex': 1, 'why': 2, 'zee': 9, 'x': 3})
+
+
 def boto3_for_some_secrets_testing():
     mocked_boto3 = MockBoto3()
     manager = mocked_boto3.client('secretsmanager')
@@ -45,32 +116,148 @@ def boto3_for_some_secrets_testing():
     return mocked_boto3
 
 
+def test_get_identity_secrets():
+    check_get_identity_secrets(get_identity_secrets)
+
+
 def test_assume_identity():
+    check_get_identity_secrets(assume_identity)
+
+
+def check_get_identity_secrets(fn):
 
     b3 = boto3_for_some_secrets_testing()  # this sets things up with some_secret_string in the SecretsManager
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
         with override_environ(IDENTITY=some_secret_identity):
-            identity = assume_identity()
-            assert identity == some_secret_table  # this is the parsed form of some_secret_string
+            secrets = fn()
+            assert secrets == some_secret_table  # this is the parsed form of some_secret_string
+
+
+def test_apply_identity():
+
+    b3 = boto3_for_some_secrets_testing()
+    with mock.patch.object(secrets_utils_module, 'boto3', b3):
+
+        with override_environ(**{secret_name: None for secret_name in some_secret_names}):
+
+            for i in range(len(some_secret_names)):
+                secret_name = some_secret_names[i]
+                # Check that this test will be useful.
+                assert secret_name not in os.environ, f"Test secret variable {secret_name} is already in os.environ."
+
+            with override_environ(IDENTITY=some_secret_identity):
+
+                apply_identity()
+
+                for i in range(len(some_secret_names)):
+                    secret_name = some_secret_names[i]
+                    secret_value = some_secret_values[i]
+                    assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
+                    assert os.environ[secret_name] == secret_value
+
+            for i in range(len(some_secret_names)):
+                secret_name = some_secret_names[i]
+                # Check that this test will be useful.
+                assert secret_name in os.environ, f"Test secret variable {secret_name} did not get globally set."
+
+
+def test_assumed_identity():
+
+    b3 = boto3_for_some_secrets_testing()
+    with mock.patch.object(secrets_utils_module, 'boto3', b3):
+
+        for i in range(len(some_secret_names)):
+            secret_name = some_secret_names[i]
+            # Check that this test will be useful.
+            assert secret_name not in os.environ, f"Test secret variable {secret_name} is already in os.environ."
+
+        with override_environ(IDENTITY=some_secret_identity):
+            with assumed_identity():
+                for i in range(len(some_secret_names)):
+                    secret_name = some_secret_names[i]
+                    secret_value = some_secret_values[i]
+                    assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
+                    assert os.environ[secret_name] == secret_value
+
+        with override_environ(MY_IDENTITY=some_secret_identity):
+            with assumed_identity(identity_kind='MY_IDENTITY'):
+                for i in range(len(some_secret_names)):
+                    secret_name = some_secret_names[i]
+                    secret_value = some_secret_values[i]
+                    assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
+                    assert os.environ[secret_name] == secret_value
+
+        alt_name_1 = f"alt_{some_secret_name_1}"
+        alt_secret_names = [alt_name_1] + some_secret_names[1:]
+        alt_secret_values = some_secret_values
+
+        with override_environ(MY_IDENTITY=some_secret_identity):
+            with assumed_identity(identity_kind='MY_IDENTITY', rename_keys={some_secret_name_1: alt_name_1}):
+                for i in range(len(alt_secret_names)):
+                    alt_name = alt_secret_names[i]
+                    alt_value = alt_secret_values[i]
+                    assert alt_name in os.environ, f"Test secret variable {alt_name} is missing in os.environ."
+                    assert os.environ[secret_name] == alt_value
+
+        some_overridden_value = 'some other value'
+        with override_environ(IDENTITY=some_secret_identity):
+            with assumed_identity(override_values={some_secret_name_1: some_overridden_value}):
+                assert os.environ[some_secret_name_1] == some_overridden_value
+                assert os.environ[some_secret_name_2] == some_secret_value_2
+
+        with override_environ(IDENTITY=some_secret_identity):
+            # This will assume the identity because some_secret_name_2 is not bound in os.environ.
+            with assumed_identity(only_if_missing=some_secret_name_2):
+                assert some_secret_name_1 in os.environ
+
+        with override_environ(IDENTITY=some_secret_identity, **{some_secret_name_1: 'anything'}):
+            # This will assume the identity because some_secret_name_2 is not bound in os.environ.
+            # (Note here that some secret names are present in the environment, but not the right one.)
+            with assumed_identity(only_if_missing=some_secret_name_2):
+                assert some_secret_name_1 in os.environ
+
+        with override_environ(IDENTITY=some_secret_identity, **{some_secret_name_2: 'anything'}):
+            # This will NOT assume the identity because some_secret_name_2 IS bound in os.environ.
+            with assumed_identity(only_if_missing=some_secret_name_2):
+                assert some_secret_name_1 not in os.environ
+
+
+def test_assumed_identity_if():
+
+    b3 = boto3_for_some_secrets_testing()
+    with mock.patch.object(secrets_utils_module, 'boto3', b3):
+
+        for i in range(len(some_secret_names)):
+            secret_name = some_secret_names[i]
+            # Check that this test will be useful.
+            assert secret_name not in os.environ, f"Test secret variable {secret_name} is already in os.environ."
+
+        with override_environ(IDENTITY=some_secret_identity):
+
+            with assumed_identity_if(True):
+                assert some_secret_name_1 in os.environ
+
+            with assumed_identity_if(False):
+                assert some_secret_name_1 not in os.environ
 
 
 def test_secrets_table_as_dict():
 
     b3 = boto3_for_some_secrets_testing()
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
-        # Note that unlike assume_identity, we don't need an IDENTITY env variable,
+        # Note that unlike get_identity_secrets, we don't need an IDENTITY env variable,
         # because this strategy is assuming a single applicable secret.
         secrets_table = SecretsTable.find_application_secrets_table()
         identity = secrets_table.as_dict()
         assert identity == some_secret_table
 
 
-def test_mock_secrets_table_as_dict_and_assume_identity_equivalence():
+def test_mock_secrets_table_as_dict_and_get_identity_secrets_equivalence():
 
     b3 = boto3_for_some_secrets_testing()
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
         with override_environ(IDENTITY=some_secret_identity):
-            identity = assume_identity()
+            identity = get_identity_secrets()
             secret_table = SecretsTable.find_application_secrets_table()
             secret_table_as_dict = secret_table.as_dict()
             assert identity == secret_table_as_dict == some_secret_table
@@ -115,8 +302,8 @@ def test_secrets_table_get():
     b3 = boto3_for_some_secrets_testing()
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
         secrets_table = SecretsTable.find_application_secrets_table()
-        secret_foo = secrets_table.get('foo')
-        assert secret_foo == some_secret_table['foo']
+        secret_foo = secrets_table.get(some_secret_name_1)
+        assert secret_foo == some_secret_table[some_secret_name_1]
         secret_missing = secrets_table.get('missing')
         assert secret_missing is None
 
@@ -126,8 +313,8 @@ def test_secrets_table_getitem():
     b3 = boto3_for_some_secrets_testing()
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
         secrets_table = SecretsTable.find_application_secrets_table()
-        secret_foo = secrets_table['foo']
-        assert secret_foo == some_secret_table['foo']
+        secret_foo = secrets_table[some_secret_name_1]
+        assert secret_foo == some_secret_table[some_secret_name_1]
         with pytest.raises(KeyError):
             secret_missing = secrets_table['missing']
             ignored(secret_missing)  # the previous line will fail
@@ -161,6 +348,8 @@ def test_secrets_table_internal_find_secrets_using_substring():
         assert len(found_secrets) > 0
         assert all(isinstance(found_secret, dict) for found_secret in found_secrets)
         found_secret_names = [secret['Name'] for secret in found_secrets]
+        print(f"found_secret_names={found_secret_names}")
+        print(f"some_secret_identities_with_common_pattern={some_secret_identities_with_common_pattern}")
         assert found_secret_names == some_secret_identities_with_common_pattern
 
 


### PR DESCRIPTION
This change lets the portal and es urls needed by foursight get inferred from the ecosystem declaration so the environment declaration really only needs the ecosystem. The changes are small to the main system, a bit more complicated to tests. It needs careful review.

In the process, `infer_foursight_url_from_env` and `infer_foursight_from_env` from `env_utils` were made to require keyword arguments since I found a case or two where one arg was passed and it was assumed it was the env name but it was being taken as a request instead. Some adjustments in `foursight-core` or `foursight-cgap` might be needed, as this is an incompatible change, but they'll be small.