### PR TITLE
Small lang_utils changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 4.5.0
 =====
 
-* A few other changes to `lang_utils.string_pluralize` to give more refined
+* A few other changes to ``lang_utils.string_pluralize`` to give more refined
   control of punctuation and to allow phrases with "that is/was" or
   "which is/was" qualifiers.
 
@@ -1418,7 +1418,7 @@ Those tests were refactored, and the following additional support was added:
 
 In ``misc_utils``:
 
-* Fix ``as_datetime`` to raise an error on bad input, allowing `raise_error=False`
+* Fix ``as_datetime`` to raise an error on bad input, allowing ``raise_error=False``
   to suppress that if needed.
 * Add ``as_ref_datetime`` to convert times to the reference timezone (US/Eastern by default).
 * Add ``as_utc_datetime`` to convert times to UTC.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Change Log
 ----------
 
 
+4.5.0
+=====
+
+* A few other changes to `lang_utils.string_pluralize` to give more refined
+  control of punctuation and to allow phrases with "that is/was" or
+  "which is/was" qualifiers.
+
+
 4.4.0
 =====
 

--- a/dcicutils/lang_utils.py
+++ b/dcicutils/lang_utils.py
@@ -102,6 +102,9 @@ class EnglishUtils:
         f"^an?[ -]+([^ -].*)$",
         re.IGNORECASE)
 
+    _NOUN_WITH_THAT_OR_WHICH_QUALIFIER = re.compile("^(.*[^,])(,|)[ ]+(that|which)[ ]+(.*)$", re.IGNORECASE)
+    _IS_QUALIFIER = re.compile("^(is|was|has)[ ]+(.*)$", re.IGNORECASE)
+
     @classmethod
     def string_pluralize(cls, word: str, allow_some=False) -> str:
         """
@@ -111,9 +114,29 @@ class EnglishUtils:
               string_pluralize('community') => 'communities'
         """
 
+        qualifier_suffix = ""
+
         charn = word[-1]
         capitalize = word[0].isupper()
         upcase = word.isupper()  # capitalize and not any(ch.islower() for ch in word)
+
+        qual_matched = cls._NOUN_WITH_THAT_OR_WHICH_QUALIFIER.match(word)
+        if qual_matched:
+            qualified, comma, connective, qualifier = qual_matched.groups()
+            word = qualified
+            is_matched = cls._IS_QUALIFIER.match(qualifier)
+            if is_matched:
+                verb, qualifying_adj = is_matched.groups()
+                orig_verb = verb
+                verb = {'is': 'are', 'was': 'were', 'has': 'have'}.get(verb.lower(), verb)
+                if orig_verb[0].isupper():
+                    if orig_verb[-1].isupper():
+                        verb = verb.upper()
+                    else:
+                        verb = verb.capitalize()
+                qualifier = f"{verb} {qualifying_adj}"
+            # Continue to other things after making a verb adjustment
+            qualifier_suffix = f"{comma} {connective} {qualifier}"
 
         # Convert 'a foo' to just 'foo' prior to pluralization. It's pointless to return 'a apples' or 'an apples'.
         # Arguably, we _could_ return 'some apples'
@@ -122,7 +145,7 @@ class EnglishUtils:
             word = indef_matched.group(1)
             if allow_some:
                 prefix = "SOME " if upcase else ("Some " if capitalize else "some ")
-                return prefix + cls.string_pluralize(word)
+                return prefix + cls.string_pluralize(word) + qualifier_suffix
 
         prep_matched = cls._NOUN_WITH_PREPOSITIONAL_ATTACHMENT.match(word)
         if prep_matched:
@@ -133,11 +156,11 @@ class EnglishUtils:
                 # It's important to do this before calling ourselves recursively to avoid getting 'some' in prep phrases
                 prep_obj = indef_matched.group(1)
                 prep_obj = cls.string_pluralize(prep_obj)
-            return cls.string_pluralize(word) + prep_spacing1 + prep + prep_spacing2 + prep_obj
+            return cls.string_pluralize(word) + prep_spacing1 + prep + prep_spacing2 + prep_obj + qualifier_suffix
 
         result = cls._special_case_plural(word)
         if result:
-            return result
+            return result + qualifier_suffix
 
         if cls._ENDS_IN_FE.match(word):
             result = cls._adjust_ending(word, 2, "ves")
@@ -157,11 +180,11 @@ class EnglishUtils:
             result = cls._adjust_ending(word, 0, "s")
 
         if upcase:
-            return result.upper()
+            return result.upper() + qualifier_suffix
         elif capitalize:
-            return result.capitalize()
+            return result.capitalize() + qualifier_suffix
         else:
-            return result
+            return result + qualifier_suffix
 
     _USE_AN = {}
 
