### PR TITLE
New class ChangeLogChecker (C4-913, C4-915)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ Change Log
 ----------
 
 
+5.1.0
+=====
+
+* In ``qa_utils``:
+
+  * New class ChangeLogChecker, like VersionChecker, but it raises an error
+    if there's a change log inconsistency.
+
+
 5.0.0
 =====
 

--- a/dcicutils/secrets_utils.py
+++ b/dcicutils/secrets_utils.py
@@ -419,3 +419,17 @@ class SecretsTable:
                                  secretsmanager_client=secretsmanager_client)
         secret_name = secret['Name']
         return SecretsTable(name=secret_name, secretsmanager_client=secretsmanager_client)
+
+    # This value is used by various DCIC tools as a placeholder for GAC values that may
+    # need to be supplied by the user. It is often treated as "empty" even though it is not false.
+    PLACEHOLDER_VALUE = 'XXX: ENTER VALUE'
+
+    @classmethod
+    def is_placeholder_value(cls, value):
+        """Returns True if its argument is the GAC placeholder value, and returns False otherwise."""
+        return value == cls.PLACEHOLDER_VALUE
+
+    @classmethod
+    def is_empty_value(cls, value):
+        """Returns True if its argument is null or is the GAC placeholder value, and returns False otherwise."""
+        return not value or cls.is_placeholder_value(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.0.0"
+version = "5.1.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_secrets_utils.py
+++ b/test/test_secrets_utils.py
@@ -530,3 +530,19 @@ def test_find_application_secrets_table():
             # There is no thing called DecoyApplicationConfiguration
             found = SecretsTable.find_application_secrets_table(application_configuration_pattern='Decoy')
             ignored(found)  # Shouldn't reach here
+
+
+def test_is_placeholder_value():
+
+    assert SecretsTable.is_placeholder_value(None) is False
+    assert SecretsTable.is_placeholder_value('') is False
+    assert SecretsTable.is_placeholder_value('foo') is False
+    assert SecretsTable.is_placeholder_value(SecretsTable.PLACEHOLDER_VALUE) is True
+
+
+def test_is_empty_value():
+
+    assert SecretsTable.is_empty_value(None) is True
+    assert SecretsTable.is_empty_value('') is True
+    assert SecretsTable.is_empty_value('foo') is False
+    assert SecretsTable.is_empty_value(SecretsTable.PLACEHOLDER_VALUE) is True


### PR DESCRIPTION
* Make a new class ChangeLogChecker that raises an `AssertionError` rather than just warning if `CHANGELOG.rst` is inconsistent with `pyproject.toml`. (part of [C4-915](https://hms-dbmi.atlassian.net/browse/C4-915))

Opportunistic (part of [C4-913](https://hms-dbmi.atlassian.net/browse/C4-913))

* In `secrets_utils`:

  * Add `SecretsTable.PLACEHOLDER_VALUE` to hold the GAC placeholder value.
  * Add `SecretsTable.is_placeholder_value()` class method (predicate to detect placeholder)
  * Add `SecretsTable.is_empty_value()` class method (predicate to detect null or placeholder)