### PR TITLE
Add search facet cnt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Change Log
 ----------
 
 
+4.4.1
+=====
+
+* In ``ff_utils``;
+
+  * add function ``get_search_facet values`` to support count from facets from any search
+
+
 4.4.0
 =====
 
@@ -58,7 +66,7 @@ NOTE: Due to a versioning error in beta, there was no 4.3.0. The previous releas
 * Fix various tests that had grown stale due to data changes.
   * ``test_post_delete_purge_links_metadata`` (needed to be re-recorded)
   * ``test_upsert_metadata`` (needed to be re-recorded)
-  * ``test_unified_authentication_prod_envs_integrated_only`` 
+  * ``test_unified_authentication_prod_envs_integrated_only``
     (simplified, removed bogus attempts at recording)
   * ``test_faceted_search_exp_set`` (needed many different counts)
   * ``test_some_decorated_methods_work`` (needed one different count)
@@ -459,7 +467,7 @@ these new items:
 =====
 
 * In ``ecs_utils``:
-  
+
   * No longer throw exception when listing services if <4 are returned
 
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -469,14 +469,15 @@ def get_item_facets(item_type, key=None, ff_env=None):
     return facets
 
 
-def get_item_facet_values(item_type, key=None, ff_env=None):
+def get_search_facet_values(search_query, key=None, ff_env=None):
     """
-    Gets all facets and returns all possible values for each one with counts
-    ie: dictionary of facets mapping to a dictionary containing all possible values
+    Gets all facets available from a provided search and returns all possible values for
+    each with counts - query should begin 'search/...'
+    ie: returns dictionary of facets mapping to a dictionary containing all possible values
     for that facet mapping to the count for that value
     format: {'Project': {'4DN': 2, 'Other': 6}, 'Lab': {...}}
     """
-    resp = get_metadata('search/?type=' + item_type, key=key, ff_env=ff_env)['facets']
+    resp = get_metadata(search_query, key=key, ff_env=ff_env)['facets']
     facets = {}
     for facet in resp:
         name = facet['title']
@@ -484,6 +485,15 @@ def get_item_facet_values(item_type, key=None, ff_env=None):
         for term in facet['terms']:
             facets[name][term['key']] = term['doc_count']
     return facets
+
+
+def get_item_facet_values(item_type, key=None, ff_env=None):
+    """
+    More specific version of the above function with passed item_type
+    used in faceted_search
+    """
+    query = 'search/?type=' + item_type
+    return get_search_facet_values(query, key=key, ff_env=ff_env)
 
 
 def faceted_search(key=None, ff_env=None, item_type=None, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.1.0"
+version = "4.1.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-<<<<<<< HEAD
-version = "4.1.1"
-=======
-version = "4.4.0"
->>>>>>> master
+version = "4.4.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -1255,12 +1255,27 @@ def test_get_item_facets(integrated_ff):
 def test_get_item_facet_values(integrated_ff):
     """ Tests that we correctly grab facets and all their possible values """
     key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
-    item_type = 'experiment_set_replicate'
+    item_type = 'ExperimentSetReplicate'
     facets = ff_utils.get_item_facet_values(item_type, key=key, ff_env=ff_env)
     assert 'Project' in facets
     assert '4DN' in facets['Project']
     assert 'Assay Details' in facets
     assert 'Target: YFG protein' in facets['Assay Details']
+    assert 'Status' in facets
+
+
+@pytest.mark.integrated
+def test_get_search_facet_values(integrated_ff):
+    """ Tests that we correctly grab facets and all their possible values
+    from a search query result """
+    key, ff_env = integrated_ff['ff_key'], integrated_ff['ff_env']
+    query = 'search/?lab.display_title=4DN+DCIC%2C+HMS&type=Biosource'
+    facets = ff_utils.get_search_facet_values(query, key=key, ff_env=ff_env)
+    print(facets)
+    assert 'Project' in facets
+    assert '4DN' in facets['Project']
+    assert 'Tissue' in facets
+    assert 'brain' in facets['Tissue']
     assert 'Status' in facets
 
 


### PR DESCRIPTION
Small change to allow you to grab the facet values and counts from any arbitrary search.
The original get_item_facet_values function returned the facet values and document counts for the specified item_type passed to the function.  
I added a new function get_search_facet_values that does all the same logic using the result of any search and changed the get_item_facet_values function to build a search string that is passed to the new function.