### PR TITLE
ECR refactor and new class ECRTagWatcher

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,39 +10,58 @@ Change Log
 4.7.0
 =====
 
-* Allow ``ecr_utils.ECRUtils`` to take some additional arguments (and store them as instance variables)
-  since they are needed for ``ecr_scripts.ECRCommandContext``.
+* New functionallity in ``ecr_utils.ECRUtils`` in support of planned changes to Foursight:
 
-* Default more arguments to ``ecr_utils.ECRUtils`` (class creation method).
+  * Add ``ECRTagWatcher`` class that can be used to watch for a new image with a given tag in an ECS repository.
 
-* Move some methods from ``ecr_scripts.ECRCommandContext`` to ``ecr_utils.ECRUtils``:
+* Refactor parts of ``ecr_utils`` and ``ecr_scripts`` to move some general-purpose parts out of
+  ``ecr_scripts`` (top-level variables and class ``ECRCommandContext``)
+  and into ``ecr_utils`` (class ``ECRUtils``):
 
-  * ``get_images_descriptions``
-  * ``_apply_image_descriptions_limit``
+  * Changes to arguments for ``ECRUtils`` constructor:
 
-* Move some variables from toplevel of ``ecr_scripts`` to be class variables in ``ecr_utils.ECRUtils``,
-  with some renaming:
+    * Allow additional arguments needed for moved methods.
+    * Default more arguments so that only relevant ones need be passed.
 
-  * ``ecr_scripts.DEFAULT_ECS_REPOSITORY`` became ``ecr_utils.ECRUtils.DEFAULT_ECS_REPOSITORY``.
-    The variable ``ecr_scripts.DEFAULT_ECS_REPOSITORY`` continues to exist
-    but is initialized from ``ecr_utils.ECRUtils.DEFAULT_ECS_REPOSITORY``.
+  * Move some methods from ``ECRCommandContext`` to ``ECRUtils``:
 
-  * ``ecr_scripts.IMAGE_COUNT_LIMIT`` became ``ecr_utils.ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT``.
-    The variable ``ecr_scripts.IMAGE_COUNT_LIMIT`` is deprecated, and may go away on dcicutils 5.0.
+    * ``get_images_descriptions``
+    * ``_apply_image_descriptions_limit``
 
-  * ``ecr_scripts.IMAGE_LIST_CHUNK_SIZE`` became ``ECRUtils.IMAGE_LIST_CHUNK_SIZE``.
-    The variable ``ecr_scripts.IMAGE_LIST_CHUNK_SIZE`` is deprecated, and may go away on dcicutils 5.0.
+  * Certain variables at ``ecr_scripts`` top-level became class variables in ``ecr_utils.ECRUtils``
+    (some with some renaming):
+
+
+    +------------------------+------------------------+--------------------------------+------------------------+
+    | .. raw:: html                                   | .. raw:: html                                           |
+    |                                                 |                                                         |
+    |    <center><tt>ecr_scripts</code></tt>          |    <center><tt>ecr_utils.ECRUtils</tt></center>         |
+    |                                                 |                                                         |
+    +------------------------+------------------------+--------------------------------+------------------------+
+    | module variable        | module variable status | class variable                 | class variable status  |
+    +========================+========================+================================+========================+
+    | DEFAULT_ECS_REPOSITORY |                        | DEFAULT_ECS_REPOSITORY         | new                    |
+    +------------------------+------------------------+--------------------------------+------------------------+
+    |  IMAGE_COUNT_LIMIT     | deprecated             | IMAGE_LIST_DEFAULT_COUNT_LIMIT | new                    |
+    +------------------------+------------------------+--------------------------------+------------------------+
+    | IMAGE_LIST_CHUNK_SIZE  | deprecated             | IMAGE_LIST_CHUNK_SIZE          | new                    |
+    +------------------------+------------------------+--------------------------------+------------------------+
+    | RELEASED_TAG           | deprecated             | IMAGE_RELEASED_TAG             | new                    |
+    +------------------------+------------------------+--------------------------------+------------------------+
 
 
 4.6.0
 =====
 
 * In ``env_utils``:
+
   * Add ``identity_name`` arguments to:
+
     * ``apply_identity``
     * ``assumed_identity_if``
     * ``assumed_identity``
     * ``get_identity_secrets``
+
   * Remove buggy defaulting of value for ``get_identity_name``.
   * Improve error messages in ``get_identity_secrets``.
 
@@ -112,6 +131,7 @@ NOTE: Due to a versioning error in beta, there was no 4.3.0. The previous releas
 * Fix test recording capability. Add (though unused) ability to record at
   the abstraction level of ``authorized_request``.
 * Fix various tests that had grown stale due to data changes.
+
   * ``test_post_delete_purge_links_metadata`` (needed to be re-recorded)
   * ``test_upsert_metadata`` (needed to be re-recorded)
   * ``test_unified_authentication_prod_envs_integrated_only``
@@ -120,11 +140,15 @@ NOTE: Due to a versioning error in beta, there was no 4.3.0. The previous releas
   * ``test_some_decorated_methods_work`` (needed one different count)
   * ``test_faceted_search_exp_set`` (newly recorded)
   * ``test_faceted_search_users`` (newly recorded)
+
 * Specify pytest options in pyproject.toml instead of a separate file.
 * In ``env_utils``:
+
   * Added ``EnvUtils.app_name`` to get the orchestrated app name.
   * Added ``EnvUtils.app_case`` to conditionalize on ``if_cgap=`` and ``if_fourfront=``.
+
 * In ``qa_utils``:
+
   * Added an ``input_mocked`` context manager.
   * Added ``MockLog`` and a ``logged_messages`` context manager.
 
@@ -133,16 +157,21 @@ NOTE: Due to a versioning error in beta, there was no 4.3.0. The previous releas
 =====
 
 * In ``cloudformation_utils``:
+
   * New function ``find_lambda_function_names`` in ``AbstractOrchestrationManager`` which
     factors out the lookup part from the ``discover_foursight_check_runner_name`` function.
+
 * In ``obfuscation_utils``:
+
   * Changed ``should_obfuscate`` to include "session" related keys.
 
 
 4.0.1
 =====
 * In ``qa_utils``:
+
   * New class ``MockBoto3Ec2`` geared toward security group rules related unit testing.
+
 * New ``obfuscation_utils`` module.
 
 
@@ -243,7 +272,7 @@ these new items:
     * ``LEGACY_CGAP_GLOBAL_ENV_BUCKET``
     * ``LEGACY_GLOBAL_ENV_BUCKET``
 
- * New type hint (variable):
+  * New type hint (variable):
 
     * ``ChaliceStage``
 
@@ -479,22 +508,33 @@ these new items:
 ======
 
 * In ``docker_utils.py``:
