### PR TITLE
Add some small utilities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ dcicutils
 Change Log
 ----------
 
+
+4.2.0
+=====
+
+* In ``ff_utils``:
+
+  * Add ``is_bodyless`` predicate on http methods (verbs) to say if they want a data arg.
+
+* In ``env_base``:
+
+  * Add ``EnvBase.set_global_env_bucket`` to avoid setting ``os.environ['GLOBAL_ENV_BUCKET']`` directly.
+
+
 4.1.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Change Log
 4.2.0
 =====
 
+* In ``command_utils``:
+
+  * Add ``script_catch_errors`` context manager, borrowed from ``SubmitCGAP``.
+
 * In ``ff_utils``:
 
   * Add ``is_bodyless`` predicate on http methods (verbs) to say if they want a data arg.
@@ -1532,9 +1536,11 @@ Older Versions
 A record of older changes can be found
 `in GitHub <https://github.com/4dn-dcic/utils/pulls?q=is%3Apr+is%3Aclosed>`_.
 To find the specific version numbers, see the ``version`` value in
-the ``poetry.app`` section of ``pyproject.toml``, as in::
+the ``poetry.app`` section of ``pyproject.toml`` for the corresponding change, as in::
 
    [poetry.app]
    name = "dcicutils"
    version = "100.200.300"
    ...etc.
+
+This would correspond with ``dcicutils 100.200.300``.

--- a/dcicutils/command_utils.py
+++ b/dcicutils/command_utils.py
@@ -5,10 +5,10 @@ import os
 import requests
 import subprocess
 
-from dcicutils.exceptions import InvalidParameterError
-from dcicutils.lang_utils import there_are
 from typing import Optional
-from .misc_utils import PRINT
+from .exceptions import InvalidParameterError
+from .lang_utils import there_are
+from .misc_utils import PRINT, environ_bool, print_error_message
 
 
 def _ask_boolean_question(question, quick=None, default=None):
@@ -308,3 +308,23 @@ def script_assure_venv(repo_path, script, default_venv_name, method='poetry'):
         script.do(f'source {venv_name}/bin/activate')
     else:
         raise RuntimeError(there_are(venv_names, kind="virtual environment"))
+
+
+DEBUG_SCRIPT = environ_bool("DEBUG_SCRIPT")
+
+SCRIPT_ERROR_HERALD = "Command exited in an unusual way. Please feel free to report this, citing the following message."
+
+
+@contextlib.contextmanager
+def script_catch_errors():
+    try:
+        yield
+        exit(0)
+    except Exception as e:
+        if DEBUG_SCRIPT:
+            # If debugging, let the error propagate, do not trap it.
+            raise
+        else:
+            PRINT(SCRIPT_ERROR_HERALD)
+            print_error_message(e)
+            exit(1)

--- a/dcicutils/env_base.py
+++ b/dcicutils/env_base.py
@@ -55,6 +55,11 @@ class EnvBase:
             yield
 
     @classmethod
+    def set_global_env_bucket(cls, bucket_name):
+        os.environ['GLOBAL_ENV_BUCKET'] = bucket_name
+        os.environ['GLOBAL_BUCKET_ENV'] = bucket_name  # Deprecated, but set for consistency.
+
+    @classmethod
     def _legacy_global_env_bucket_for_testing(cls):
         if not LegacyController.LEGACY_DISPATCH_ENABLED:
             raise LegacyDispatchDisabled(operation="_legacy_global_env_bucket_for_testing", mode='setup-envbase')

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -185,6 +185,22 @@ def purge_request_with_retries(request_fxn, url, auth, verb, **kwargs):
     return final_res
 
 
+# Per https://specs.openstack.org/openstack/api-wg/guidelines/http/methods.html
+# although TRACE is the only method that actively disallows a body,
+# in normal practice GET, DELETE, TRACE, OPTIONS and HEAD methods are not expected to have a body.
+
+BODYLESS_REQUEST_METHODS = {'GET', 'DELETE', 'TRACE', 'OPTIONS', 'HEAD'}
+
+
+def is_bodyless(request_method):
+    """
+    Tests the given HTTP request method name to see if it needs a body in its http(s) request.
+    """
+    u = request_method.upper()
+    res = u in BODYLESS_REQUEST_METHODS
+    return res
+
+
 REQUESTS_VERBS = {
     'GET': requests.get,
     'POST': requests.post,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.1.0"
+version = "4.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.2.0"
+version = "4.1.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.1.0.1b0"
+version = "4.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_env_base.py
+++ b/test/test_env_base.py
@@ -1,1 +1,22 @@
-# Tests of EnvManager (test_env_manager_xxx) need to move here from test_s3_utils.py
+import os
+
+from dcicutils.env_base import EnvBase
+
+
+# TODO: Some tests of EnvManager (test_env_manager_xxx) need to move here from test_s3_utils.py
+
+
+def test_set_global_env_bucket():
+
+    sample_bucket_name1 = "my-global-env-bucket-one"
+    sample_bucket_name2 = "my-global-env-bucket-two"
+
+    with EnvBase.global_env_bucket_named(sample_bucket_name1):
+
+        assert os.environ['GLOBAL_BUCKET_ENV'] == sample_bucket_name1
+        assert os.environ['GLOBAL_ENV_BUCKET'] == sample_bucket_name1
+
+        EnvBase.set_global_env_bucket(sample_bucket_name2)
+
+        assert os.environ['GLOBAL_BUCKET_ENV'] == sample_bucket_name2
+        assert os.environ['GLOBAL_ENV_BUCKET'] == sample_bucket_name2

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -435,6 +435,31 @@ def test_stuff_in_queues_integrated(integrated_ff):
     assert 'Must provide a full fourfront environment name' in str(exec_info.value)
 
 
+@pytest.mark.unit
+def test_is_bodyless():
+
+    for http_method in ['get', 'delete', 'trace', 'options', 'head']:
+        print(f"Testing {http_method}...")
+        assert ff_utils.is_bodyless(http_method) is True
+        assert ff_utils.is_bodyless(http_method.upper()) is True
+        assert ff_utils.is_bodyless(http_method.capitalize()) is True
+        print(f"OK: {http_method}")
+
+    for http_method in ['post', 'patch', 'put']:
+        print(f"Testing {http_method}...")
+        assert ff_utils.is_bodyless(http_method) is False
+        assert ff_utils.is_bodyless(http_method.upper()) is False
+        assert ff_utils.is_bodyless(http_method.capitalize()) is False
+        print(f"OK: {http_method}")
+
+    for http_method in ['anythingelse']:
+        print(f"Testing {http_method}...")
+        assert ff_utils.is_bodyless(http_method) is False
+        assert ff_utils.is_bodyless(http_method.upper()) is False
+        assert ff_utils.is_bodyless(http_method.capitalize()) is False
+        print(f"OK: {http_method}")
+
+
 @pytest.mark.integrated
 @pytest.mark.flaky
 def test_authorized_request_integrated(integrated_ff):


### PR DESCRIPTION
* In `ff_utils`:

  * Add `is_bodyless` predicate on http methods (verbs) to say if they want a data arg.
    (I needed this in two different places recently.)

* In `env_base`:

  * Add `EnvBase.set_global_env_bucket` to avoid setting `os.environ['GLOBAL_ENV_BUCKET']` directly.
     (I want to tell people to use this and not to set the env variables directly for now.)