### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Publish
         env:
           PYPI_USER: ${{ secrets.PYPI_USER }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Install Deps
         run: |
           pip install poetry
-
+          poetry --version
+          pip freeze | grep poetry-core
       - name: QA
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -44,7 +45,7 @@ jobs:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
           GLOBAL_ENV_BUCKET: foursight-envs
         run: |
-          poetry install
+          poetry install -vvv
           make test-for-ga
 
       - name: Coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
           GLOBAL_ENV_BUCKET: foursight-envs
         run: |
-          poetry install -vvv
+          poetry install
           make test-for-ga
 
       - name: Coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9]
+        python_version: [3.7, 3.8, 3.9]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,12 +9,12 @@ Change Log
 5.0.0
 =====
 
-Breaking change:
+**BREAKING CHANGE**: Drop support for Python 3.6
 
-* Drop support for Python 3.6
 
-Other changes:
-  
+4.1.0
+=====
+
 * Add better ``CHANGELOG.rst`` for the changes that happened in 4.0.0.
 * Add unit testing for stray ``print(...)`` or ``pdb.set_trace()``
 * Support for ``ENCODED_CREATE_MAPPING_SKIP``, ``ENCODED_CREATE_MAPPING_WIPE_ES``,
@@ -1531,3 +1531,4 @@ the ``poetry.app`` section of ``pyproject.toml``, as in::
    name = "dcicutils"
    version = "100.200.300"
    ...etc.
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,15 @@ dcicutils
 Change Log
 ----------
 
-4.1.0
+5.0.0
 =====
 
+Breaking change:
+
+* Drop support for Python 3.6
+
+Other changes:
+  
 * Add better ``CHANGELOG.rst`` for the changes that happened in 4.0.0.
 * Add unit testing for stray ``print(...)`` or ``pdb.set_trace()``
 * Support for ``ENCODED_CREATE_MAPPING_SKIP``, ``ENCODED_CREATE_MAPPING_WIPE_ES``,