+
   * Add ``docker_is_running`` predicate (used by the fix to ``test_ecr_utils_workflow`` to skip that test
     if docker is not running.
+
 * In ``test_ecr_utils.py``:
+
   * Fix ``test_ecr_utils_workflow`` to skip if docker is not enabled.
+
 * In ``test_s3_utils.py``:
+
   * Remove ``test_s3utils_creation_cgap_ordinary`` because there are no more CGAP beanstalks.
   * Revise ``test_regression_s3_utils_short_name_c4_706`` to use ``fourfront-mastertest``
     rather than a CGAP env, since the CGAP beanstalk envs have gone away.
+
 * In ``qa_utils.py``:
+
   * ``MockBoto3Session``.
   * ``MockBoto3SecretsManager`` and support for ``MockBoto3`` to make it.
+
 * In ``secrets_utils.py`` and ``test_secrets_utils.py``:
+
   * Add support for ``SecretsTable``.
   * Add unit tests for existing ``secrets_utils.assume_identity`` and for new ``SecretsTable`` functionality.
+
 * Small cosmetic adjustments to ``Makefile`` to show a timestamp and info about current branch state
   when ``make test`` starts and again when it ends.
+
 * A name containing an underscore will not be shortened by ``short_env_name`` nor lengthened by
   ``full_env_name`` (nor ``full_cgap_env_name`` nor ``full_fourfront_env_name``).
 
@@ -1052,52 +1092,52 @@ that big change happened.
 
 * In ``deployment_utils``:
 
-   * Add environment variables that can be set per stack/instance:
+  * Add environment variables that can be set per stack/instance:
 
-     * ``ENCODED_S3_BUCKET_ORG`` - a unique token for your organization to be used in auto-generating S3 bucket orgs.
-       The defaulted value (which includes possible override by a ``--s3_bucket_org`` argument in the generator command)
-       will be usable as ``${S3_BUCKET_ORG}`` in ``.ini`` file templates.
+    * ``ENCODED_S3_BUCKET_ORG`` - a unique token for your organization to be used in auto-generating S3 bucket orgs.
+      The defaulted value (which includes possible override by a ``--s3_bucket_org`` argument in the generator command)
+      will be usable as ``${S3_BUCKET_ORG}`` in ``.ini`` file templates.
 
-     * ``ENCODED_S3_BUCKET_ENV`` - a unique token for your organization to be used in auto-generating S3 bucket names.
-       The defaulted value (which includes possible override by a ``--s3_bucket_env`` argument in the generator command)
-       will be usable as ``${S3_BUCKET_ENV}`` in ``.ini`` file templates.
+    * ``ENCODED_S3_BUCKET_ENV`` - a unique token for your organization to be used in auto-generating S3 bucket names.
+      The defaulted value (which includes possible override by a ``--s3_bucket_env`` argument in the generator command)
+      will be usable as ``${S3_BUCKET_ENV}`` in ``.ini`` file templates.
 
-     * ``ENCODED_FILE_UPLOAD_BUCKET`` - the name of the file upload bucket to use if a ``--file_upload_bucket`` argument
-       is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-files``
-       is not desired. This fully defaulted value will be available as ``${FILE_UPLOAD_BUCKET}`` in ``.ini`` file
-       templates, and is the recommended way to compute the proper value for the ``file_upload_bucket`` configuration
-       parameter.
+    * ``ENCODED_FILE_UPLOAD_BUCKET`` - the name of the file upload bucket to use if a ``--file_upload_bucket`` argument
+      is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-files``
+      is not desired. This fully defaulted value will be available as ``${FILE_UPLOAD_BUCKET}`` in ``.ini`` file
+      templates, and is the recommended way to compute the proper value for the ``file_upload_bucket`` configuration
+      parameter.
 
-     * ``ENCODED_FILE_WFOUT_BUCKET`` - the name of the file wfout bucket to use if a ``--file_wfout_bucket`` argument
+    * ``ENCODED_FILE_WFOUT_BUCKET`` - the name of the file wfout bucket to use if a ``--file_wfout_bucket`` argument
       is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-wfoutput``
       is not desired. This fully defaulted value will be available as ``${FILE_WFOUT_BUCKET}`` in ``.ini`` file
-       templates, and is the recommended way to compute the proper value for the ``file_wfout_bucket`` configuration
-       parameter.
+      templates, and is the recommended way to compute the proper value for the ``file_wfout_bucket`` configuration
+      parameter.
 
-     * ``ENCODED_BLOB_BUCKET`` - the name of the blob bucket to use if a ``--blob_bucket`` argument
-       is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-blobs``
-       is not desired. This fully defaulted value will be available as ``${BLOB_BUCKET}`` in ``.ini`` file
-       templates, and is the recommended way to compute the proper value for the ``blob_bucket`` configuration
-       parameter.
+    * ``ENCODED_BLOB_BUCKET`` - the name of the blob bucket to use if a ``--blob_bucket`` argument
+      is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-blobs``
+      is not desired. This fully defaulted value will be available as ``${BLOB_BUCKET}`` in ``.ini`` file
+      templates, and is the recommended way to compute the proper value for the ``blob_bucket`` configuration
+      parameter.
 
-     * ``ENCODED_SYSTEM_BUCKET`` - the name of the system bucket to use if a ``--system_bucket`` argument
-       is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-system``
-       is not desired. This fully defaulted value will be available as ``${SYSTEM_BUCKET}`` in ``.ini`` file
-       templates, and is the recommended way to compute the proper value for the ``system_bucket`` configuration
-       parameter.
+    * ``ENCODED_SYSTEM_BUCKET`` - the name of the system bucket to use if a ``--system_bucket`` argument
+      is not given in the generator command, and the default of ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-system``
+      is not desired. This fully defaulted value will be available as ``${SYSTEM_BUCKET}`` in ``.ini`` file
+      templates, and is the recommended way to compute the proper value for the ``system_bucket`` configuration
+      parameter.
 
-     * ``ENCODED_METADATA_BUNDLES_BUCKET`` - the name of the metadata bundles bucket to use if a
-       ``--metadata_bundles_bucket`` argument is not given in the generator command, and the default of
-       ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-metadata-bundles`` is not desired. This fully defaulted value will be
-       available as ``${METADATA_BUNDLES_BUCKET}`` in ``.ini`` file
-       templates, and is the recommended way to compute the proper value for the ``metadata_bundles_bucket`` configuration
-       parameter.
+    * ``ENCODED_METADATA_BUNDLES_BUCKET`` - the name of the metadata bundles bucket to use if a
+      ``--metadata_bundles_bucket`` argument is not given in the generator command, and the default of
+      ``${S3_BUCKET_ORG}-${S3_BUCKET_ENV}-metadata-bundles`` is not desired. This fully defaulted value will be
+      available as ``${METADATA_BUNDLES_BUCKET}`` in ``.ini`` file
+      templates, and is the recommended way to compute the proper value for the ``metadata_bundles_bucket`` configuration
+      parameter.
 
-     * Fixed a bug that the index_server argument was not being correctly passed into lower level functions when
-       ``--index_server`` was specified on the command line.
+    * Fixed a bug that the index_server argument was not being correctly passed into lower level functions when
+      ``--index_server`` was specified on the command line.
 
-     * Fixed a bug where passing no ``--encoded_data_set`` but an explicit null-string value of the environment variable
-       ``ENCODED_DATA_SET`` did not lead to further defaulting in some circumstances.
+    * Fixed a bug where passing no ``--encoded_data_set`` but an explicit null-string value of the environment variable
+      ``ENCODED_DATA_SET`` did not lead to further defaulting in some circumstances.
 
   * In ``ff_utils``:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,33 @@ Change Log
 ----------
 
 
+4.7.0
+=====
+
+* Allow ``ecr_utils.ECRUtils`` to take some additional arguments (and store them as instance variables)
+  since they are needed for ``ecr_scripts.ECRCommandContext``.
+
+* Default more arguments to ``ecr_utils.ECRUtils`` (class creation method).
+
+* Move some methods from ``ecr_scripts.ECRCommandContext`` to ``ecr_utils.ECRUtils``:
+
+  * ``get_images_descriptions``
+  * ``_apply_image_descriptions_limit``
+
+* Move some variables from toplevel of ``ecr_scripts`` to be class variables in ``ecr_utils.ECRUtils``,
+  with some renaming:
+
+  * ``ecr_scripts.DEFAULT_ECS_REPOSITORY`` became ``ecr_utils.ECRUtils.DEFAULT_ECS_REPOSITORY``.
+    The variable ``ecr_scripts.DEFAULT_ECS_REPOSITORY`` continues to exist
+    but is initialized from ``ecr_utils.ECRUtils.DEFAULT_ECS_REPOSITORY``.
+
+  * ``ecr_scripts.IMAGE_COUNT_LIMIT`` became ``ecr_utils.ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT``.
+    The variable ``ecr_scripts.IMAGE_COUNT_LIMIT`` is deprecated, and may go away on dcicutils 5.0.
+
+  * ``ecr_scripts.IMAGE_LIST_CHUNK_SIZE`` became ``ECRUtils.IMAGE_LIST_CHUNK_SIZE``.
+    The variable ``ecr_scripts.IMAGE_LIST_CHUNK_SIZE`` is deprecated, and may go away on dcicutils 5.0.
+
+
 4.6.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 
   * Add ``ECRTagWatcher`` class that can be used to watch for a new image with a given tag in an ECS repository.
 
+* New functionality in ``qa_utils`` to support a mock ECR client.
+
 * Refactor parts of ``ecr_utils`` and ``ecr_scripts`` to move some general-purpose parts out of
   ``ecr_scripts`` (top-level variables and class ``ECRCommandContext``)
   and into ``ecr_utils`` (class ``ECRUtils``):
@@ -48,6 +50,8 @@ Change Log
     +------------------------+------------------------+--------------------------------+------------------------+
     | RELEASED_TAG           | deprecated             | IMAGE_RELEASED_TAG             | new                    |
     +------------------------+------------------------+--------------------------------+------------------------+
+
+* Unit tests for new functionality, and backfilled unit tests for some parts of ``ecr_utils``.
 
 
 4.6.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,7 +42,7 @@ Change Log
     +------------------------+------------------------+--------------------------------+------------------------+
     | module variable        | module variable status | class variable                 | class variable status  |
     +========================+========================+================================+========================+
-    | DEFAULT_ECS_REPOSITORY |                        | DEFAULT_ECS_REPOSITORY         | new                    |
+    | DEFAULT_ECS_REPOSITORY | deprecated             | DEFAULT_IMAGE_REPOSITORY       | new                    |
     +------------------------+------------------------+--------------------------------+------------------------+
     |  IMAGE_COUNT_LIMIT     | deprecated             | IMAGE_LIST_DEFAULT_COUNT_LIMIT | new                    |
     +------------------------+------------------------+--------------------------------+------------------------+

--- a/dcicutils/ecr_scripts.py
+++ b/dcicutils/ecr_scripts.py
@@ -5,7 +5,6 @@ import contextlib
 import os
 
 from typing import Optional, Union, List
-from .common import REGION
 from .command_utils import yes_or_no
 from .ecr_utils import ECRUtils
 from .misc_utils import PRINT, full_class_name
@@ -25,11 +24,7 @@ CONFIRM_DEFAULT_ACCOUNT_NUMBER = 'confirm-default-account-number'
 
 IMAGE_COUNT_LIMIT = ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT  # Deprecated (to remove in release 5.0) -kmp 4-Sep-2022
 IMAGE_LIST_CHUNK_SIZE = ECRUtils.IMAGE_LIST_CHUNK_SIZE  # Deprecated (to remove in release 5.0) -kmp 4-Sep-2022
-
-# This tag is presently called "latest", but I'd like to call it "released". -kmp 12-Mar-2022
-# For now refer to it indirectly through a variable.
-
-RELEASED_TAG = 'latest'
+RELEASED_TAG = ECRUtils.IMAGE_RELEASED_TAG  # Deprecated (to remove in release 5.0) -kmp 4-Sep-2022
 
 
 def make_sorted_string_list(elements, separator=","):

--- a/dcicutils/ecr_scripts.py
+++ b/dcicutils/ecr_scripts.py
@@ -7,6 +7,7 @@ import os
 from typing import Optional, Union, List
 from .common import REGION
 from .command_utils import yes_or_no
+from .ecr_utils import ECRUtils
 from .misc_utils import PRINT, full_class_name
 from .lang_utils import n_of
 
@@ -14,9 +15,7 @@ from .lang_utils import n_of
 EPILOG = __doc__
 
 
-# In many cases, the ECR repo named 'main' is where images live.
-# There could be blue/green deploys or other multi-environment account situations where others are used.
-DEFAULT_ECS_REPOSITORY = 'main'
+DEFAULT_ECS_REPOSITORY = ECRUtils.DEFAULT_ECS_REPOSITORY
 
 # This is the currently selected environment, though commands might want to require confirmation before using it.
 DEFAULT_ACCOUNT_NUMBER = os.environ.get('ACCOUNT_NUMBER')
@@ -24,15 +23,8 @@ DEFAULT_ACCOUNT_NUMBER = os.environ.get('ACCOUNT_NUMBER')
 # Use if an unsupplied value requires interactive confirmation before defaulting
 CONFIRM_DEFAULT_ACCOUNT_NUMBER = 'confirm-default-account-number'
 
-# Typically only the recent images are what needs to be seen when doing things like adding or removing labels.
-# But this number is quite arbitrary. Since the command to show a list will summarize how many were not shown,
-# it should be easy to ask for a wider window.
-IMAGE_COUNT_LIMIT = 10
-
-# This is extremely arbitrary. It shouldn't be a major efficiency matter since this is rarely used.
-# A small number means the feature of managing multiple chunks is regularly tested and less likely to have
-# weird bugs creep in that we don't notice until later.
-IMAGE_LIST_CHUNK_SIZE = 25
+IMAGE_COUNT_LIMIT = ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT  # Deprecated (to remove in release 5.0) -kmp 4-Sep-2022
+IMAGE_LIST_CHUNK_SIZE = ECRUtils.IMAGE_LIST_CHUNK_SIZE  # Deprecated (to remove in release 5.0) -kmp 4-Sep-2022
 
 # This tag is presently called "latest", but I'd like to call it "released". -kmp 12-Mar-2022
 # For now refer to it indirectly through a variable.
@@ -99,7 +91,7 @@ def ecr_command_context(account_number, ecs_repository=None, ecr_client=None):
 
 class ECRCommandContext:
 
-    def __init__(self, account_number, ecs_repository=None, ecr_client=None):
+    def __init__(self, account_number=None, ecs_repository=None, ecr_client=None):
         """
         Initializes an ECRContextText
 
@@ -108,14 +100,15 @@ class ECRCommandContext:
             ecs_repository: The name of an ecs_repository, such as 'main'.
             ecr_client: an AWS ecr_client to use instead of having to make one.
         """
-        self.account_number = account_number
+        self.account_number = account_number or DEFAULT_ACCOUNT_NUMBER
         self.ecs_repository = ecs_repository or DEFAULT_ECS_REPOSITORY
-        self.ecr_client = ecr_client or boto3.client('ecr', region_name=REGION)
+        self.ecr_client = ecr_client or boto3.client('ecr', region_name=ECRUtils.REGION)
+        self.ecr_utils = ECRUtils(ecs_repository=self.ecs_repository, ecr_client=self.ecr_client)
 
     def get_images_descriptions(self,
                                 digests: Optional[List[str]] = None,
                                 tags: Optional[List[str]] = None,
-                                limit: Optional[Union[int, str]] = IMAGE_COUNT_LIMIT):
+                                limit: Optional[Union[int, str]] = ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT):
         """
         Args:
             digests: a list of image digests (each represented as a string in sha256 format)
@@ -130,55 +123,12 @@ class ECRCommandContext:
             The descriptions are a list of individual dictionaries with keys that include, at least,
             'imagePushedAt', 'imageTags', and 'imageDigest'.
         """