@@ -320,8 +343,8 @@ class EnglishUtils:
 
     @classmethod
     def there_are(cls, items, *, kind: str = "thing", count: Optional[int] = None, there: str = "there",
-                  capitalize=True, joiner=None, zero: object = "no", punctuate=False, use_article=False,
-                  show=True, context=None, tense='present',
+                  capitalize=True, joiner=None, zero: object = "no", punctuate=None, punctuate_none=None,
+                  use_article=False, show=True, context=None, tense='present',
                   **joiner_options) -> str:
         """
         Constructs a sentence that enumerates a set of things.
@@ -360,6 +383,12 @@ class EnglishUtils:
 
         """
 
+        if punctuate is None:
+            punctuate = False if show else True
+
+        if punctuate_none is None:
+            punctuate_none = True if show else punctuate
+
         there = capitalize1(there) if capitalize else there
         n = len(items) if count is None else count
         # If the items is not in the tenses table, it's assumed to be a modal like 'might', 'may', 'must', 'can' etc.
@@ -368,7 +397,8 @@ class EnglishUtils:
         if context:
             part1 += f" {context}"
         if n == 0 or not show:
-            return part1 + "."
+            punctuation = "." if punctuate_none else ""
+            return part1 + punctuation
         else:
             if use_article:
                 items = [a_or_an(str(item)) for item in items]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.4.0"
+version = "4.5.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_lang_utils.py
+++ b/test/test_lang_utils.py
@@ -115,6 +115,23 @@ def test_string_pluralize():
     assert string_pluralize("AN APPLE", allow_some=True) == "SOME APPLES"
     assert string_pluralize("THE APPLE") == "THE APPLES"
 
+    assert string_pluralize("file that has to be closed") == "files that have to be closed"
+    assert string_pluralize("file that will have to be closed") == "files that will have to be closed"
+    assert string_pluralize("file that will be opened") == "files that will be opened"
+    assert string_pluralize("file that is still open") == "files that are still open"
+    assert string_pluralize("file that was still open") == "files that were still open"
+
+    assert string_pluralize("file, which has to be closed") == "files, which have to be closed"
+    assert string_pluralize("file, which is what we searched for") == "files, which are what we searched for"
+
+    assert string_pluralize("a name of a file that has to be closed") == "names of files that have to be closed"
+    assert string_pluralize("a name of a file that is open") == "names of files that are open"
+    assert string_pluralize("a name of a file that was open") == "names of files that were open"
+
+    assert string_pluralize("A NAME OF A FILE THAT IS OPEN") == "NAMES OF FILES THAT ARE OPEN"
+    assert string_pluralize("a NAME of a File that is open") == "NAMES of Files that are open"
+    assert string_pluralize("a NAME of a File that IS open") == "NAMES of Files that ARE open"
+
 
 def test_n_of():
     assert EnglishUtils.n_of(-1, "day") == "-1 days"  # This could go either way, but it's easiest just to do this.
@@ -413,6 +430,36 @@ def test_there_are():
                      ) == "There are 2 users: Joe and Sally."
     assert there_are(['Joe'], kind="user", joiner=conjoined_list, punctuate=True) == "There is 1 user: Joe."
     assert there_are([], kind="user", joiner=conjoined_list, punctuate=True) == "There are no users."
+
+    assert there_are([], kind="user", joiner=conjoined_list) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, punctuate=True) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, punctuate=None) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, punctuate=False) == "There are no users."
+
+    assert there_are([], kind="user", joiner=conjoined_list, show=False) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, show=False, punctuate=True) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, show=False, punctuate=None) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, show=False, punctuate=False) == "There are no users"
+
+    assert there_are([], kind="user", joiner=conjoined_list, show=False) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, show=False, punctuate_none=True) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, show=False, punctuate_none=None) == "There are no users."
+    assert there_are([], kind="user", joiner=conjoined_list, show=False, punctuate_none=False) == "There are no users"
+
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list) == "There is 1 user: Joe"
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, punctuate=True) == "There is 1 user: Joe."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, punctuate=None) == "There is 1 user: Joe"
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, punctuate=False) == "There is 1 user: Joe"
+
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False) == "There is 1 user."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False, punctuate=True) == "There is 1 user."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False, punctuate=None) == "There is 1 user."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False, punctuate=False) == "There is 1 user"
+
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False) == "There is 1 user."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False, punctuate_none=True) == "There is 1 user."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False, punctuate_none=None) == "There is 1 user."
+    assert there_are(['Joe'], kind="user", joiner=conjoined_list, show=False, punctuate_none=False) == "There is 1 user"
 
     def check_tense(tense, if0, if1, if2):
         assert there_are([], tense=tense, show=False, kind="foo") == if0


### PR DESCRIPTION
This is mostly uninteresting to most tools but it came up in my work with scripting (in `c4-scripts` repo) this weekend that I couldn't write strings in a natural way that I thought the tools should handle.

* Fixes the string pluralizer to handle punctuation in a more refined way.
* Allows strings to pluralize like "file that must be closed" => "files that must be closed".

There's a pretty good set of regression tests for things, so I don't think this breaks anything. It just makes it possible to say some new things in a concise fashion.

It's probably easiest to understand by looking at the test cases.