### PR TITLE
Refinements to secrets_utils (C4-901)

### DIFF
--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -99,11 +99,11 @@ def get_identity_secrets(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION,
         if 'SecretString' in get_secret_value_response:
             identity_secrets = json.loads(get_secret_value_response['SecretString'])
         else:
-            raise Exception('Got unexpected response structure from boto3')
+            raise Exception('Got unexpected response structure from boto3. (Missing SecretString.)')
     if not identity_secrets:
-        raise Exception('Identity could not be found! Check the secret name.')
+        raise Exception(f'Identity {secret_name!r} could not be found.')
     elif not isinstance(identity_secrets, dict):
-        raise Exception("Identity was not in expected dictionary form.")
+        raise Exception("Identity {secret_name!r} was found but was not in the expected dictionary form.")
     return identity_secrets
 
 

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -23,27 +23,22 @@ logger = structlog.getLogger(__name__)
 GLOBAL_APPLICATION_CONFIGURATION = 'IDENTITY'
 
 
-# TODO: Rethink whether this should be a constant. Maybe it should be a function of the identity_kind?
-#       Maybe the caller should pass a default and this function should have none. -kmp 18-Jul-2022
-LEGACY_DEFAULT_IDENTITY_NAME = 'dev/beanstalk/cgap-dev'
-LEGACY_ACCOUNT_NUMBER = '643366669028'
-
-
 def get_identity_name(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> str:
     """
-    This evaluates the given environment variable, handling defaults only in the legacy account.
+    This evaluates the given environment variable.
+    (In the future, it might also do discovery of some sort, but presently it does not.)
     """
     identity_name = os.environ.get(identity_kind)
     if identity_name:
         return identity_name
-    account_number = os.environ.get('ACCOUNT_NUMBER')
-    if not account_number or account_number == LEGACY_ACCOUNT_NUMBER:
-        # We do this independent of identity_kind. Is that right? -kmp 31-Aug-2022
-        return LEGACY_DEFAULT_IDENTITY_NAME
     # TODO: Add discovery here? This can probably be inferred.
     #       Need to be careful because not all users may have IAM privileges.
     #       -kmp 31-Aug-2022
-    raise ValueError(f"There is no default identity name available for {identity_kind} in account {account_number}.")
+    context = ""
+    account_number = os.environ.get('ACCOUNT_NUMBER')
+    if account_number:
+        context = f" in account {account_number}"
+    raise ValueError(f"There is no default identity name available for {identity_kind}{context}.")
 
 
 def identity_is_defined(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> bool:

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -30,6 +30,9 @@ LEGACY_ACCOUNT_NUMBER = '643366669028'
 
 
 def get_identity_name(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> str:
+    """
+    This evaluates the given environment variable, handling defaults only in the legacy account.
+    """
     identity_name = os.environ.get(identity_kind)
     if identity_name:
         return identity_name
@@ -67,11 +70,11 @@ def get_identity_secrets(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION,
     Returns a dictionary of secrets that the secrets manager has associated with specified identity.
     These secrets generally represent some kind of core configuration information for the application.
     The identity may be specified by indicating its kind (an environment variable such as 'IDENTITY')
-    and looking it up from there, or by specifying the name of the identity itself. 
+    and looking it up from there, or by specifying the name of the identity itself.
 
     If an identity_kind is specified but there is no value (or a null value), the default is resolved
     using get_identity_name.
-     
+
     :param identity_kind: the kind of identity (default: 'IDENTITY')
     :param identity_name: an actual identity name (default: None, meaning unspecified)
     """

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -40,7 +40,7 @@ def get_identity_name(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> 
     # TODO: Add discovery here? This can probably be inferred.
     #       Need to be careful because not all users may have IAM privileges.
     #       -kmp 31-Aug-2022
-    raise ValueError(f"There is no default identity name available for account {account_number}.")
+    raise ValueError(f"There is no default identity name available for {identity_kind} in account {account_number}.")
 
 
 def identity_is_defined(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -> bool:
@@ -173,7 +173,7 @@ def assumed_identity(*,
     if only_if and (not only_if_missing or not os.environ.get(only_if_missing)):
         identity_name = identity_name or get_identity_name(identity_kind=identity_kind)
         if identity_name:
-            secrets = get_identity_secrets(identity_kind=identity_kind)
+            secrets = get_identity_secrets(identity_name=identity_name)
             secrets = apply_overrides(secrets=secrets, rename_keys=rename_keys, override_values=override_values)
             if only_if_missing and only_if_missing not in secrets:
                 raise RuntimeError(f"No {only_if_missing} was found where expected"

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -47,7 +47,7 @@ def identity_is_defined(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION) -
     return bool(os.environ.get(identity_kind))
 
 
-KNOWN_SECRETS_ERRORS = {
+_KNOWN_SECRETS_ERRORS = {
     "DecryptionFailureException":
         "A protected secret text can't be decrypted using the provided KMS key.",
     "InternalServiceErrorException":
@@ -89,9 +89,9 @@ def get_identity_secrets(identity_kind: str = GLOBAL_APPLICATION_CONFIGURATION,
         )
     except ClientError as e:  # leaving some useful debug info to help narrow issues
         code = e.response['Error']['Code']
-        if code in KNOWN_SECRETS_ERRORS:
+        if code in _KNOWN_SECRETS_ERRORS:
             logger.warning(f'Encountered a known exception ({code}) trying to acquire secrets.'
-                           f' {KNOWN_SECRETS_ERRORS[code]}')
+                           f' {_KNOWN_SECRETS_ERRORS[code]}')
         raise e
     else:
         # Decrypts secret using the associated KMS CMK.

--- a/test/test_secrets_utils.py
+++ b/test/test_secrets_utils.py
@@ -7,7 +7,7 @@ from dcicutils import secrets_utils as secrets_utils_module
 from dcicutils.misc_utils import override_environ, ignored
 from dcicutils.qa_utils import MockBoto3
 from dcicutils.secrets_utils import (
-    GLOBAL_APPLICATION_CONFIGURATION, LEGACY_DEFAULT_IDENTITY_NAME, LEGACY_ACCOUNT_NUMBER,
+    GLOBAL_APPLICATION_CONFIGURATION,
     get_identity_name, identity_is_defined, apply_overrides,
     assumed_identity, assumed_identity_if, apply_identity,
     get_identity_secrets, assume_identity, SecretsTable,
@@ -50,7 +50,7 @@ decoy_2_identity = some_unique_decoy_name
 some_secret_identities_with_common_pattern = [some_secret_identity, decoy_1_identity]
 some_secret_identities = [some_secret_identity, decoy_1_identity, decoy_2_identity]
 
-NON_LEGACY_ACCOUNT_NUMBER = '9' * len(LEGACY_ACCOUNT_NUMBER)  # an account number of all 9's
+SAMPLE_ACCOUNT_NUMBER = '111222333444'
 
 
 def test_get_identity_name():
@@ -61,28 +61,22 @@ def test_get_identity_name():
     some_other_identity = 'OtherIdentityForTesting'
 
     # No matter the account, if the identity variable has a value, that value gets used.
-    for account_number in [LEGACY_ACCOUNT_NUMBER, None, NON_LEGACY_ACCOUNT_NUMBER]:
+    for account_number in [SAMPLE_ACCOUNT_NUMBER, None]:
         with override_environ(ACCOUNT_NUMBER=account_number):
+
             with override_environ(IDENTITY=some_identity, OTHER_IDENTITY=some_other_identity):
                 assert get_identity_name() == some_identity
                 assert get_identity_name('IDENTITY') == some_identity
                 assert get_identity_name('OTHER_IDENTITY') == some_other_identity
 
-    # In legacy account, all identities default to value of LEGACY_DEFAULT_IDENTITY if no environment variable is set.
-    for account_number in [LEGACY_ACCOUNT_NUMBER, None]:
-        with override_environ(IDENTITY=None, OTHER_IDENTITY=None, ACCOUNT_NUMBER=account_number):
-            assert get_identity_name() == LEGACY_DEFAULT_IDENTITY_NAME
-            assert get_identity_name('IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
-            assert get_identity_name('OTHER_IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
-
-    # Outside the legacy account, all identities raise ValueError if no environment variable is set.
-    with override_environ(IDENTITY=None, OTHER_IDENTITY=None, ACCOUNT_NUMBER=NON_LEGACY_ACCOUNT_NUMBER):
-        with pytest.raises(ValueError):
-            get_identity_name()
-        with pytest.raises(ValueError):
-            get_identity_name('IDENTITY')
-        with pytest.raises(ValueError):
-            get_identity_name('OTHER_IDENTITY')
+            # All identities raise ValueError if no environment variable is set.
+            with override_environ(IDENTITY=None, OTHER_IDENTITY=None):
+                with pytest.raises(ValueError):
+                    get_identity_name()
+                with pytest.raises(ValueError):
+                    get_identity_name('IDENTITY')
+                with pytest.raises(ValueError):
+                    get_identity_name('OTHER_IDENTITY')
 
 
 def test_identity_is_defined():

--- a/test/test_secrets_utils.py
+++ b/test/test_secrets_utils.py
@@ -7,7 +7,7 @@ from dcicutils import secrets_utils as secrets_utils_module
 from dcicutils.misc_utils import override_environ, ignored
 from dcicutils.qa_utils import MockBoto3
 from dcicutils.secrets_utils import (
-    GLOBAL_APPLICATION_CONFIGURATION, LEGACY_DEFAULT_IDENTITY_NAME,
+    GLOBAL_APPLICATION_CONFIGURATION, LEGACY_DEFAULT_IDENTITY_NAME, LEGACY_ACCOUNT_NUMBER,
     get_identity_name, identity_is_defined, apply_overrides,
     assumed_identity, assumed_identity_if, apply_identity,
     get_identity_secrets, assume_identity, SecretsTable,
@@ -50,17 +50,39 @@ decoy_2_identity = some_unique_decoy_name
 some_secret_identities_with_common_pattern = [some_secret_identity, decoy_1_identity]
 some_secret_identities = [some_secret_identity, decoy_1_identity, decoy_2_identity]
 
+NON_LEGACY_ACCOUNT_NUMBER = '9' * len(LEGACY_ACCOUNT_NUMBER)
+
 
 def test_get_identity_name():
 
-    with override_environ(**{GLOBAL_APPLICATION_CONFIGURATION: None}):
-        assert get_identity_name() == LEGACY_DEFAULT_IDENTITY_NAME
-        assert get_identity_name('MY_IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
+    assert GLOBAL_APPLICATION_CONFIGURATION == 'IDENTITY'
 
-    some_name = 'SomeIdentityForTesting'
-    with override_environ(**{GLOBAL_APPLICATION_CONFIGURATION: some_name}):
-        assert get_identity_name() == some_name
-        assert get_identity_name('MY_IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
+    some_identity = 'SomeIdentityForTesting'
+    some_other_identity = 'OtherIdentityForTesting'
+
+    # No matter the account, if the identity variable has a value, that value gets used.
+    for account_number in [LEGACY_ACCOUNT_NUMBER, None, NON_LEGACY_ACCOUNT_NUMBER]:
+        with override_environ(ACCOUNT_NUMBER=account_number):
+            with override_environ(IDENTITY=some_identity, OTHER_IDENTITY=some_other_identity):
+                assert get_identity_name() == some_identity
+                assert get_identity_name('IDENTITY') == some_identity
+                assert get_identity_name('OTHER_IDENTITY') == some_other_identity
+
+    # In legacy account, all identities default to value of LEGACY_DEFAULT_IDENTITY if no environment variable is set.
+    for account_number in [LEGACY_ACCOUNT_NUMBER, None]:
+        with override_environ(IDENTITY=None, OTHER_IDENTITY=None, ACCOUNT_NUMBER=account_number):
+            assert get_identity_name() == LEGACY_DEFAULT_IDENTITY_NAME
+            assert get_identity_name('IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
+            assert get_identity_name('OTHER_IDENTITY') == LEGACY_DEFAULT_IDENTITY_NAME
+
+    # Outside the legacy account, all identities raise ValueError if no environment variable is set.
+    with override_environ(IDENTITY=None, OTHER_IDENTITY=None, ACCOUNT_NUMBER=NON_LEGACY_ACCOUNT_NUMBER):
+        with pytest.raises(ValueError):
+            get_identity_name()
+        with pytest.raises(ValueError):
+            get_identity_name('IDENTITY')
+        with pytest.raises(ValueError):
+            get_identity_name('OTHER_IDENTITY')
 
 
 def test_identity_is_defined():
@@ -124,44 +146,79 @@ def test_assume_identity():
     check_get_identity_secrets(assume_identity)
 
 
-def check_get_identity_secrets(fn):
+def check_get_identity_secrets(secrets_getter):
 
     b3 = boto3_for_some_secrets_testing()  # this sets things up with some_secret_string in the SecretsManager
+
+    # Note in these examples that some_secret_table is the parsed form of some_secret_string.
+
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
+
         with override_environ(IDENTITY=some_secret_identity):
-            secrets = fn()
-            assert secrets == some_secret_table  # this is the parsed form of some_secret_string
+            secrets = secrets_getter()
+            assert secrets == some_secret_table
+
+        with override_environ(IDENTITY=None):
+            secrets = secrets_getter(identity_name=some_secret_identity)
+            assert secrets == some_secret_table
+
+        with override_environ(IDENTITY=decoy_1_identity):
+            secrets = secrets_getter(identity_name=some_secret_identity)
+            # Here note that even if the identity_kind (IDENTITY) has a value, identity_name is preferred.
+            assert secrets == some_secret_table
 
 
 def test_apply_identity():
 
+    def apply_via_name_arg(the_identity):
+        apply_identity(identity_name=the_identity)
+
+    check_apply_identity(apply_via_name_arg)
+
+    def apply_via_env_var_default(the_identity):
+        with override_environ(IDENTITY=the_identity):
+            apply_identity()
+
+    check_apply_identity(apply_via_env_var_default)
+
+    def apply_via_env_var_explicit(the_identity):
+        with override_environ(IDENTITY=the_identity):
+            apply_identity(identity_kind='IDENTITY')
+
+    check_apply_identity(apply_via_env_var_explicit)
+
+    def apply_via_env_var_other(the_identity):
+        with override_environ(OTHER_IDENTITY=the_identity, IDENTITY=None):
+            apply_identity(identity_kind='OTHER_IDENTITY')
+
+    check_apply_identity(apply_via_env_var_other)
+
+
+def check_apply_identity(secrets_applier):
+
     b3 = boto3_for_some_secrets_testing()
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
 
+        # First make sure our environment is clean of default values for all keys in some_secret_names.
         with override_environ(**{secret_name: None for secret_name in some_secret_names}):
 
+            # Double-check our presumption that the environment is clean at the start.
             for i in range(len(some_secret_names)):
                 secret_name = some_secret_names[i]
                 # Check that this test will be useful.
                 assert secret_name not in os.environ, f"Test secret variable {secret_name} is already in os.environ."
 
-            with override_environ(IDENTITY=some_secret_identity):
-
-                apply_identity()
-
-                for i in range(len(some_secret_names)):
-                    secret_name = some_secret_names[i]
-                    secret_value = some_secret_values[i]
-                    assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
-                    assert os.environ[secret_name] == secret_value
+            secrets_applier(some_secret_identity)
 
             for i in range(len(some_secret_names)):
                 secret_name = some_secret_names[i]
-                # Check that this test will be useful.
-                assert secret_name in os.environ, f"Test secret variable {secret_name} did not get globally set."
+                secret_value = some_secret_values[i]
+                assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
+                assert os.environ[secret_name] == secret_value
 
 
-def test_assumed_identity():
+
+def test_assumed_identity_by_kind():
 
     b3 = boto3_for_some_secrets_testing()
     with mock.patch.object(secrets_utils_module, 'boto3', b3):
@@ -220,6 +277,61 @@ def test_assumed_identity():
             # This will NOT assume the identity because some_secret_name_2 IS bound in os.environ.
             with assumed_identity(only_if_missing=some_secret_name_2):
                 assert some_secret_name_1 not in os.environ
+
+
+def test_assumed_identity_by_name():
+
+    b3 = boto3_for_some_secrets_testing()
+    with mock.patch.object(secrets_utils_module, 'boto3', b3):
+
+        for i in range(len(some_secret_names)):
+            secret_name = some_secret_names[i]
+            # Check that this test will be useful.
+            assert secret_name not in os.environ, f"Test secret variable {secret_name} is already in os.environ."
+
+        with override_environ(IDENTITY=None, MY_IDENTITY=None, OTHER_IDENTITY=None,
+                              **{some_secret_name_1: None, some_secret_name_2: None}):
+
+            with assumed_identity(identity_name=some_secret_identity):
+                for i in range(len(some_secret_names)):
+                    secret_name = some_secret_names[i]
+                    secret_value = some_secret_values[i]
+                    assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
+                    assert os.environ[secret_name] == secret_value
+
+            alt_name_1 = f"alt_{some_secret_name_1}"
+            alt_secret_names = [alt_name_1] + some_secret_names[1:]
+            alt_secret_values = some_secret_values
+
+            with assumed_identity(identity_name=some_secret_identity, rename_keys={some_secret_name_1: alt_name_1}):
+                for i in range(len(alt_secret_names)):
+                    alt_name = alt_secret_names[i]
+                    alt_value = alt_secret_values[i]
+                    assert alt_name in os.environ, f"Test secret variable {alt_name} is missing in os.environ."
+                    assert os.environ[secret_name] == alt_value
+
+            some_overridden_value = 'some other value'
+            with assumed_identity(identity_name=some_secret_identity,
+                                  override_values={some_secret_name_1: some_overridden_value}):
+                assert os.environ[some_secret_name_1] == some_overridden_value
+                assert os.environ[some_secret_name_2] == some_secret_value_2
+
+            # This will assume the identity because some_secret_name_2 is not bound in os.environ.
+            with assumed_identity(identity_name=some_secret_identity, only_if_missing=some_secret_name_2):
+                assert some_secret_name_1 in os.environ
+
+            with override_environ(**{some_secret_name_1: 'anything'}):
+                # This will assume the identity because some_secret_name_2 is not bound in os.environ.
+                # (Note here that some secret names are present in the environment, but not the right one.)
+                with assumed_identity(identity_name=some_secret_identity, only_if_missing=some_secret_name_2):
+                    assert os.environ[some_secret_name_1] != 'anything'  # This is one of the secrets that gets re-bound
+                    assert some_secret_name_2 in os.environ
+
+            with override_environ(**{some_secret_name_2: 'anything'}):
+                # This will NOT assume the identity because some_secret_name_2 IS bound in os.environ.
+                with assumed_identity(identity_name=some_secret_identity, only_if_missing=some_secret_name_2):
+                    assert some_secret_name_1 not in os.environ
+                    assert os.environ[some_secret_name_2] == 'anything'  # This secret won't have been re-bound
 
 
 def test_assumed_identity_if():

--- a/test/test_secrets_utils.py
+++ b/test/test_secrets_utils.py
@@ -50,7 +50,7 @@ decoy_2_identity = some_unique_decoy_name
 some_secret_identities_with_common_pattern = [some_secret_identity, decoy_1_identity]
 some_secret_identities = [some_secret_identity, decoy_1_identity, decoy_2_identity]
 
-NON_LEGACY_ACCOUNT_NUMBER = '9' * len(LEGACY_ACCOUNT_NUMBER)
+NON_LEGACY_ACCOUNT_NUMBER = '9' * len(LEGACY_ACCOUNT_NUMBER)  # an account number of all 9's
 
 
 def test_get_identity_name():
@@ -215,7 +215,6 @@ def check_apply_identity(secrets_applier):
                 secret_value = some_secret_values[i]
                 assert secret_name in os.environ, f"Test secret variable {secret_name} is missing in os.environ."
                 assert os.environ[secret_name] == secret_value
-
 
 
 def test_assumed_identity_by_kind():


### PR DESCRIPTION
* Allow identity_name in various secrets_utils operations
* Change a PRINT operation to a logged warning. Improve the wording of the warning.
* Improve some error messages.