-        next_token = None
-        image_descriptions = []
-        # We don't know what order they are in, so we need to pull them all down,
-        # and only hen sort them before applying the limit.
-        while True:
-            options = {'repositoryName': self.ecs_repository}
-            if next_token:
-                options['nextToken'] = next_token
-            else:
-                ids = []
-                if digests:
-                    # We may only provide this option on the first call, and only if it's non-null.
-                    ids.extend([{'imageDigest': digest} for digest in digests])
-                if tags:
-                    ids.extend([{'imageTag': tag} for tag in tags])
-                if ids:
-                    options['imageIds'] = ids
-                else:
-                    options['maxResults'] = IMAGE_LIST_CHUNK_SIZE  # can only be provided on the first call
-            response = self.ecr_client.describe_images(**options)
-            image_descriptions.extend(response['imageDetails'])
-            next_token = response.get('nextToken')
-            if not next_token:
-                break
-        image_descriptions = sorted(image_descriptions, key=lambda x: x['imagePushedAt'], reverse=True)
-        total = len(image_descriptions)
-        image_descriptions = self._apply_image_descriptions_limit(image_descriptions=image_descriptions, limit=limit)
-        return {'descriptions': image_descriptions, 'count': len(image_descriptions), 'total': total}
-
-    @classmethod
-    def _apply_image_descriptions_limit(cls, image_descriptions, limit):
-        if not limit:
-            return image_descriptions
-        elif isinstance(limit, int):
-            return image_descriptions[:limit]
-        elif isinstance(limit, str):
-            new_image_descriptions = []
-            for image_description in image_descriptions:
-                new_image_descriptions.append(image_description)
-                if limit in image_description.get('imageTags', []):
-                    break
-            return new_image_descriptions
-        else:
-            raise ValueError("A limit must be an integer position, a string tag, or None.")
+        return self.ecr_utils.get_images_descriptions(digests=digests, tags=tags, limit=limit)
 
     def show_image_catalog(self,
                            digests: Optional[List[str]] = None,
                            tags: Optional[List[str]] = None,
-                           limit: Optional[Union[int, str]] = IMAGE_COUNT_LIMIT,
+                           limit: Optional[Union[int, str]] = ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT,
                            summarize: bool = True):
         """
         Shows a list of tabular information about images in the given account number and ECS respository.
@@ -200,11 +150,12 @@ class ECRCommandContext:
         n = info['count']
         total = info['total']
         if summarize:
+            current_account = f"account {self.account_number}" if self.account_number else "current account"
             if digests or tags:
-                PRINT(f"Only {n_of(n, 'relevant image')} in account {self.account_number} shown.")
+                PRINT(f"Only {n_of(n, 'relevant image')} in {current_account} shown.")
             else:
                 PRINT(f"{'All' if n == total else 'Most recent'} {info['count']} of {info['total']} images"
-                      f" in account {self.account_number} shown.")
+                      f" in {current_account} shown.")
 
     def get_image_manifest(self, tag=None, digest=None) -> str:
         """
