### PR TITLE
Add foursight_env_name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,15 +7,30 @@ Change Log
 ----------
 
 
+4.7.0
+=====
+
+* In ``env_utils``:
+
+  * New function ``foursight_env_name``, an alias for
+    ``lambda envname: infer_foursight_from_env(envname=envname)``
+
+* Add error checking for running tests that looks to see that we're in the right account before we move ahead
+  only to find this out in a less intelligible way.
+
+
 4.6.0
 =====
 
 * In ``env_utils``:
+
   * Add ``identity_name`` arguments to:
+
     * ``apply_identity``
     * ``assumed_identity_if``
     * ``assumed_identity``
     * ``get_identity_secrets``
+
   * Remove buggy defaulting of value for ``get_identity_name``.
   * Improve error messages in ``get_identity_secrets``.
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import os
+
+_account_number = os.environ.get('ACCOUNT_NUMBER')
+
+if _account_number and _account_number != '643366669028':
+    raise Exception(f"These tests must be run with legacy credentials."
+                    f"Your credentials are set to account {_account_number}")

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -1015,6 +1015,17 @@ def infer_foursight_url_from_env(*, request=None, envname: Optional[EnvName] = N
     return EnvUtils.FOURSIGHT_URL_PREFIX + infer_foursight_from_env(request=request, envname=envname)
 
 
+def foursight_env_name(envname):
+    """
+    Returns the form of the given envname that foursight prefers to use.
+    The result is the public_env_name of the given envname (if there is one), or else its short_env_name otherwise.
+
+    :param envname: a valid environment name
+    :return: the form of the given envname that foursight prefers
+    """
+    return infer_foursight_from_env(envname=envname)
+
+
 @if_orchestrated
 def infer_foursight_from_env(*, request=None, envname: Optional[EnvName] = None, short: bool = True) -> EnvName:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.6.0"
+version = "4.6.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.6.0.1b0"
+version = "4.7.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -10,7 +10,7 @@ from dcicutils.env_utils import (
     is_stg_or_prd_env, is_cgap_env, is_fourfront_env, blue_green_mirror_env,
     get_mirror_env_from_context, is_test_env, is_hotseat_env, get_standard_mirror_env,
     prod_bucket_env, prod_bucket_env_for_app, public_url_mappings, public_url_for_app, permit_load_data,
-    default_workflow_env, infer_foursight_url_from_env,
+    default_workflow_env, infer_foursight_url_from_env, foursight_env_name,
     infer_repo_from_env, data_set_for_env, get_bucket_env, infer_foursight_from_env,
     is_indexer_env, indexer_env_for_env, classify_server_url,
     short_env_name, full_env_name, full_cgap_env_name, full_fourfront_env_name, is_cgap_server, is_fourfront_server,
@@ -1033,6 +1033,23 @@ FOURFRONT_SETTINGS_FOR_TESTING = dict(
         }
     ]
 )
+
+
+@using_orchestrated_behavior()
+def test_orchestrated_foursight_env_name():
+
+    assert foursight_env_name('acme-prd') == 'cgap'  # this is in our test ecosystem's public_urL_table
+    assert foursight_env_name('acme-mastertest') == 'mastertest'  # the rest of these are short names
+    assert foursight_env_name('acme-webdev') == 'webdev'
+    assert foursight_env_name('acme-hotseat') == 'hotseat'
+
+    with stage_mirroring(enabled=True):
+        with local_attrs(EnvUtils, **FOURFRONT_SETTINGS_FOR_TESTING):  # PRD = fourfront-blue, STG = fourfront-green
+
+            assert foursight_env_name('fourfront-blue') == 'data'  # this is in the public_url_table
+            assert foursight_env_name('fourfront-green') == 'staging'  # this is, too
+            assert foursight_env_name('fourfront-mastertest') == 'mastertest'  # these are short names
+            assert foursight_env_name('fourfront-hotseat') == 'hotseat'
 
 
 @using_orchestrated_behavior()


### PR DESCRIPTION
Primary goal:

* Add `foursight_env_name`. This is like `infer_foursight_from_env` but its name is better and it doesn't have to be keyword-called.

Opportunistic:

* Add error-checking that testing is being done in the right account to fail early with a clear message.