--- a/poetry.lock
+++ b/poetry.lock
@@ -921,8 +921,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.1,<3.10"
-content-hash = "f4b5dc93c5194ad820e62dfb46f5d64d23dba31c15ec8d54fe3a04a231c7008f"
+python-versions = ">=3.7,<3.10"
+content-hash = "7dc70bacccfee09d43af039ec491580586ffacd67c7c4d84b6838dc1c6dc3946"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,29 +11,29 @@ packages = [
   { include="dcicutils", from="." }
 ]
 classifiers = [
-    # How mature is this project? Common values are
-    #   3 - Alpha
-    #   4 - Beta
-    #   5 - Production/Stable
-    'Development Status :: 4 - Beta',
-
-    # Indicate who your project is intended for
-    'Intended Audience :: Developers',
-    'Intended Audience :: Science/Research',
-
-    # Pick your license as you wish (should match "license" above)
-    'License :: OSI Approved :: MIT License',
-
-    # Relevant topics
-    'Topic :: Database :: Database Engines/Servers',
-
-    # Specify the Python versions you support here. In particular, ensure
-    # that you indicate whether you support Python 2, Python 3 or both.
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
+#    # How mature is this project? Common values are
+#    #   3 - Alpha
+#    #   4 - Beta
+#    #   5 - Production/Stable
+#    'Development Status :: 4 - Beta',
+#
+#    # Indicate who your project is intended for
+#    'Intended Audience :: Developers',
+#    'Intended Audience :: Science/Research',
+#
+#    # Pick your license as you wish (should match "license" above)
+#    'License :: OSI Approved :: MIT License',
+#
+#    # Relevant topics
+#    'Topic :: Database :: Database Engines/Servers',
+#
+#    # Specify the Python versions you support here. In particular, ensure
+#    # that you indicate whether you support Python 2, Python 3 or both.
+#    'Programming Language :: Python :: 3',
+#    'Programming Language :: Python :: 3.6',
+#    'Programming Language :: Python :: 3.7',
+#    'Programming Language :: Python :: 3.8',
+#    'Programming Language :: Python :: 3.9',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,37 +10,25 @@ repository = "https://github.com/4dn-dcic/utils"
 packages = [
   { include="dcicutils", from="." }
 ]
-#classifiers = [
-#    # How mature is this project? Common values are
-#    #   3 - Alpha
-#    #   4 - Beta
-#    #   5 - Production/Stable
-#    'Development Status :: 4 - Beta',
-#
-#    # Indicate who your project is intended for
-#    'Intended Audience :: Developers',
-#    'Intended Audience :: Science/Research',
-#
-#    # Pick your license as you wish (should match "license" above)
-#    'License :: OSI Approved :: MIT License',
-#
-#    # Relevant topics
-#    'Topic :: Database :: Database Engines/Servers',
-#
-#    # Specify the Python versions you support here. In particular, ensure
-#    # that you indicate whether you support Python 2, Python 3 or both.
-#    'Programming Language :: Python :: 3',
-#    'Programming Language :: Python :: 3.6',
-#    'Programming Language :: Python :: 3.7',
-#    'Programming Language :: Python :: 3.8',
-#    'Programming Language :: Python :: 3.9',
-#]
 classifiers = [
+    # How mature is this project? Common values are
+    #   3 - Alpha
+    #   4 - Beta
+    #   5 - Production/Stable
     'Development Status :: 4 - Beta',
+
+    # Indicate who your project is intended for
     'Intended Audience :: Developers',
     'Intended Audience :: Science/Research',
+
+    # Pick your license as you wish (should match "license" above)
     'License :: OSI Approved :: MIT License',
+
+    # Relevant topics
     'Topic :: Database :: Database Engines/Servers',
+
+    # Specify the Python versions you support here. In particular, ensure
+    # that you indicate whether you support Python 2, Python 3 or both.
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
 ]
 
+
 [tool.poetry.dependencies]
 python = ">=3.7,<3.10"
 boto3 = "^1.17.39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,10 @@ norecursedirs = ["*env", "site-packages", ".cache", ".git", ".idea", "*.egg-info
 # pep8maxlinelength = 120
 testpaths = ["test"]
 
-
 [build-system]
-requires = ["poetry_core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+#[build-system]
+#requires = ["poetry_core>=1.0.0"]
+#build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     # Specify the Python versions you support here. In particular, ensure
     # that you indicate whether you support Python 2, Python 3 or both.
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/4dn-dcic/utils"
 packages = [
   { include="dcicutils", from="." }
 ]
-classifiers = [
+#classifiers = [
 #    # How mature is this project? Common values are
 #    #   3 - Alpha
 #    #   4 - Beta
@@ -34,8 +34,19 @@ classifiers = [
 #    'Programming Language :: Python :: 3.7',
 #    'Programming Language :: Python :: 3.8',
 #    'Programming Language :: Python :: 3.9',
+#]
+classifiers = [
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: MIT License',
+    'Topic :: Database :: Database Engines/Servers',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
 ]
-
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.10"
@@ -91,10 +102,7 @@ norecursedirs = ["*env", "site-packages", ".cache", ".git", ".idea", "*.egg-info
 # pep8maxlinelength = 120
 testpaths = ["test"]
 
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
 
-#[build-system]
-#requires = ["poetry_core>=1.0.0"]
-#build-backend = "poetry.core.masonry.api"
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.1.0"
+version = "5.0.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -38,7 +38,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.6.1,<3.10"
+python = ">=3.7,<3.10"
 boto3 = "^1.17.39"
 botocore = "^1.20.39"
 # The DCIC portals (cgap-portal and fourfront) are very particular about which ElasticSearch version.


### PR DESCRIPTION
The actual change is pretty simple:

* Drop Python 3.6 support in `pyproject.toml`
* Adjust GA workflow.
* Update `CHANGELOG.rst`

**NOTE: I think we should hold off on this change for a few days until other things have subsided, since a lot of repos would need to incorporate an incompatible version update (`dcicutils = "^5.0.0"` instead of `dcicutils = "^4.0.0"`) to get this.**

Also, taking this change should get rid of this warning (from testing on GA):
```
/home/runner/.cache/pypoetry/virtualenvs/dcicutils--i6xsha8-py3.6/lib/python3.6/site-packages/boto3/compat.py:88: 
PythonDeprecationWarning: Boto3 will no longer support Python 3.6 starting May 30, 2022. 
To continue receiving service updates, bug fixes, and security updates please upgrade to Python 3.7 or later. 
More information can be found here: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
```