@@ -337,8 +288,9 @@ def show_image_catalog_main(override_args=None):
     parser.add_argument('--ecs-repository', dest='ecs_repository',
                         default=DEFAULT_ECS_REPOSITORY, metavar="<repo-name>",
                         help=f"repository name to show images for (default: {DEFAULT_ECS_REPOSITORY})")
-    parser.add_argument('--limit', default=IMAGE_COUNT_LIMIT, metavar="<n>", type=int,
-                        help=f"maximum number of images to describe (default: {IMAGE_COUNT_LIMIT})")
+    parser.add_argument('--limit', default=ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT, metavar="<n>", type=int,
+                        help=f"maximum number of images to describe"
+                             f" (default: {ECRUtils.IMAGE_LIST_DEFAULT_COUNT_LIMIT})")
     parsed = parser.parse_args(args=override_args)
 
     with ecr_command_context(account_number=parsed.account_number,

--- a/dcicutils/ecr_utils.py
+++ b/dcicutils/ecr_utils.py
@@ -1,13 +1,16 @@
 import boto3
 import base64
+import json
 import os
 
-from typing import List, Optional, Union
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
+from typing import List, Optional, Tuple, Union
 from .common import REGION as COMMON_REGION
 from .misc_utils import PRINT
 
 
-class ECRUtils(object):
+class ECRUtils:
     """ Utility class for interacting with ECR.
         Initialized with an env name, from which a repo URL is resolved.
 
@@ -15,6 +18,11 @@ class ECRUtils(object):
         created if it does not already exist.
         NOTE 2: the (already created) ECR repository must have the env_name in the URI
     """
+
+    # This tag is presently called "latest", but I'd like to call it "released". -kmp 12-Mar-2022
+    # For now refer to it indirectly through a variable.
+
+    IMAGE_RELEASED_TAG = 'latest'
 
     # In many cases, the ECR repo named 'main' is where images live.
     # There could be blue/green deploys or other multi-environment account situations where others are used.
@@ -136,6 +144,9 @@ class ECRUtils(object):
 
     @classmethod
     def _apply_image_descriptions_limit(cls, image_descriptions, limit):
+        """
+        Internal helper for get_images_descriptions to apply certain filters
+        """
         if not limit:
             return image_descriptions
         elif isinstance(limit, int):
@@ -150,6 +161,99 @@ class ECRUtils(object):
         else:
             raise ValueError("A limit must be an integer position, a string tag, or None.")
 
+
+class ECRTagWatcher:
+
+    DEFAULT_TAG = ECRUtils.IMAGE_RELEASED_TAG
+    DEFAULT_REGION = ECRUtils.REGION
+
+    def __init__(self, tag: Optional[str] = None, region: str = None, ecs_repository: Optional[str] = None,
+                 ecr_client: Optional[BaseClient] = None, ecr_utils: Optional[ECRUtils] = None):
+        """
+
+        :param tag: a tag to watch for, which if None or unsupplied will default
+            from the class variable DEFAULT_TAG,
+            which is in turn defaulted from ECRUtils.IMAGE_RELEASED_TAG)
+        :param region: an AWS region, which if None or unsupplied will default
+            from the class variable DEFAULT_REGION,
+            which is in turn defaulted from ECRUtils.REGION
+        :param ecs_repository: an ecs repository name, which is None or unsupplied
+            will be defaulted by ECRUtils using ECRUtils.DEFAULT_ECS_REPOSITORY.
+        :param ecr_client: an AWS ecr client, in case you have one already.
+            One will be created if you don't.
+        :param ecr_utils: an ECRUtils object, in case you already have one that has been initialized appropriately.
+            One will be created if you don't.
+        """
+        self.tag = tag or self.DEFAULT_TAG
+        self.ecr_utils = ecr_utils or ECRUtils(ecs_repository=ecs_repository,
+                                               ecr_client=(ecr_client
+                                                           or boto3.client('ecr',
+                                                                           region_name=(region
+                                                                                        or self.DEFAULT_REGION))))
+        self.last_image_digest = self.get_current_image_digest()
+
+    def get_current_image_digest(self) -> Optional[str]:
+        """
+        Returns the image digest of image in the watcher's ECS repository that is currently tagged with the watched tag,
+        or None if there is no such tagged image
+
+        Returns:
+            an image digest or None
+        """
+        try:
+            summary = self.ecr_utils.get_images_descriptions(tags=[self.tag])
+            if summary:
+                descriptions = summary['descriptions']
+                if len(descriptions) != 1:
+                    raise ValueError(f"Expected exactly one tagged image. Got {json.dumps(descriptions, default=str)}")
+                return descriptions[0]['imageDigest']
+            return None
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ImageNotFoundException':
+                return None
+            else:
+                raise
+
+    def check_if_image_digest_changed(self) -> Tuple[bool, Optional[str]]:
+        """
+        Checks the watcher's ECS respository for the image tag associated with watcher,
+        returning two pieces of information:
+
+        * whether the image has changed since the last time a check was done
+        * the image digest for the currently tagged image (or None if there is no image currently tagged)
+
+        Use this method if you need to distinguish between 'changed to None' and 'did not change'.
+        Neither of these is a situation where there is a new image to deploy. If all you want
+        to know is whether there is a reason to deploy due to change, use check_for_new_image_to_deploy.
+
+        Returns:
+            a tuple of (changed, current_digest) where changed is a boolean saying whether
+            the value changed since last time, and current_digest is the digest description
+            of the current image with that tag.
+        """
+        current_digest = self.get_current_image_digest()
+        changed = self.last_image_digest != current_digest
+        self.last_image_digest = current_digest
+        return changed, current_digest
+
+    def check_for_new_image_to_deploy(self) -> Optional[str]:
+        """
+        Checks the watcher's ECS respository for the image tag associated with watcher,
+        returning the image digest of an image description to deploy or None.
+
+        Use this method if you just want to know if now is a good time to start a deploy.
+
+        Note that this does not distinguish the case of tagging state being unchanged
+        and a change to a state in which there is no image associated with the tag.
+        Neither of these cases would be a good time to deploy.
+        Only when an actual newly-tagged image is available will this return a true value (the new image digest).
+
+        Returns:
+            the image digest of an image to be deployed if a new one has been newly tagged
+            since the last check, or None otherwise
+        """
+        changed, new_digest = self.check_if_image_digest_changed()
+        return new_digest if changed else None
 
 
 # These two variables are deprecated. Please use references to ECRUtils instead. They will go away in the future.

--- a/dcicutils/ecr_utils.py
+++ b/dcicutils/ecr_utils.py
@@ -7,7 +7,7 @@ from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 from typing import List, Optional, Tuple, Union
 from .common import REGION as COMMON_REGION
-from .misc_utils import PRINT
+from .misc_utils import ignorable
 
 
 class ECRUtils:
@@ -53,15 +53,16 @@ class ECRUtils:
     def resolve_repository_uri(self, url=None):
         if not self.url or url:
             # TODO: Should be a logging or debugging statement
-            # PRINT('NOTE: Calling out to ECR')
+            # print('NOTE: Calling out to ECR')
             try:
                 resp = self.ecr_client.describe_repositories()
                 for repo in resp.get('repositories', []):
                     if repo['repositoryUri'].endswith(self.env):
                         url = repo['repositoryUri']
             except Exception as e:
+                ignorable(e)
                 # TODO: Should be a logging or debugging statement
-                # PRINT('Could not retrieve repository information from ECR: %s' % e)
+                # print('Could not retrieve repository information from ECR: %s' % e)
                 pass
         self.url = url  # hang onto this
         return url
@@ -85,8 +86,9 @@ class ECRUtils:
             [auth_data] = self.ecr_client.get_authorization_token()['authorizationData']
             return auth_data
         except Exception as e:
+            ignorable(e)
             # TODO: Should be a logging or debugging statement
-            # PRINT('Could not acquire ECR authorization credentials: %s' % e)
+            # print('Could not acquire ECR authorization credentials: %s' % e)
             raise
 
     @staticmethod

--- a/dcicutils/ecr_utils.py
+++ b/dcicutils/ecr_utils.py
@@ -1,6 +1,8 @@
 import boto3
 import base64
+import os
 
+from typing import List, Optional, Union
 from .common import REGION as COMMON_REGION
 from .misc_utils import PRINT
 
@@ -14,36 +16,43 @@ class ECRUtils(object):
         NOTE 2: the (already created) ECR repository must have the env_name in the URI
     """
 
+    # In many cases, the ECR repo named 'main' is where images live.
+    # There could be blue/green deploys or other multi-environment account situations where others are used.
+    DEFAULT_ECS_REPOSITORY = 'main'
+
     REGION = COMMON_REGION  # this default must match what ecs_utils.ECSUtils and secrets_utils.assume_identity use
 
-    # Will thinks this is no longer used. -kmp 14-Jul-2022
-    #
-    # ECR_LAYOUT = {
-    #     'latest-wsgi': 'Latest version of WSGI Application',
-    #     'latest-indexer': 'Latest version of Indexer Application',
-    #     'latest-ingester': 'Latest version of the Ingester Application',
-    #     'stable-wsgi': 'Stable version of WSGI Application',
-    #     'stable-indexer': 'Stable version of Indexer Application',
-    #     'stable-ingester': 'Stable version of the Ingester Application'
-    # }
+    # Typically only the recent images are what needs to be seen when doing things like adding or removing labels.
+    # But this number is quite arbitrary. Since the command to show a list will summarize how many were not shown,
+    # it should be easy to ask for a wider window.
+    IMAGE_LIST_DEFAULT_COUNT_LIMIT = 10
+
+    # This is extremely arbitrary. It shouldn't be a major efficiency matter since this is rarely used.
+    # A small number means the feature of managing multiple chunks is regularly tested and less likely to have
+    # weird bugs creep in that we don't notice until later.
+    IMAGE_LIST_CHUNK_SIZE = 25
 
     # defaults were formerly env_name='cgap-mastertest', local_repository='cgap-wsgi'
-    def __init__(self, *, env_name, local_repository, region=None):
+    def __init__(self, *, env_name=None, local_repository=None, region=None, ecr_client=None,
+                 ecs_repository=None):
         """ Creates an ECR client on startup """
-        self.env = env_name
-        self.local_repository = local_repository
-        self.client = boto3.client('ecr', region_name=region or self.REGION)
+        self.env = env_name or os.environ.get('ENV_NAME')
+        self.local_repository = local_repository  # Not sure this is even used any more. Should we deprecate it?
+        self.ecr_client = ecr_client or boto3.client('ecr', region_name=region or self.REGION)
+        self.ecs_repository = ecs_repository or self.DEFAULT_ECS_REPOSITORY
         self.url = None  # set by calling the below method
 
     def resolve_repository_uri(self, url=None):
         if not self.url or url:
+            # TODO: Should be a logging or debugging statement
             PRINT('NOTE: Calling out to ECR')
             try:
-                resp = self.client.describe_repositories()
+                resp = self.ecr_client.describe_repositories()
                 for repo in resp.get('repositories', []):
                     if repo['repositoryUri'].endswith(self.env):
                         url = repo['repositoryUri']
             except Exception as e:
+                # TODO: Should be a logging or debugging statement
                 PRINT('Could not retrieve repository information from ECR: %s' % e)
         self.url = url  # hang onto this
         return url
@@ -64,9 +73,10 @@ class ECRUtils(object):
                 }
         """
         try:
-            [auth_data] = self.client.get_authorization_token()['authorizationData']
+            [auth_data] = self.ecr_client.get_authorization_token()['authorizationData']
             return auth_data
         except Exception as e:
+            # TODO: Should be a logging or debugging statement
             PRINT('Could not acquire ECR authorization credentials: %s' % e)
             raise
 
@@ -76,6 +86,70 @@ class ECRUtils(object):
             above API call.
         """
         return base64.b64decode(authorization['authorizationToken']).replace(b'AWS:', b'').decode('utf-8')
+
+    def get_images_descriptions(self,
+                                digests: Optional[List[str]] = None,
+                                tags: Optional[List[str]] = None,
+                                limit: Optional[Union[int, str]] = IMAGE_LIST_DEFAULT_COUNT_LIMIT):
+        """
+        Args:
+            digests: a list of image digests (each represented as a string in sha256 format)
+            tags: a list of strings (each being a potential or actual image tag).
+            limit: an int indicating a limit on how many results to return,
+                   a string indicating a limiting tag,
+                   or None indicating no limit.
+
+        Returns:
+            a dictionary with keys 'descriptions' (the primary result), 'count' (the number of descriptions),
+            and 'total' (the total number of registered images in the catalog).
+            The descriptions are a list of individual dictionaries with keys that include, at least,
+            'imagePushedAt', 'imageTags', and 'imageDigest'.
+        """
+        next_token = None
+        image_descriptions = []
+        # We don't know what order they are in, so we need to pull them all down,
+        # and only hen sort them before applying the limit.
+        while True:
+            options = {'repositoryName': self.ecs_repository}
+            if next_token:
+                options['nextToken'] = next_token
+            else:
+                ids = []
+                if digests:
+                    # We may only provide this option on the first call, and only if it's non-null.
+                    ids.extend([{'imageDigest': digest} for digest in digests])
+                if tags:
+                    ids.extend([{'imageTag': tag} for tag in tags])
+                if ids:
+                    options['imageIds'] = ids
+                else:
+                    options['maxResults'] = self.IMAGE_LIST_CHUNK_SIZE  # can only be provided on the first call
+            response = self.ecr_client.describe_images(**options)
+            image_descriptions.extend(response['imageDetails'])
+            next_token = response.get('nextToken')
+            if not next_token:
+                break
+        image_descriptions = sorted(image_descriptions, key=lambda x: x['imagePushedAt'], reverse=True)
+        total = len(image_descriptions)
+        image_descriptions = self._apply_image_descriptions_limit(image_descriptions=image_descriptions, limit=limit)
+        return {'descriptions': image_descriptions, 'count': len(image_descriptions), 'total': total}
+
+    @classmethod
+    def _apply_image_descriptions_limit(cls, image_descriptions, limit):
+        if not limit:
+            return image_descriptions
+        elif isinstance(limit, int):
+            return image_descriptions[:limit]
+        elif isinstance(limit, str):
+            new_image_descriptions = []
+            for image_description in image_descriptions:
+                new_image_descriptions.append(image_description)
+                if limit in image_description.get('imageTags', []):
+                    break
+            return new_image_descriptions
+        else:
+            raise ValueError("A limit must be an integer position, a string tag, or None.")
+
 
 
 # These two variables are deprecated. Please use references to ECRUtils instead. They will go away in the future.

--- a/dcicutils/ecr_utils.py
+++ b/dcicutils/ecr_utils.py
@@ -53,7 +53,7 @@ class ECRUtils:
     def resolve_repository_uri(self, url=None):
         if not self.url or url:
             # TODO: Should be a logging or debugging statement
-            PRINT('NOTE: Calling out to ECR')
+            # PRINT('NOTE: Calling out to ECR')
             try:
                 resp = self.ecr_client.describe_repositories()
                 for repo in resp.get('repositories', []):
@@ -61,7 +61,8 @@ class ECRUtils:
                         url = repo['repositoryUri']
             except Exception as e:
                 # TODO: Should be a logging or debugging statement
-                PRINT('Could not retrieve repository information from ECR: %s' % e)
+                # PRINT('Could not retrieve repository information from ECR: %s' % e)
+                pass
         self.url = url  # hang onto this
         return url
 
@@ -85,7 +86,7 @@ class ECRUtils:
             return auth_data
         except Exception as e:
             # TODO: Should be a logging or debugging statement
-            PRINT('Could not acquire ECR authorization credentials: %s' % e)
+            # PRINT('Could not acquire ECR authorization credentials: %s' % e)
             raise
 
     @staticmethod

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -33,7 +33,7 @@ from .lang_utils import n_of, conjoined_list, there_are
 from .misc_utils import (
     PRINT, ignored, Retry, CustomizableProperty, getattr_customized, remove_prefix, REF_TZ,
     environ_bool, exported, override_environ, override_dict, local_attrs, full_class_name,
-    find_associations, as_seconds,
+    find_associations,
 )
 
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -33,7 +33,7 @@ from .lang_utils import n_of, conjoined_list, there_are
 from .misc_utils import (
     PRINT, ignored, Retry, CustomizableProperty, getattr_customized, remove_prefix, REF_TZ,
     environ_bool, exported, override_environ, override_dict, local_attrs, full_class_name,
-    find_associations,
+    find_associations, as_seconds,
 )
 
 
@@ -1369,6 +1369,169 @@ class MockBoto3Lambda(MockBoto3Client):
         }
         if next_marker is not None:
             result['NextMarker'] = next_marker
+        return result
+
+
+@MockBoto3.register_client(kind='ecr')
+class MockBotoECR(MockBoto3Client):
+
+    # Our mock acts as if this is the current account number
+    _MOCK_ACCOUNT_NUMBER = '111222333444'
+
+    # Our mocked image creation times are this plus a small number of days
+    _MOCK_PUSH_TIME_BASE = datetime.datetime(2020, 1, 1)   # arbitrary
+
+    # Our mocked image sizes are this plus a small amount
+    _MOCK_IMAGE_SIZE_BASE = 900000000
+
+    # When nextToken is not in play for some operations, this can be used.
+    # It is important that it be both a string and false, hence the empty string.
+    _NO_NEXT_TOKEN = ""
+
+    def __init__(self, region_name: str = None, boto3: MockBoto3 = None) -> None:
+        self.region_name = region_name
+        self.account_number = self._MOCK_ACCOUNT_NUMBER
+        self.boto3 = boto3 or MockBoto3()
+        self.images = None
+        self.digest_counter = 0
+        reality = self.boto3.shared_reality
+        if 'ecs_repositories' in reality:
+            self.ecs_repositories = reality['ecs_repositories']
+        else:
+            reality['ecs_repositories'] = repositories = {}
+            self.ecs_repositories = repositories
+
+    def describe_repositories(self):
+        return {
+            "repositories": [
+                repo['metadata'] for repo in self.ecs_repositories.values()
+            ],
+            "ResponseMetadata": self.compute_mock_response_metadata()
+        }
+
+    def add_image_repository_for_testing(self, repository):
+        # A sample of a result from boto3.client('ecr').describe_repositories() might return.
+        # {
+        #     "repositories":
+        #         {
+        #             "repositoryArn": "arn:aws:ecr:us-east-1:643366669028:repository/fourfront-mastertest",
+        #             "registryId": "643366669028",
+        #             "repositoryName": "fourfront-mastertest",
+        #             "repositoryUri": "643366669028.dkr.ecr.us-east-1.amazonaws.com/fourfront-mastertest",
+        #             "createdAt": "2021-10-07 14:57:06-04:00",
+        #             "imageTagMutability": "MUTABLE",
+        #             "imageScanningConfiguration": {
+        #             "scanOnPush": true
+        #         },
+        #         "encryptionConfiguration": {
+        #             "encryptionType": "AES256"
+        #         }
+        #     },
+        #     "ResponseMetadata": {...}
+        # }
+        entry = {
+            "metadata": {
+                "repositoryName": repository,
+                "repositoryUri": f"{self.account_number}.dkr.ecr.{self.region_name}.amazonaws.com/{repository}",
+            },
+            "images": [],  # not something AWS keeps track of
+        }
+        self.ecs_repositories[repository] = entry
+        return entry
+
+    def get_repository_for_testing(self, repository):
+        try:
+            return self.ecs_repositories[repository]
+        except Exception:
+            raise AssertionError(f"Undefined mock ECS repository {repository}."
+                                 f" You may need to add_image_repository_for_testing.")
+
+    def get_repository_images_for_testing(self, repository) -> List[dict]:
+        return self.get_repository_for_testing(repository)['images']
+
+    def get_image_repository_metadata_for_testing(self, repository) -> List[dict]:
+        return self.get_repository_for_testing(repository)['metadata']
+
+    def add_image_metadata_for_testing(self, repository, image_digest=None, pushed_at=None, tags=None):
+        # Typical image restriction from AWS...
+        # {
+        #     "registryId": "262461168236",
+        #     "repositoryName": "main",
+        #     "imageDigest": "sha256:177aa1b7188e9eb81b0a8405653c2e0131119c74b04d8a70ed3ec5cedc833ab2",
+        #     "imageTags": ["latest"],
+        #     "imageSizeInBytes": 975668379,
+        #     "imagePushedAt": "2022-08-29 10:46:49-04:00",
+        #     "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        #     "artifactMediaType": "application/vnd.docker.container.image.v1+json",
+        #     "lastRecordedPullTime": "2022-09-01 14:20:08.711000-04:00"
+        # }
+        self.digest_counter += 1
+        tag_set = set(tags) if tags else set()
+        entry = {
+            "_mock_digest_counter": self.digest_counter,
+            "imageDigest": image_digest or f"sha256:{str(self.digest_counter).rjust(64, '0')}",
+            # Note that mock won't error-check duplication, but tags are supposed to be unique
+            "imageTags": tag_set,
+            "imageManifestMediateType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json",
+            "imageSizeInBytes": self._MOCK_IMAGE_SIZE_BASE + self.digest_counter,  # make all have different sizes
+            "imagePushedAt": pushed_at or self._MOCK_PUSH_TIME_BASE + datetime.timedelta(days=self.digest_counter),
+            "lastRecordedPullTime": None,
+        }
+        images = self.get_repository_images_for_testing(repository)
+        for image in images:
+            image['imageTags'] = image['imageTags'] - tag_set
+        images.append(entry)
+        return entry
+
+    def describe_images(self, repositoryName, imageIds=None, maxResults=None, nextToken=_NO_NEXT_TOKEN):  # noQA - AWS choices
+        if maxResults is None:
+            maxResults = 100
+        assert isinstance(maxResults, int) and 1 <= maxResults <= 1000, "maxResults must be an integer from 1 to 1000."
+        images = self.get_repository_images_for_testing(repositoryName)
+        new_next_token = None
+        if nextToken:
+            startpos = int(nextToken)
+            endpos = startpos + maxResults
+            new_next_token = str(endpos + 1) if len(images) > endpos else self._NO_NEXT_TOKEN
+            found_images = images[startpos:endpos]
+        elif imageIds:
+            image_digests_to_find = set()
+            image_tags_to_find = set()
+            for entry in imageIds:
+                digest = entry.get('imageDigest')
+                if digest:
+                    image_digests_to_find.add(digest)
+                else:
+                    tag = entry.get('imageTag')
+                    image_tags_to_find.add(tag)
+            found_images = []
+            for image in images:
+                digest = image['imageDigest']
+                # print(f"Searching for digest={digest!r} in {image_digests_to_find!r}...")
+                # print(f"Then searching image_tags_to_find={image_tags_to_find!r} & tags={image['imageTags']}")
+                if digest in image_digests_to_find:
+                    # print("Found digest")
+                    found_images.append(image)
+                elif image_tags_to_find & image['imageTags']:
+                    # print("Found tags")
+                    found_images.append(image)
+                else:
+                    # print("Neither found")
+                    pass
+        else:
+            found_images = images[:maxResults]
+            new_next_token = str(maxResults + 1) if len(images) > maxResults else self._NO_NEXT_TOKEN
+        found_images = [dict(image,
+                             imageTags=sorted(list(image['imageTags'])),
+                             registryId=self.account_number,
+                             repositoryName=repositoryName)
+                        for image in found_images]
+        result = {
+            'imageDetails': found_images,
+        }
+        if new_next_token:
+            result['nextToken'] = new_next_token
         return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "4.6.0"
+version = "4.7.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -1,9 +1,12 @@
+import json
 import pytest
 
 from unittest import mock
-from dcicutils.ecr_utils import ECRUtils
+from dcicutils import ecr_utils as ecr_utils_module
+from dcicutils.ecr_utils import ECRUtils, ECRTagWatcher
 from dcicutils.docker_utils import DockerUtils
 from dcicutils.misc_utils import ignored, ignorable, filtered_warnings
+from dcicutils.qa_utils import MockBoto3, MockBotoECR
 from .helpers import using_fresh_cgap_state_for_testing
 
 
@@ -55,6 +58,71 @@ def test_ecr_utils_workflow():
             # XXX: integrated test the remaining?
 
 
-def test_ecr_utils_integrated():
-    """ Write me! """
-    pass
+def test_ecr_utils_get_uri():
+    print()  # start output on fresh line
+    mock_boto3 = MockBoto3()
+    with mock.patch.object(ecr_utils_module, "boto3", mock_boto3):
+        ecr_client: MockBotoECR = mock_boto3.client('ecr')
+        for repo in ['main', 'decoy-1', 'fourfront-foo', 'decoy-2']:
+            print(f"Adding image repository"
+                  f" {json.dumps(ecr_client.add_image_repository_for_testing(repo), indent=2, default=str)}")
+        print("---- Setup complete. Beginning test. ----")
+        ecr_utils = ECRUtils(env_name='fourfront-foo')
+        assert ecr_utils.url is None
+        with pytest.raises(Exception):
+            ecr_utils.get_uri()  # This intentionally raises an error if there is no URL
+        ecr_utils.resolve_repository_uri()
+        print(f"ecr_utils.url = {ecr_utils.url}")
+        assert ecr_utils.url is not None
+        print(f"ecr_utils.get_uri() = {ecr_utils.get_uri()}")
+        assert ecr_utils.get_uri() is not None
+
+
+def test_ecr_utils_resolve_repository_uri():
+    print()  # start output on fresh line
+    mock_boto3 = MockBoto3()
+    with mock.patch.object(ecr_utils_module, "boto3", mock_boto3):
+        ecr_client: MockBotoECR = mock_boto3.client('ecr')
+        for repo in ['main', 'decoy-1', 'fourfront-foo', 'decoy-2']:
+            print(f"Adding image repository"
+                  f" {json.dumps(ecr_client.add_image_repository_for_testing(repo), indent=2, default=str)}")
+        print("---- Setup complete. Beginning test. ----")
+        ecr_utils = ECRUtils(env_name='fourfront-foo')
+        print(f"ecr_utils.url = {ecr_utils.url}")
+        assert ecr_utils.url is None
+        print("resolving repository URI")
+        ecr_utils.resolve_repository_uri()
+        print(f"ecr_utils.url = {ecr_utils.url}")
+        assert ecr_utils.url is not None
+
+
+def test_ecr_tag_watcher():
+    print()  # start output on fresh line
+    mock_boto3 = MockBoto3()
+    with mock.patch.object(ecr_utils_module, "boto3", mock_boto3):
+        ecr_client: MockBotoECR = mock_boto3.client('ecr')
+        ecr_client.add_image_repository_for_testing('main')
+        for i in range(5):
+            last_from_loop = ecr_client.add_image_metadata_for_testing('main', tags=['latest'])
+        watcher = ECRTagWatcher()
+        first_found = watcher.get_current_image_digest()
+        print(f"first_found = {first_found}")
+        assert first_found == last_from_loop['imageDigest']
+        to_deploy = watcher.check_for_new_image_to_deploy()
+        assert not to_deploy
+        print(f"to_deploy =   {to_deploy}")
+        assert first_found == watcher.get_current_image_digest()
+        print(f"Simulating deploy.")
+        even_newer = ecr_client.add_image_metadata_for_testing('main', tags=['latest'])
+        next_found = watcher.get_current_image_digest()
+        print(f"next_found =  {next_found}")
+        assert next_found != first_found
+        assert next_found == even_newer['imageDigest']
+        assert next_found == watcher.get_current_image_digest()  # It stays this until next deploy
+        to_deploy = watcher.check_for_new_image_to_deploy()
+        print(f"to_deploy =   {to_deploy}")
+        assert to_deploy
+        assert to_deploy == next_found
+        to_deploy = watcher.check_for_new_image_to_deploy()
+        print(f"to_deploy =   {to_deploy}")
+        assert not to_deploy

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -74,8 +74,10 @@ def test_ecr_utils_get_uri():
         ecr_utils.resolve_repository_uri()
         print(f"ecr_utils.url = {ecr_utils.url}")
         assert ecr_utils.url is not None
-        print(f"ecr_utils.get_uri() = {ecr_utils.get_uri()}")
-        assert ecr_utils.get_uri() is not None
+        uri = ecr_utils.get_uri()
+        print(f"ecr_utils.get_uri() = {uri}")
+        assert isinstance(uri, str)
+        assert uri.endswith('/fourfront-foo')
 
 
 def test_ecr_utils_resolve_repository_uri():

--- a/test/test_ecr_utils.py
+++ b/test/test_ecr_utils.py
@@ -27,7 +27,7 @@ def test_ecr_utils_basic():
     """ Tests something simple for now, more tests to be added later. """
     # init args no longer default. -kmp 14-Jul-2022
     cli = ECRUtils(env_name='cgap-mastertest', local_repository='cgap-wsgi')
-    with mock.patch.object(cli.client, 'describe_repositories', mocked_describe_respositories):
+    with mock.patch.object(cli.ecr_client, 'describe_repositories', mocked_describe_respositories):
         url = cli.resolve_repository_uri()
         assert url == REPO_URL
 
@@ -39,7 +39,7 @@ def test_ecr_utils_workflow():
     # init args no longer default. -kmp 14-Jul-2022
     ecr_cli = ECRUtils(env_name='cgap-mastertest', local_repository='cgap-wsgi')
     docker_cli = DockerUtils()
-    with mock.patch.object(ecr_cli.client, 'describe_repositories', mocked_describe_respositories):
+    with mock.patch.object(ecr_cli.ecr_client, 'describe_repositories', mocked_describe_respositories):
         ecr_cli.resolve_repository_uri()
         ecr_user, ecr_pass = 'dummy', 'dummy'  # XXX: integrated test for this mechanism
         with mock.patch.object(docker_cli.client, 'login', mocked_ecr_login):


### PR DESCRIPTION
* This adds a new class `ecr_utils.ECRTagWatcher` that may be useful in Foursight to know if it's time to deploy.
* This does some detailed refactoring of `ecr_utils.py` and `ecr_scripts.py`. See `CHANGELOG.rst` for details.
* Added `qa_utils` support for ECR client.
* Added unit tests for new functionality.
* Added unit tests for some pre-existing `ECRUtils` functionality.

Opportunistic:

* There were some syntax problems with the changelog that were not making things unreadable but were generating the wrong markup, so I did some adjustments.

