### PR TITLE
More static checkers

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,43 @@
+# Standard static test runner
+
+name: Static Checks
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    name: Static checks of source code (PEP8 and our custom checks)
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Python Package Setup
+        run: |
+          make configure
+          poetry install
+      - name: Static Checks
+        env:
+          # Some repos don't have server fixtures, but this next line is harmless there.
+          NO_SERVER_FIXTURES: TRUE
+          # Anything that has dcicutils available will understand and need this to keep from talking to AWS in static testing
+          USE_SAMPLE_ENVUTILS: TRUE
+        run: |
+          make test-static
+          make lint

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -34,9 +34,7 @@ jobs:
           poetry install
       - name: Static Checks
         env:
-          # Some repos don't have server fixtures, but this next line is harmless there.
           NO_SERVER_FIXTURES: TRUE
-          # Anything that has dcicutils available will understand and need this to keep from talking to AWS in static testing
           USE_SAMPLE_ENVUTILS: TRUE
         run: |
           make test-static

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,40 @@ Change Log
 ----------
 
 
+5.2.0
+=====
+
+* Some functionality moved from ``qa_utils`` to ``qa_checkers``.
+  In each case, to be compatible, the ``qa_utils`` module will continue
+  to have the entity availble for import until the next major release.
+
+  * Class ``VersionChecker``
+  * Class ``ChangeLogChecker``
+  * Function ``confirm_no_uses``
+  * Function ``find_uses``
+  * Variable ``QA_EXCEPTION_PATTERN``
+
+  As an official matter, use of these moved entities from by importing
+  them from ``dcicutils.qa_utils`` is deprecated. Please update programs
+  to import these from ``dcicutils.qa_checkers`` instead.
+
+* New functionality in ``qa_checkers``:
+
+  * New class ``DocsChecker``
+  * New class ``DebuggingArtifactChecker``
+
+* In ``misc_utils``:
+
+  * New function ``lines_printed_to``.
+
+* New ``pytest`` marker ``static`` for static tests.
+
+* New ``make`` target ``test-static`` to run tests marked with
+  ``@pytest.mark.static``.
+
+* New GithubActions (GA) workflow: ``static_checks.yml``
+
+
 5.1.0
 =====
 

--- a/Makefile
+++ b/Makefile
@@ -36,28 +36,28 @@ test-all:  # you have to be really brave to want this. a lot of things will err
 test-most:  # leaves out things that will probably err but runs unit tests and both kinds of integrations
 	@git log -1 --decorate | head -1
 	@date
-	poetry run pytest -vv -r w -m "not beanstalk_failure and not direct_es_query"
+	poetry run pytest -vv -r w -m "not static and not beanstalk_failure and not direct_es_query"
 	@git log -1 --decorate | head -1
 	@date
 
 test-units-with-coverage:
 	@git log -1 --decorate | head -1
 	@date
-	poetry run coverage run --source dcicutils -m pytest -vv -r w -m "not integratedx and not beanstalk_failure and not direct_es_query"
+	poetry run coverage run --source dcicutils -m pytest -vv -r w -m "not static and not integratedx and not beanstalk_failure and not direct_es_query"
 	@git log -1 --decorate | head -1
 	@date
 
 test-units:  # runs unit tests (and integration tests not backed by a unit test)
 	@git log -1 --decorate | head -1
 	@date
-	poetry run pytest -vv -r w -m "not integratedx and not beanstalk_failure and not direct_es_query"
+	poetry run pytest -vv -r w -m "not static and not integratedx and not beanstalk_failure and not direct_es_query"
 	@git log -1 --decorate | head -1
 	@date
 
 test-integrations:  # runs integration tests
 	@git log -1 --decorate | head -1
 	@date
-	poetry run pytest -vv -r w -m "(integrated or integratedx) and not beanstalk_failure and not direct_es_query"
+	poetry run pytest -vv -r w -m "not static and (integrated or integratedx) and not beanstalk_failure and not direct_es_query"
 	@git log -1 --decorate | head -1
 	@date
 
@@ -65,6 +65,13 @@ test-direct-es-query:  # must be called inside VPC (e.g., from foursight after c
 	@git log -1 --decorate | head -1
 	@date
 	poetry run pytest -vv -r w -m "direct_es_query"
+	@git log -1 --decorate | head -1
+	@date
+
+test-static:
+	@git log -1 --decorate | head -1
+	@date
+	poetry run pytest -vv -r w -m "static"
 	@git log -1 --decorate | head -1
 	@date
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,18 @@
 import os
 
+from dcicutils.env_utils import EnvUtils
+from dcicutils.misc_utils import environ_bool, PRINT
+
+
+NO_SERVER_FIXTURES = environ_bool("NO_SERVER_FIXTURES")
+
+
 _account_number = os.environ.get('ACCOUNT_NUMBER')
 
 if _account_number and _account_number != '643366669028':
     raise Exception(f"These tests must be run with legacy credentials."
                     f"Your credentials are set to account {_account_number}")
 
-
+if NO_SERVER_FIXTURES:
+    PRINT(f"EnvUtils using sample configuration template.")
+    EnvUtils.set_declared_data(data=EnvUtils.SAMPLE_TEMPLATE_FOR_CGAP_TESTING)

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ from dcicutils.env_utils import EnvUtils
 from dcicutils.misc_utils import environ_bool, PRINT
 
 
-NO_SERVER_FIXTURES = environ_bool("NO_SERVER_FIXTURES")
+USE_SAMPLE_ENVUTILS = environ_bool("USE_SAMPLE_ENVUTILS")
 
 
 _account_number = os.environ.get('ACCOUNT_NUMBER')
@@ -13,6 +13,6 @@ if _account_number and _account_number != '643366669028':
     raise Exception(f"These tests must be run with legacy credentials."
                     f"Your credentials are set to account {_account_number}")
 
-if NO_SERVER_FIXTURES:
+if USE_SAMPLE_ENVUTILS:
     PRINT(f"EnvUtils using sample configuration template.")
     EnvUtils.set_declared_data(data=EnvUtils.SAMPLE_TEMPLATE_FOR_CGAP_TESTING)

--- a/conftest.py
+++ b/conftest.py
@@ -5,3 +5,5 @@ _account_number = os.environ.get('ACCOUNT_NUMBER')
 if _account_number and _account_number != '643366669028':
     raise Exception(f"These tests must be run with legacy credentials."
                     f"Your credentials are set to account {_account_number}")
+
+

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -29,6 +29,8 @@ _MOCK_APPLICATION_OPTIONS_PARTIAL = (
     f"MOCK_USERNAME={_MOCK_SERVICE_USERNAME},MOCK_PASSWORD={_MOCK_SERVICE_PASSWORD},ENV_NAME="
 )
 
+NO_SERVER_FIXTURES = environ_bool("NO_SERVER_FIXTURES")
+
 
 class MockBoto4DNLegacyElasticBeanstalkClient(MockBotoElasticBeanstalkClient):  # noQA - missing some abstract methods
 
@@ -726,6 +728,10 @@ class AbstractIntegratedFixture:
 
     @classmethod
     def initialize_class(cls):
+
+        if NO_SERVER_FIXTURES:
+            return
+
         cls.S3_CLIENT = s3_utils.s3Utils(env=cls.ENV_NAME)
         cls.ES_URL = _portal_health_get(portal_url=cls.ENV_PORTAL_URL,
                                         namespace=cls.ENV_INDEX_NAMESPACE,
@@ -743,6 +749,9 @@ class AbstractIntegratedFixture:
 
     @classmethod
     def verify_portal_access(cls, portal_access_key):
+        if NO_SERVER_FIXTURES:
+            return
+
         response = authorized_request(
             portal_access_key['server'],
             auth=portal_access_key)

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -730,7 +730,7 @@ class AbstractIntegratedFixture:
     def initialize_class(cls):
 
         if NO_SERVER_FIXTURES:
-            return
+            return 'NO_SERVER_FIXTURES'
 
         cls.S3_CLIENT = s3_utils.s3Utils(env=cls.ENV_NAME)
         cls.ES_URL = _portal_health_get(portal_url=cls.ENV_PORTAL_URL,
@@ -750,7 +750,7 @@ class AbstractIntegratedFixture:
     @classmethod
     def verify_portal_access(cls, portal_access_key):
         if NO_SERVER_FIXTURES:
-            return
+            return 'NO_SERVER_FIXTURES'
 
         response = authorized_request(
             portal_access_key['server'],

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -54,6 +54,19 @@ PRINT = _PRINT()
 PRINT.__name__ = 'PRINT'
 
 
+@contextlib.contextmanager
+def lines_printed_to(file):
+    """
+    This context manager opens a file and returns a function that can be called repeatedly during the body context
+    to do do line-by-line output to that file. It uses PRINT to do that output, so the unit test tools for PRINT
+    can be used to test this.
+    """
+    with io.open(file, 'w') as fp:
+        def write_line(s=""):
+            PRINT(s, file=fp)
+        yield write_line
+
+
 def print_error_message(exception, full=False):
     """
     Prints an error message (using dcicutils.misc_utils.PRINT) in the conventional way, as:

--- a/dcicutils/qa_checkers.py
+++ b/dcicutils/qa_checkers.py
@@ -1,0 +1,372 @@
+import glob
+import io
+import os
+import re
+import toml
+import warnings
+
+from collections import defaultdict
+from typing import Optional, List
+from .lang_utils import conjoined_list, n_of, there_are
+from .misc_utils import PRINT, remove_prefix, remove_suffix, getattr_customized, CustomizableProperty
+
+
+QA_EXCEPTION_PATTERN = re.compile(r"[#].*\b[N][O][Q][A]\b", re.IGNORECASE)
+
+
+def find_uses(*, where, patterns, recursive=False):
+    """
+    In the files specified by where (a glob pattern), finds uses of pattern (a regular expression).
+
+    :param where: a glob pattern
+    :param patterns: a dictionary mapping problem summaries to regular expressions
+    :param recursive: a boolean saying whether to look recursively [UNIMPLEMENTED]
+    """
+
+    assert not recursive, "The recursive option to find_uses is not yet implemented."
+
+    checks = []
+    for summary, pattern in patterns.items():
+        checks.append((re.compile(pattern), summary))
+    uses = defaultdict(lambda: [])
+    files = glob.glob(where)
+    for file in files:
+        with io.open(file, 'r') as fp:
+            line_number = 0
+            for line in fp:
+                line_number += 1
+                for matcher, summary in checks:
+                    if matcher.search(line):
+                        problem_ignorable = QA_EXCEPTION_PATTERN.search(line)
+                        if not problem_ignorable:
+                            uses[file].append({"line_number": line_number, "line": line.rstrip('\n'),
+                                               "summary": summary})
+    return uses
+
+
+def confirm_no_uses(*, where, patterns):
+    """
+    In the files specified by where (a glob pattern), finds uses of pattern (a regular expression).
+
+    :param where: a glob pattern
+    :param patterns: dicionary mapping summaries to regular expressions
+    """
+
+    __tracebackhide__ = True
+
+    def summarize(problems):
+        categories = defaultdict(lambda: 0)
+        for problem in problems:
+            categories[problem['summary']] += 1
+        return conjoined_list([n_of(count, category) for category, count in categories.items()])
+
+    uses = find_uses(patterns=patterns, where=where)
+    if uses:
+        detail = ""
+        n = 0
+        for file, matches in uses.items():
+            n += len(matches)
+            detail += f"\n In {file}, {summarize(matches)}."
+        message = f"{n_of(n, 'problem')} detected:" + detail
+        raise AssertionError(message)
+
+
+class ChangeLogChecker:
+
+    """
+    Given appropriate customizations, this allows cross-checking of pyproject.toml and a changelog for consistency.
+
+    By default, it will raise an error if the CHANGELOG is specified and is not consistent with the version
+    (unless that version is a beta).
+
+    If the class variable RAISE_ERROR_IF_CHANGELOG_MISMATCH is set to False, as is the case in
+    subclass VersionChecker, only a warning (of a kind given by WARNING_CATEGORY) will be generated,
+    not an error, so use that subclass if you don't want hard errors for version inconsistency.
+
+    You must subclass this class, specifying both the pyproject filename and the changelog filename as
+    class variables PYPROJECT and CHANGELOG, respectively.
+
+    def test_version():
+
+        class MyAppChangeLogChecker(ChangeLogChecker):
+            PYPROJECT = os.path.join(ROOT_DIR, "pyproject.toml")
+            CHANGELOG = os.path.join(ROOT_DIR, "CHANGELOG.rst")
+
+        MyAppChangeLogChecker.check_version()
+
+    """
+
+    PYPROJECT = CustomizableProperty('PYPROJECT', description="The repository-relative name of the pyproject file.")
+    CHANGELOG = CustomizableProperty('CHANGELOG', description="The repository-relative name of the change log.")
+
+    # I wanted to use pytest.PytestConfigWarning, but that creates a dependency
+    # on particular versions of pytest, and we don't export a delivery
+    # constraint of a particular pytest version. So RuntimeWarning is a
+    # safer setting for now. -kmp 14-Jan-2021
+    WARNING_CATEGORY = RuntimeWarning
+
+    @classmethod
+    def check_version(cls):
+        version = cls._check_version()
+        if getattr_customized(cls, "CHANGELOG"):
+            cls._check_change_history(version)
+
+    @classmethod
+    def _check_version(cls):
+
+        __tracebackhide__ = True
+
+        pyproject_file = getattr_customized(cls, 'PYPROJECT')
+        assert os.path.exists(pyproject_file), "Missing pyproject file: %s" % pyproject_file
+        pyproject = toml.load(pyproject_file)
+        version = pyproject.get('tool', {}).get('poetry', {}).get('version', None)
+        assert version, "Missing version in %s." % pyproject_file
+        PRINT("Version = %s" % version)
+        return version
+
+    RAISE_ERROR_IF_CHANGELOG_MISMATCH = True
+
+    VERSION_LINE_PATTERN = re.compile("^[#* ]*([0-9]+[.][^ \t\n]*)([ \t\n].*)?$")
+    VERSION_IS_BETA_PATTERN = re.compile("^.*[0-9][Bb][0-9]+$")
+
+    @classmethod
+    def _check_change_history(cls, version=None):
+
+        if version and cls.VERSION_IS_BETA_PATTERN.match(version):
+            # Don't require beta versions to match up in change log.
+            # We don't just strip the version and look at that because sometimes we use other numbers on betas.
+            # Better to just not do it at all.
+            return
+
+        changelog_file = getattr_customized(cls, "CHANGELOG")
+
+        if not changelog_file:
+            if version:
+                raise AssertionError("Cannot check version without declaring a CHANGELOG file.")
+            return
+
+        assert os.path.exists(changelog_file), "Missing changelog file: %s" % changelog_file
+
+        with io.open(changelog_file) as fp:
+            versions = []
+            for line in fp:
+                m = cls.VERSION_LINE_PATTERN.match(line)
+                if m:
+                    versions.append(m.group(1))
+
+        assert versions, "No version info was parsed from %s" % changelog_file
+
+        # Might be sorted top to bottom or bottom to top, but ultimately the current version should be first or last.
+        if versions[0] != version and versions[-1] != version:
+            message = "Missing entry for version %s in %s." % (version, changelog_file)
+            if cls.RAISE_ERROR_IF_CHANGELOG_MISMATCH:
+                raise AssertionError(message)
+            else:
+                warnings.warn(message, category=cls.WARNING_CATEGORY, stacklevel=2)
+            return
+
+
+class VersionChecker(ChangeLogChecker):
+
+    """
+    Given appropriate customizations, this allows cross-checking of pyproject.toml and a changelog for consistency.
+
+    By default, a warning (of a kind given by WARNING_CATEGORY) will be generated, not an error, if the change
+    log is not consistent. If you want a hard error, use the superclass ChangeLogChecker.
+
+    You must subclass this class, specifying both the pyproject filename and the changelog filename as
+    class variables PYPROJECT and CHANGELOG, respectively.
+
+    def test_version():
+
+        class MyAppVersionChecker(VersionChecker):
+            PYPROJECT = os.path.join(ROOT_DIR, "pyproject.toml")
+            CHANGELOG = os.path.join(ROOT_DIR, "CHANGELOG.rst")
+
+        MyAppVersionChecker.check_version()
+
+    """
+
+    RAISE_ERROR_IF_CHANGELOG_MISMATCH = False
+
+
+class StaticChecker:
+
+    ROOT_DIR = None
+
+    def __init__(self, sources_subdir, root_dir=None):
+        self.root_dir = os.path.abspath(root_dir or self.ROOT_DIR or os.curdir)
+        self.sources_dir = os.path.abspath(os.path.join(self.root_dir, sources_subdir))
+        super().__init__()
+
+
+class DocsChecker(StaticChecker):
+
+    SKIP_SUBMODULES: List[str] = []
+
+    DOCS_SUBDIR = "docs/source"
+
+    def __init__(self, *, sources_subdir, docs_index_file,
+                 root_dir: Optional[str] = None, docs_subdir: Optional[str] = None,
+                 module_name: Optional[str] = None, skip_submodules: List[str] = None, recursive: bool = False):
+        """
+        A DocChecker is potentially capable of various kinds of checks of a repository's documentation.
+
+        :param sources_subdir: In most cases, e.g., for a library, code will live in a subdir that names the library,
+            such as 'dcicutils' for this (4dn-dcic/utils) repository.
+            For CGAP and Fourfront, sources in a more obscure place, 'src/encoded'.
+        :param docs_index_file: The name of the documentation file in which module reference documentation would be.
+            This is not necessarily the root of the documentation, which may contain other introductory material.
+            Typically this will have a name like 'index.rst' but for this library (dcicutils), the name `dcicutils.rst'
+            is used. Our repositories vary a lot, so no point in guessing. Just specify it.
+        :param root_dir: The name of the folder that is the root of this repository (e.g., where the pyproject.toml
+            file or CHANGELOG.rst files would be, but also the place relative to which the various subdirs are given).
+            By default, as the system loads, it's assumed you're in the root directory so the default is
+            os.path.abspath(os.curdir).
+        :param docs_subdir: The place to find documentation. By default we assume 'docs/source'.
+        :param module_name: The top-level module name (usually a library or an application name).
+            If not specified, a default will be taken from the last component of the sources_subdir.
+        :param skip_submodules: The name of modules that are not expected to be documented. These might be modules
+            containing deprecated functionality or other implementation substrate not intended to be documented.
+        :param recursive: Whether to consider source files beyond the top-level of the sources_subdir. If False,
+            only the immediate contents of sources_subdir are considered. Otherwise, all of its contents recursively
+            are considered, subject to some filtering that might be done by some operations.
+        """
+
+        super().__init__(sources_subdir=sources_subdir, root_dir=root_dir)
+        self.module_name = module_name or sources_subdir.split('.')[-1]
+        self.docs_dir = os.path.join(self.root_dir, docs_subdir or self.DOCS_SUBDIR)
+        self.docs_index_file = os.path.join(self.docs_dir, docs_index_file)
+        self.skip_submodules = set(skip_submodules or self.SKIP_SUBMODULES)
+        self.sources_files = self.compute_sources_files(recursive=recursive)
+
+    _UNWANTED_SUBMODULE_FILTER = re.compile("(tests?/|/test_|/[^a-z])", re.IGNORECASE)
+
+    @classmethod
+    def is_allowed_submodule_file(cls, submodule_file_candidate):
+        """
+        Returns true if the given submodule filename looks like a module that should be docuemnted.
+        Modules that are not documented are test files or files in test folders, as well as __init__.py
+        or any hidden files.
+
+        This method can be customized in subclasses if someone disagrees with this selection.
+        """
+        return not cls._UNWANTED_SUBMODULE_FILTER.search(submodule_file_candidate)
+
+    def compute_sources_files(self, recursive=False):
+        """
+        This computes the set of source files referred to.
+        By default, it returns all python files in the sources directory and any of its subdirectories,
+        except those that are not acceptable to .is_allowed_submodule_file().
+
+        This method can be customized in subclasses if someone disagrees with this selection.
+        """
+        # This is all the files in the backbone of the sources subdir, but not recursively,
+        # which we'll use to get a list of actual submodules we might want to autodoc.
+        glob_pattern = os.path.join(self.sources_dir, "*.py")
+        recursive_glob_pattern = os.path.join(self.sources_dir, "**/*.py")
+        all_files = glob.glob(os.path.join(self.sources_dir, glob_pattern))
+        more_files = glob.glob(os.path.join(self.sources_dir, recursive_glob_pattern)) if recursive else []
+        sources_files = [
+            file for file in all_files + more_files
+            if self.is_allowed_submodule_file(file)
+        ]
+        return sources_files
+
+    @classmethod
+    def as_module_name(cls, file, relative_to_prefix=''):
+        """
+        Converts a filename to a module name, relative to a given prefix.
+        >>> DocsChecker.as_module_name('/foo/bar/baz/alpha.py', relative_to_prefix="/foo/bar")
+        baz.alpha
+        """
+        if ':' in file:
+            # Presumably this could occur on Windows. On MacOS & Linux, not a big concern.
+            raise ValueError(f"Don't know how to convert {file} to a module name.")
+        return remove_suffix(".py", remove_prefix(relative_to_prefix, file).lstrip('/').replace('/', '.'))
+
+    def expected_modules(self) -> set:
+        all_modules = {
+            self.as_module_name(file, relative_to_prefix=self.sources_dir)
+            for file in self.sources_files
+            if file.endswith(".py")
+        }
+        return all_modules - self.skip_submodules
+
+    _SECTION_OR_SUBSECTION_LINE = re.compile(r"^([=]+|[-]+)$")
+
+    _SUBSUBSECTION_LINE = re.compile(r"^[\^]+$")
+
+    _AUTOMODULE_LINE = re.compile(f"^[.][.][ ]+automodule::[ ]+[A-Za-z][A-Za-z0-9_]*[.](.*)$")
+
+    def check_documentation(self):
+
+        with io.open(self.docs_index_file) as fp:
+
+            line_number = 0
+            current_module = None
+            automodules_seen_in_current_section = 0
+            prev_line = None
+            problems = []
+            expected_modules = self.expected_modules()
+            documented_modules = set()
+            for line in fp:
+                line_number += 1  # We count the first line as line 1
+                line = line.strip()
+                if self._SUBSUBSECTION_LINE.match(line):
+                    if current_module and automodules_seen_in_current_section == 0:
+                        problems.append(f"Line {line_number}:"
+                                        f" Missing automodule declaration for section {current_module}.")
+                    current_module = prev_line
+                    automodules_seen_in_current_section = 0
+                elif self._SECTION_OR_SUBSECTION_LINE.match(line):
+                    current_module = None
+                    automodules_seen_in_current_section = 0
+                else:
+                    matched = self._AUTOMODULE_LINE.match(line)
+                    if matched:
+                        automodule_module = matched.group(1)
+                        if not current_module:
+                            problems.append(f"Line {line_number}: Unexpected automodule declaration"
+                                            f" outside of module section.")
+                        else:
+                            documented_modules.add(automodule_module)
+                            if automodules_seen_in_current_section == 1:
+                                # If fewer than 1 seen, no issue.
+                                # If more than 1 seen, we already warned, so don't duplicate.
+                                # So really only the n == 1 case matters to us.
+                                problems.append(f"Line {line_number}: More than one automodule"
+                                                f" in section {current_module}?")
+                            if automodule_module != current_module:
+                                problems.append(f"Line {line_number}: Unexpected automodule declaration"
+                                                f" for section {current_module}: {automodule_module}.")
+                        automodules_seen_in_current_section += 1
+                prev_line = line
+            undocumented_modules = expected_modules - documented_modules
+            if undocumented_modules:
+                problems.append(there_are(sorted(undocumented_modules), kind="undocumented module", punctuate=True,
+                                          context=f"and {len(documented_modules) or 'none'} documented"))
+            if problems:
+                for n, problem in enumerate(problems, start=1):
+                    PRINT(f"PROBLEM {n}: {problem}")
+                message = there_are(problems, kind="problem", tense='past', show=False,
+                                    context=f"found in the readthedocs declaration file, {self.docs_index_file!r}")
+                raise AssertionError(message)
+
+
+class DebuggingArtifactChecker(StaticChecker):
+
+    _PRINT_PATTERN = "^[^#]*print[(]"
+    _TRACE_PATTERN = "^[^#]*pdb[.]set_trace[(][)]"
+
+    DEBUGGING_PATTERNS = {
+        "call to print": _PRINT_PATTERN,
+        "active use of pdb.set_trace": _TRACE_PATTERN
+    }
+
+    def __init__(self, sources_subdir, root_dir=None, debugging_patterns=None):
+        super().__init__(sources_subdir=sources_subdir, root_dir=root_dir)
+        self.debugging_patterns = debugging_patterns or self.DEBUGGING_PATTERNS
+
+    def check_for_debugging_patterns(self):
+        confirm_no_uses(where=os.path.join(self.sources_dir, "*.py"), patterns=self.debugging_patterns)

--- a/dcicutils/qa_checkers.py
+++ b/dcicutils/qa_checkers.py
@@ -14,7 +14,7 @@ from .misc_utils import PRINT, remove_prefix, remove_suffix, getattr_customized,
 QA_EXCEPTION_PATTERN = re.compile(r"[#].*\b[N][O][Q][A]\b", re.IGNORECASE)
 
 
-def find_uses(*, where, patterns, recursive=True):
+def find_uses(*, where, patterns, skip=None, recursive=True):
     """
     In the files specified by where (a glob pattern), finds uses of pattern (a regular expression).
 
@@ -29,6 +29,8 @@ def find_uses(*, where, patterns, recursive=True):
     uses = defaultdict(lambda: [])
     files = glob.glob(where, recursive=recursive)
     for file in files:
+        if skip and skip in file:
+            continue
         with io.open(file, 'r') as fp:
             line_number = 0
             for line in fp:
@@ -42,7 +44,7 @@ def find_uses(*, where, patterns, recursive=True):
     return uses
 
 
-def confirm_no_uses(*, where, patterns, recursive=True):
+def confirm_no_uses(*, where, patterns, skip=None, recursive=True):
     """
     In the files specified by where (a glob pattern), finds uses of pattern (a regular expression).
 
@@ -58,7 +60,7 @@ def confirm_no_uses(*, where, patterns, recursive=True):
             categories[problem['summary']] += 1
         return conjoined_list([n_of(count, category) for category, count in categories.items()])
 
-    uses = find_uses(patterns=patterns, where=where, recursive=recursive)
+    uses = find_uses(patterns=patterns, where=where, skip=skip, recursive=recursive)
     if uses:
         detail = ""
         n = 0
@@ -197,6 +199,23 @@ class StaticChecker:
         self.sources_dir = os.path.abspath(os.path.join(self.root_dir, sources_subdir))
         super().__init__()
 
+    @classmethod
+    def compute_sources_files(cls, *, where, recursive, base_only: Optional[bool] = None) -> List[str]:
+        """
+        This computes the set of source files referred to.
+        By default, it returns all python files in the sources directory and any of its subdirectories,
+        except those that are not acceptable to .is_allowed_submodule_file().
+
+        This method can be customized in subclasses if someone disagrees with this selection.
+        """
+        base_only = not recursive if base_only is None else base_only
+        # This is all the files in the backbone of the sources subdir, but not recursively,
+        # which we'll use to get a list of actual submodules we might want to autodoc.
+        all_files_raw = glob.glob(os.path.join(where, "**/*.py" if recursive else "*.py"), recursive=recursive)
+        all_files = [os.path.basename(file) if base_only else file
+                     for file in all_files_raw]
+        return all_files
+
 
 class DocsChecker(StaticChecker):
 
@@ -206,7 +225,8 @@ class DocsChecker(StaticChecker):
 
     def __init__(self, *, sources_subdir, docs_index_file,
                  root_dir: Optional[str] = None, docs_subdir: Optional[str] = None,
-                 module_name: Optional[str] = None, skip_submodules: List[str] = None, recursive: bool = True):
+                 module_name: Optional[str] = None, skip_submodules: List[str] = None, recursive: bool = True,
+                 show_detail: bool = True):
         """
         A DocChecker is potentially capable of various kinds of checks of a repository's documentation.
 
@@ -232,14 +252,14 @@ class DocsChecker(StaticChecker):
         """
 
         super().__init__(sources_subdir=sources_subdir, root_dir=root_dir)
-        self.sources_subdir = sources_subdir
         self.module_name = module_name or sources_subdir.split('.')[-1]
         self.docs_dir = os.path.join(self.root_dir, docs_subdir or self.DOCS_SUBDIR)
         self.docs_index_file = os.path.join(self.docs_dir, docs_index_file)
         self.skip_submodules = set(skip_submodules or self.SKIP_SUBMODULES)
         self.sources_files = self.compute_sources_files(where=sources_subdir, recursive=recursive)
+        self.show_detail = show_detail
 
-    _UNWANTED_SUBMODULE_FILTER = re.compile("(tests?/|(^|/)test_|(^|/)[^a-z])", re.IGNORECASE)
+    _UNWANTED_SUBMODULE_FILTER = re.compile("(tests?/|/test_|^test_|/[^a-z]|^[^a-z/])", re.IGNORECASE)
 
     @classmethod
     def is_allowed_submodule_file(cls, submodule_file_candidate):
@@ -252,7 +272,8 @@ class DocsChecker(StaticChecker):
         """
         return not cls._UNWANTED_SUBMODULE_FILTER.search(submodule_file_candidate)
 
-    def compute_sources_files(self, *, where, recursive):
+    @classmethod
+    def compute_sources_files(cls, *, where, recursive, base_only: Optional[bool] = None):
         """
         This computes the set of source files referred to.
         By default, it returns all python files in the sources directory and any of its subdirectories,
@@ -260,16 +281,9 @@ class DocsChecker(StaticChecker):
 
         This method can be customized in subclasses if someone disagrees with this selection.
         """
-        # This is all the files in the backbone of the sources subdir, but not recursively,
-        # which we'll use to get a list of actual submodules we might want to autodoc.
-        all_files_raw = glob.glob(os.path.join(where, "**/*.py" if recursive else "*.py"), recursive=recursive)
-        all_files = [file if recursive else remove_prefix(where, file).lstrip('/')
-                     for file in all_files_raw]
-        sources_files = [
-            file for file in all_files
-            if self.is_allowed_submodule_file(file)
-        ]
-        return sources_files
+        return [file
+                for file in super().compute_sources_files(where=where, recursive=recursive, base_only=base_only)
+                if cls.is_allowed_submodule_file(file)]
 
     @classmethod
     def as_module_name(cls, file, relative_to_prefix=''):
@@ -298,6 +312,8 @@ class DocsChecker(StaticChecker):
     _AUTOMODULE_LINE = re.compile(f"^[.][.][ ]+automodule::[ ]+[A-Za-z][A-Za-z0-9_]*[.](.*)$")
 
     def check_documentation(self):
+
+        __tracebackhide__ = True
 
         with io.open(self.docs_index_file) as fp:
 
@@ -347,7 +363,7 @@ class DocsChecker(StaticChecker):
             if problems:
                 for n, problem in enumerate(problems, start=1):
                     PRINT(f"PROBLEM {n}: {problem}")
-                message = there_are(problems, kind="problem", tense='past', show=False,
+                message = there_are(problems, kind="problem", tense='past', show=self.show_detail,
                                     context=f"found in the readthedocs declaration file, {self.docs_index_file!r}")
                 raise AssertionError(message)
 
@@ -362,13 +378,25 @@ class DebuggingArtifactChecker(StaticChecker):
         "active use of pdb.set_trace": _TRACE_PATTERN
     }
 
-    def __init__(self, sources_subdir, root_dir=None, debugging_patterns=None, recursive=True):
+    TEST_DEBUGGING_PATTERNS = {
+        "active use of pdb.set_trace": _TRACE_PATTERN
+    }
+
+    def __init__(self, sources_subdir, root_dir=None, debugging_patterns=None, skip_files=None, recursive=True):
         super().__init__(sources_subdir=sources_subdir, root_dir=root_dir)
-        self.debugging_patterns = debugging_patterns or self.DEBUGGING_PATTERNS
+        self.debugging_patterns = debugging_patterns or (
+            self.TEST_DEBUGGING_PATTERNS
+            if 'test' in sources_subdir
+            else self.DEBUGGING_PATTERNS)
+        self.skip_files = skip_files
         self.recursive = recursive
+        self.sources_pattern = os.path.join(self.sources_dir, '**/*.py' if recursive else '*.py')
 
-    def check_for_debugging_patterns(self, recursive=None):
-        confirm_no_uses(where=os.path.join(self.sources_dir, "**/*.py" if self.recursive else "*.py"),
+    def check_for_debugging_patterns(self):
+
+        __tracebackhide__ = True
+
+        confirm_no_uses(where=self.sources_pattern,
                         patterns=self.debugging_patterns,
+                        skip=self.skip_files,
                         recursive=self.recursive)
-

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -1943,7 +1943,7 @@ class MockBotoS3Client:
                  storage_class=None, boto3=None):
         self.boto3 = boto3 or MockBoto3()
         if region_name not in (None, 'us-east-1'):
-            raise ValueError("Unexpected region:", region_name)
+            raise ValueError(f"Unexpected region: {region_name}")
 
         files_cache_marker = '_s3_file_data'
         shared_reality = self.boto3.shared_reality
@@ -2298,7 +2298,7 @@ class MockBotoSQSClient(MockBoto3Client):
 
     def __init__(self, *, region_name=None, boto3=None):
         if region_name not in (None, 'us-east-1'):
-            raise RuntimeError("Unexpected region:", region_name)
+            raise ValueError(f"Unexpected region: {region_name}")
         self._mock_queue_name_seen = None
         self.boto3 = boto3 or MockBoto3()
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -397,7 +397,7 @@ class MockFileWriter:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         content = self.stream.getvalue()
-        if FILE_SYSTEM_VERBOSE:
+        if FILE_SYSTEM_VERBOSE:  # noQA This is just debugging stuff. No need to test it.
             PRINT("Writing %r to %s." % (content, self.file))
         self.file_system.files[self.file] = content if isinstance(content, bytes) else content.encode(self.encoding)
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -397,7 +397,7 @@ class MockFileWriter:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         content = self.stream.getvalue()
-        if FILE_SYSTEM_VERBOSE:  # noQA This is just debugging stuff. No need to test it.
+        if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
             PRINT("Writing %r to %s." % (content, self.file))
         self.file_system.files[self.file] = content if isinstance(content, bytes) else content.encode(self.encoding)
 
@@ -442,7 +442,7 @@ class MockFileSystem:
             raise FileNotFoundError("No such file or directory: %s" % file)
 
     def open(self, file, mode='r', encoding=None):
-        if FILE_SYSTEM_VERBOSE:
+        if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
             PRINT("Opening %r in mode %r." % (file, mode))
         if mode in ('w', 'wt', 'w+', 'w+t', 'wt+'):
             return self._open_for_write(file_system=self, file=file, binary=False, encoding=encoding)
@@ -460,7 +460,7 @@ class MockFileSystem:
         content = self.files.get(file)
         if content is None:
             raise FileNotFoundError("No such file or directory: %s" % file)
-        if FILE_SYSTEM_VERBOSE:
+        if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
             PRINT("Read %r from %s." % (content, file))
         return io.BytesIO(content) if binary else io.StringIO(content.decode(encoding or self.default_encoding))
 

--- a/docs/source/dcicutils.rst
+++ b/docs/source/dcicutils.rst
@@ -191,6 +191,13 @@ obfuscation_utils
    :members:
 
 
+qa_checkers
+^^^^^^^^^^^
+
+.. automodule:: dcicutils.qa_checkers
+   :members:
+
+
 qa_utils
 ^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.1.0"
+version = "5.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.0"
+version = "5.1.0.2b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "file_operation: a test that utilizes files",
   "beanstalk_failure: an obsolete beanstalk-related test that needs fixing",
   "direct_es_query: a test of direct ES _search that is disabled for now and needs to move inside the firewall",
+  "static: mark as a test that is testing the static form of code, not its runtime functionality",
   "stg_or_prd_testing_needs_repair: some or all of a test that was failing on stg/prd has been temporarily disabled",
   "recordable: uses recording technology so that if RECORDING_ENABLED=TRUE, a new test recording is made",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.1.0.2b0"
+version = "5.1.0.2b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.1.0.2b1"
+version = "5.1.0.2b2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.1.0.2b2"
+version = "5.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,12 +4,8 @@ import requests
 
 from dcicutils.common import LEGACY_GLOBAL_ENV_BUCKET
 from dcicutils.env_utils import LegacyController, EnvUtils
-from dcicutils.misc_utils import environ_bool, PRINT
 from dcicutils.ff_mocks import IntegratedFixture
 from .conftest_settings import TEST_DIR, INTEGRATED_ENV
-
-
-NO_SERVER_FIXTURES = environ_bool("NO_SERVER_FIXTURES")
 
 
 def _portal_health_get(namespace, portal_url, key):
@@ -109,8 +105,3 @@ def integrated_s3_info(integrated_names):
         'zip_filename': integrated_names['zip_filename'],
         'zip_filename2': integrated_names['zip_filename2'],
     }
-
-
-if NO_SERVER_FIXTURES:
-    PRINT(f"EnvUtils using sample configuration template.")
-    EnvUtils.set_declared_data(data=EnvUtils.SAMPLE_TEMPLATE_FOR_CGAP_TESTING)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,8 +4,12 @@ import requests
 
 from dcicutils.common import LEGACY_GLOBAL_ENV_BUCKET
 from dcicutils.env_utils import LegacyController, EnvUtils
+from dcicutils.misc_utils import environ_bool, PRINT
 from dcicutils.ff_mocks import IntegratedFixture
 from .conftest_settings import TEST_DIR, INTEGRATED_ENV
+
+
+NO_SERVER_FIXTURES = environ_bool("NO_SERVER_FIXTURES")
 
 
 def _portal_health_get(namespace, portal_url, key):
@@ -105,3 +109,8 @@ def integrated_s3_info(integrated_names):
         'zip_filename': integrated_names['zip_filename'],
         'zip_filename2': integrated_names['zip_filename2'],
     }
+
+
+if NO_SERVER_FIXTURES:
+    PRINT(f"EnvUtils using sample configuration template.")
+    EnvUtils.set_declared_data(data=EnvUtils.SAMPLE_TEMPLATE_FOR_CGAP_TESTING)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,7 @@ LegacyController.LEGACY_DISPATCH_ENABLED = True
 os.environ['GLOBAL_ENV_BUCKET'] = LEGACY_GLOBAL_ENV_BUCKET
 os.environ['ENV_NAME'] = INTEGRATED_ENV
 
-EnvUtils.init(force=True)  # This would be a good time to force EnvUtils to synchronize with the real environment
+EnvUtils.init()  # This would be a good time to get EnvUtils to synchronize with an environment if it hasn't
 
 
 @pytest.fixture(scope='session')

--- a/test/conftest_settings.py
+++ b/test/conftest_settings.py
@@ -9,3 +9,5 @@ INTEGRATED_ENV = IntegratedFixture.ENV_NAME
 INTEGRATED_ENV_INDEX_NAMESPACE = IntegratedFixture.ENV_INDEX_NAMESPACE
 INTEGRATED_ENV_PORTAL_URL = IntegratedFixture.ENV_PORTAL_URL
 INTEGRATED_ES = IntegratedFixture.ES_URL
+
+REPOSITORY_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -4,6 +4,7 @@ import json
 import os
 import pytest
 
+from dcicutils.env_base import LegacyController
 from dcicutils.common import APP_CGAP, APP_FOURFRONT  # , LEGACY_GLOBAL_ENV_BUCKET
 from dcicutils.env_manager import EnvManager
 from dcicutils.env_utils import (
@@ -17,12 +18,14 @@ from dcicutils.env_utils import (
     # make_env_name_cfn_compatible,
     get_foursight_bucket, get_foursight_bucket_prefix, ecr_repository_for_env,
     # New support
-    EnvUtils, p, c, get_env_real_url
+    EnvUtils, p, c, get_env_real_url,
+    _make_no_legacy,  # noQA - yes, protected, but we want to test it
+    if_orchestrated, UseLegacy,
 )
-from dcicutils.env_utils_legacy import FF_PRODUCTION_ECR_REPOSITORY
+from dcicutils.env_utils_legacy import FF_PRODUCTION_ECR_REPOSITORY, blue_green_mirror_env
 from dcicutils.exceptions import (
     BeanstalkOperationNotImplemented,  # MissingFoursightBucketTable, IncompleteFoursightBucketTable,
-    EnvUtilsLoadError,
+    EnvUtilsLoadError, LegacyDispatchDisabled,
 )
 from dcicutils.misc_utils import decorator, local_attrs, ignorable, override_environ
 from dcicutils.qa_utils import raises_regexp
@@ -1774,3 +1777,86 @@ def test_get_config_ecosystem_from_s3():
         expected = ping_ecosystem
         actual = EnvUtils._get_config_ecosystem_from_s3(env_bucket=circular_testing_bucket, config_key='pong.ecosystem')
         assert actual == expected
+
+
+def test_make_no_legacy():
+
+    def foo(a, b, *, c):
+        return [a, b, c]
+
+    foo_prime = _make_no_legacy(foo, 'foo')
+
+    with pytest.raises(NotImplementedError) as exc:
+        foo_prime(3, 4, c=7)
+    assert str(exc.value) == ("There is only an orchestrated version of foo, not a legacy version."
+                              " args=(3, 4) kwargs={'c': 7}")
+
+
+def test_set_declared_data_legacy():
+    with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=False):
+        with pytest.raises(LegacyDispatchDisabled) as exc:
+            EnvUtils.set_declared_data({'is_legacy': True})
+        assert str(exc.value) == ('Attempt to use legacy operation set_declared_data'
+                                  ' with args=None kwargs=None mode=load-env.')
+
+
+def test_if_orchestrated_various_legacy_errors():
+    def foo(x):
+        return ['foo', x]
+    def bar(x):
+        return ['bar', x]
+    def baz(x):
+        if x == 99:
+            raise UseLegacy()
+        return ['baz', x]
+    with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=False):
+        with pytest.raises(LegacyDispatchDisabled) as exc:
+            if_orchestrated(use_legacy=True)(foo)
+        # This error message could be better. The args aren't really involved. But it gets its point across
+        # and anyway it should never happen. We're testing it just for coverage's sake. -kmp 25-Sep-2022
+        assert str(exc.value) == "Attempt to use legacy operation foo with args=None kwargs=None mode=decorate."
+
+    with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=True):
+        foo_prime = if_orchestrated(use_legacy=True)(foo)
+        bar_prime = if_orchestrated(unimplemented=True)(bar)
+        baz_prime = if_orchestrated(assumes_cgap=True)(baz)
+
+        with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=False):
+            with pytest.raises(NotImplementedError) as exc:
+                foo_prime(3)
+            assert str(exc.value) == ("There is only an orchestrated version of foo,"
+                                      " not a legacy version. args=(3,) kwargs={}")
+
+            with pytest.raises(NotImplementedError) as exc:
+                bar_prime(3)
+            assert str(exc.value) == ("Unimplemented: test.test_env_utils_orchestrated.bar")
+
+            with local_attrs(EnvUtils, ORCHESTRATED_APP='cgap'):
+                assert baz_prime(3) == ['baz', 3]
+                with pytest.raises(LegacyDispatchDisabled) as exc:
+                    baz_prime(99)
+                assert str(exc.value) == "Attempt to use legacy operation baz with args=(99,) kwargs={} mode=raised."
+                with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=True):
+                    with pytest.raises(NotImplementedError) as exc:
+                        assert baz_prime(3) == ['baz', 3]
+                        baz_prime(99)  # This will try to use the legacy version, which is enabled but doesn't exist.
+                    assert str(exc.value) == ("There is only an orchestrated version of baz,"
+                                              " not a legacy version. args=(99,) kwargs={}")
+            with local_attrs(EnvUtils, ORCHESTRATED_APP='fourfront'):
+                with pytest.raises(NotImplementedError) as exc:
+                    baz_prime(3)
+                assert 'Non-cgap applications are not supported.' in str(exc.value)
+
+            with pytest.raises(LegacyDispatchDisabled) as exc:
+                if_orchestrated(use_legacy=True)(blue_green_mirror_env)
+            assert str(exc.value) == ("Attempt to use legacy operation blue_green_mirror_env"
+                                      " with args=None kwargs=None mode=decorate.")
+
+        bg = if_orchestrated()(blue_green_mirror_env)
+        with local_attrs(EnvUtils, IS_LEGACY=True):
+            assert bg('acme-green') == 'acme-blue'
+            with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=False):
+                with pytest.raises(LegacyDispatchDisabled) as exc:
+                    assert bg('acme-green') == 'acme-blue'
+                assert str(exc.value) == ("Attempt to use legacy operation blue_green_mirror_env"
+                                          " with args=('acme-green',) kwargs={} mode=dispatch.")

--- a/test/test_env_utils_orchestrated.py
+++ b/test/test_env_utils_orchestrated.py
@@ -22,7 +22,9 @@ from dcicutils.env_utils import (
     _make_no_legacy,  # noQA - yes, protected, but we want to test it
     if_orchestrated, UseLegacy,
 )
-from dcicutils.env_utils_legacy import FF_PRODUCTION_ECR_REPOSITORY, blue_green_mirror_env
+from dcicutils.env_utils_legacy import (
+    FF_PRODUCTION_ECR_REPOSITORY, blue_green_mirror_env as legacy_blue_green_mirror_env
+)
 from dcicutils.exceptions import (
     BeanstalkOperationNotImplemented,  # MissingFoursightBucketTable, IncompleteFoursightBucketTable,
     EnvUtilsLoadError, LegacyDispatchDisabled,
@@ -1801,14 +1803,18 @@ def test_set_declared_data_legacy():
 
 
 def test_if_orchestrated_various_legacy_errors():
+
     def foo(x):
         return ['foo', x]
+
     def bar(x):
         return ['bar', x]
+
     def baz(x):
         if x == 99:
             raise UseLegacy()
         return ['baz', x]
+
     with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=False):
         with pytest.raises(LegacyDispatchDisabled) as exc:
             if_orchestrated(use_legacy=True)(foo)
@@ -1829,7 +1835,7 @@ def test_if_orchestrated_various_legacy_errors():
 
             with pytest.raises(NotImplementedError) as exc:
                 bar_prime(3)
-            assert str(exc.value) == ("Unimplemented: test.test_env_utils_orchestrated.bar")
+            assert str(exc.value) == "Unimplemented: test.test_env_utils_orchestrated.bar"
 
             with local_attrs(EnvUtils, ORCHESTRATED_APP='cgap'):
                 assert baz_prime(3) == ['baz', 3]
@@ -1848,11 +1854,11 @@ def test_if_orchestrated_various_legacy_errors():
                 assert 'Non-cgap applications are not supported.' in str(exc.value)
 
             with pytest.raises(LegacyDispatchDisabled) as exc:
-                if_orchestrated(use_legacy=True)(blue_green_mirror_env)
+                if_orchestrated(use_legacy=True)(legacy_blue_green_mirror_env)
             assert str(exc.value) == ("Attempt to use legacy operation blue_green_mirror_env"
                                       " with args=None kwargs=None mode=decorate.")
 
-        bg = if_orchestrated()(blue_green_mirror_env)
+        bg = if_orchestrated()(legacy_blue_green_mirror_env)
         with local_attrs(EnvUtils, IS_LEGACY=True):
             assert bg('acme-green') == 'acme-blue'
             with local_attrs(LegacyController, LEGACY_DISPATCH_ENABLED=False):

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -1,9 +1,6 @@
 from dcicutils import ff_mocks as ff_mocks_module
 from dcicutils.ff_mocks import AbstractIntegratedFixture
-from dcicutils.misc_utils import override_environ
 from unittest import mock
-
-
 
 
 def test_abstract_integrated_fixture_no_server_fixtures():

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -1,0 +1,13 @@
+from dcicutils import ff_mocks as ff_mocks_module
+from dcicutils.ff_mocks import AbstractIntegratedFixture
+from dcicutils.misc_utils import override_environ
+from unittest import mock
+
+
+
+
+def test_abstract_integrated_fixture_no_server_fixtures():
+
+    with mock.patch.object(ff_mocks_module, "NO_SERVER_FIXTURES"):  # too late to set env variable, but this'll do.
+        assert AbstractIntegratedFixture.initialize_class() == 'NO_SERVER_FIXTURES'
+        assert AbstractIntegratedFixture.verify_portal_access('not-a-dictionary') == 'NO_SERVER_FIXTURES'

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -22,7 +22,7 @@ def test_utils_debugging_artifacts():
     checker = DebuggingArtifactChecker(sources_subdir="dcicutils")
     checker.check_for_debugging_patterns()
 
-    checker = DebuggingArtifactChecker(sources_subdir="test", skip_files="data_files/")
+    checker = DebuggingArtifactChecker(sources_subdir="test", skip_files="data_files/", filter_patterns=['pdb'])
     checker.check_for_debugging_patterns()
 
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,95 +1,19 @@
-import glob
-import io
-import os
-import re
+import pytest
 
-from dcicutils.common import LIBRARY_DIR
-from dcicutils.misc_utils import PRINT, remove_suffix
-from dcicutils.lang_utils import there_are
-from dcicutils.qa_utils import confirm_no_uses
+from dcicutils.qa_checkers import DocsChecker, DebuggingArtifactChecker
 
 
-_MY_DIR = os.path.dirname(__file__)
-
-_ROOT_DIR = os.path.dirname(_MY_DIR)
-
-_DCICUTILS_DIR = os.path.join(_ROOT_DIR, "dcicutils")
-
-_DCICUTILS_DOC_FILE = os.path.join(_ROOT_DIR, "docs/source/dcicutils.rst")
-
-_DCICUTILS_FILES = glob.glob(os.path.join(_DCICUTILS_DIR, "*.py"))
-
-_SECTION_OR_SUBSECTION_LINE = re.compile(r"^([=]+|[-]+)$")
-
-_SUBSUBSECTION_LINE = re.compile(r"^[\^]+$")
-
-_AUTOMODULE_LINE = re.compile(r"^[.][.][ ]+automodule::[ ]+dcicutils[.](.*)$")
+class UtilsDocsChecker(DocsChecker):
+    SKIP_SUBMODULES = ['jh_utils', 'env_utils_legacy']
 
 
-SKIP_MODULES = {'jh_utils', 'env_utils_legacy', '__init__'}
+@pytest.mark.static
+def test_utils_doc():
+    checker = UtilsDocsChecker(sources_subdir="dcicutils", docs_index_file="dcicutils.rst")
+    checker.check_documentation()
 
 
-def test_documentation():
-
-    with io.open(_DCICUTILS_DOC_FILE) as fp:
-
-        line_number = 0
-        current_module = None
-        automodules_seen = 0
-        prev_line = None
-        problems = []
-        expected_modules = {remove_suffix(".py", os.path.basename(file)) for file in _DCICUTILS_FILES} - SKIP_MODULES
-        documented_modules = set()
-        for line in fp:
-            line_number += 1  # We count the first line as line 1
-            line = line.strip()
-            if _SUBSUBSECTION_LINE.match(line):
-                if current_module and automodules_seen == 0:
-                    problems.append(f"Line {line_number}: Missing automodule declaration for section {current_module}.")
-                current_module = prev_line
-                automodules_seen = 0
-            elif _SECTION_OR_SUBSECTION_LINE.match(line):
-                current_module = None
-                automodules_seen = 0
-            else:
-                matched = _AUTOMODULE_LINE.match(line)
-                if matched:
-                    automodule_module = matched.group(1)
-                    if not current_module:
-                        problems.append(f"Line {line_number}: Unexpected automodule declaration"
-                                        f" outside of module section.")
-                    else:
-                        documented_modules.add(automodule_module)
-                        if automodules_seen == 1:
-                            # If fewer than 1 seen, no issue.
-                            # If more than 1 seen, we already warned, so don't duplicate.
-                            # So really only the n == 1 case matters to us.
-                            problems.append(f"Line {line_number}: More than one automodule"
-                                            f" in section {current_module}?")
-                        if automodule_module != current_module:
-                            problems.append(f"Line {line_number}: Unexpected automodule declaration"
-                                            f" for section {current_module}: {automodule_module}.")
-                    automodules_seen += 1
-            prev_line = line
-        undocumented_modules = expected_modules - documented_modules
-        if undocumented_modules:
-            problems.append(there_are(sorted(undocumented_modules), kind="undocumented module", punctuate=True))
-        if problems:
-            for n, problem in enumerate(problems, start=1):
-                PRINT(f"PROBLEM {n}: {problem}")
-            message = there_are(problems, kind="problem", tense='past', show=False,
-                                context=f"found in the readthedocs declaration file, {_DCICUTILS_DOC_FILE!r}")
-            raise AssertionError(message)
-
-
-PRINT_PATTERN = "^[^#]*print[(]"
-TRACE_PATTERN = "^[^#]*pdb[.]set_trace[(][)]"
-
-DEBUGGING_PATTERNS = {
-    "call to print": PRINT_PATTERN,
-    "active use of pdb.set_trace": TRACE_PATTERN
-}
-
-
-def test_for_debugging_print():
-    confirm_no_uses(where=os.path.join(LIBRARY_DIR, "*.py"), patterns=DEBUGGING_PATTERNS)
+@pytest.mark.static
+def test_utils_debugging_artifacts():
+    checker = DebuggingArtifactChecker(sources_subdir="dcicutils")
+    checker.check_for_debugging_patterns()

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,15 +1,16 @@
+import os
 import pytest
 
-from dcicutils.qa_checkers import DocsChecker, DebuggingArtifactChecker
-
-
-class UtilsDocsChecker(DocsChecker):
-    SKIP_SUBMODULES = ['jh_utils', 'env_utils_legacy']
+from dcicutils.qa_checkers import DocsChecker, DebuggingArtifactChecker, ChangeLogChecker
 
 
 @pytest.mark.static
 def test_utils_doc():
-    checker = UtilsDocsChecker(sources_subdir="dcicutils", docs_index_file="dcicutils.rst")
+
+    class UtilsDocsChecker(DocsChecker):
+        SKIP_SUBMODULES = ['jh_utils', 'env_utils_legacy']
+
+    checker = UtilsDocsChecker(sources_subdir="dcicutils", docs_index_file="dcicutils.rst", recursive=False)
     checker.check_documentation()
 
 
@@ -17,3 +18,17 @@ def test_utils_doc():
 def test_utils_debugging_artifacts():
     checker = DebuggingArtifactChecker(sources_subdir="dcicutils")
     checker.check_for_debugging_patterns()
+
+
+@pytest.mark.static
+def test_changelog_consistency():
+
+    class MyChangeLogChecker(ChangeLogChecker):
+        PYPROJECT = os.path.join(os.path.dirname(__file__), "../pyproject.toml")
+        CHANGELOG = os.path.join(os.path.dirname(__file__), "../CHANGELOG.rst")
+
+    MyChangeLogChecker.check_version()
+
+
+def test_foo_bar():
+    import pdb; pdb.set_trace()

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -4,13 +4,17 @@ import pytest
 from dcicutils.qa_checkers import DocsChecker, DebuggingArtifactChecker, ChangeLogChecker
 
 
+_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
 @pytest.mark.static
 def test_utils_doc():
 
     class UtilsDocsChecker(DocsChecker):
         SKIP_SUBMODULES = ['jh_utils', 'env_utils_legacy']
 
-    checker = UtilsDocsChecker(sources_subdir="dcicutils", docs_index_file="dcicutils.rst", recursive=False)
+    checker = UtilsDocsChecker(sources_subdir="dcicutils", docs_index_file="dcicutils.rst", recursive=False,
+                               show_detail=False)
     checker.check_documentation()
 
 
@@ -19,16 +23,15 @@ def test_utils_debugging_artifacts():
     checker = DebuggingArtifactChecker(sources_subdir="dcicutils")
     checker.check_for_debugging_patterns()
 
+    checker = DebuggingArtifactChecker(sources_subdir="test", skip_files="data_files/")
+    checker.check_for_debugging_patterns()
+
 
 @pytest.mark.static
 def test_changelog_consistency():
 
     class MyChangeLogChecker(ChangeLogChecker):
-        PYPROJECT = os.path.join(os.path.dirname(__file__), "../pyproject.toml")
-        CHANGELOG = os.path.join(os.path.dirname(__file__), "../CHANGELOG.rst")
+        PYPROJECT = os.path.join(_ROOT_DIR, "pyproject.toml")
+        CHANGELOG = os.path.join(_ROOT_DIR, "CHANGELOG.rst")
 
     MyChangeLogChecker.check_version()
-
-
-def test_foo_bar():
-    import pdb; pdb.set_trace()

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -3,8 +3,7 @@ import pytest
 
 from dcicutils.qa_checkers import DocsChecker, DebuggingArtifactChecker, ChangeLogChecker
 
-
-_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+from .conftest_settings import REPOSITORY_ROOT_DIR
 
 
 @pytest.mark.static
@@ -31,7 +30,7 @@ def test_utils_debugging_artifacts():
 def test_changelog_consistency():
 
     class MyChangeLogChecker(ChangeLogChecker):
-        PYPROJECT = os.path.join(_ROOT_DIR, "pyproject.toml")
-        CHANGELOG = os.path.join(_ROOT_DIR, "CHANGELOG.rst")
+        PYPROJECT = os.path.join(REPOSITORY_ROOT_DIR, "pyproject.toml")
+        CHANGELOG = os.path.join(REPOSITORY_ROOT_DIR, "CHANGELOG.rst")
 
     MyChangeLogChecker.check_version()

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -25,7 +25,7 @@ from dcicutils.misc_utils import (
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
     capitalize1, local_attrs, dict_zip, json_leaf_subst, print_error_message, get_error_message,
     _is_function_of_exactly_one_required_arg,  # noQA
-    string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists,
+    string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists, lines_printed_to,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output, raises_regexp
@@ -2689,3 +2689,15 @@ def test_merge_key_value_dict_lists():
     actual = merge_key_value_dict_lists(old, new)
     expected = [{'Key': 'a', 'Value': '7'}, {'Key': 'b', 'Value': '3'}, {'Key': 'd', 'Value': '4'}]
     assert actual == expected
+
+
+def test_lines_printed_to():
+    mfs = MockFileSystem()
+
+    with mfs.mock_exists_open_remove():
+        with lines_printed_to("foo.text") as out:
+
+            out("This is line 1.")
+            out("This is line 2.")
+
+        assert file_contents("foo.text") == "This is line 1.\nThis is line 2.\n"

--- a/test/test_qa_checkers.py
+++ b/test/test_qa_checkers.py
@@ -1,0 +1,259 @@
+import io
+import os
+import pytest
+
+from dcicutils.misc_utils import lines_printed_to, remove_prefix
+from dcicutils.qa_checkers import (
+    DebuggingArtifactChecker, DocsChecker, ChangeLogChecker, VersionChecker, confirm_no_uses, find_uses,
+)
+from dcicutils.qa_utils import MockFileSystem, printed_output
+from unittest import mock
+from .conftest_settings import TEST_DIR
+
+
+PRINT_PATTERN = "^[^#]*print[(]"
+TRACE_PATTERN = "^[^#]*pdb[.]set_trace[(][)]"
+
+DEBUGGING_PATTERNS = {
+    "call to print": PRINT_PATTERN,
+    "active use of pdb.set_trace": TRACE_PATTERN
+}
+
+
+def test_change_log_checker():
+
+    mfs = MockFileSystem()
+
+    with mfs.mock_exists_open_remove():
+
+        with lines_printed_to("badpyproject.toml") as out:
+            out('[tool.poetry]')
+            out('name = "Sample"')
+            # Missing version = ...
+            out('other = "whatever"')
+
+        class BadVersionChecker(VersionChecker):
+            PYPROJECT = "badpyproject.toml"
+            CHANGELOG = None
+
+        with pytest.raises(AssertionError) as exc:
+            BadVersionChecker().check_version()
+        assert str(exc.value) == "Missing version in badpyproject.toml."
+
+        with lines_printed_to("pyproject.toml") as out:
+            out('[tool.poetry]')
+            out('name = "Sample"')
+            out('version = "1.0.2"')
+            out('other = "whatever"')
+
+        class SimpleProjectChecker(VersionChecker):
+            PYPROJECT = "pyproject.toml"
+            CHANGELOG = None
+
+        SimpleProjectChecker.check_version()
+
+        with lines_printed_to("goodchangelog.rst") as out:
+            out("1.0.2")
+            out("=====")
+            out()
+            out("Another small patch to version one.")
+            out()
+            out("1.0.1")
+            out("=====")
+            out()
+            out("Small patch to version one.")
+            out()
+            out("1.0.0")
+            out("=====")
+            out()
+            out("First big release.")
+            out()
+
+        class GoodChangeLogChecker(ChangeLogChecker):
+            PYPROJECT = "pyproject.toml"
+            CHANGELOG = "goodchangelog.rst"
+
+        GoodChangeLogChecker().check_version()
+
+        with lines_printed_to("goodchangelog.md") as out:
+            out("# 1.0.2")
+            out()
+            out("Another small patch to version one.")
+            out()
+            out("# 1.0.1")
+            out()
+            out("Small patch to version one.")
+            out()
+            out("# 1.0.0")
+            out()
+            out("First big release.")
+            out()
+
+        class GoodMdChangeLogChecker(ChangeLogChecker):
+            PYPROJECT = "pyproject.toml"
+            CHANGELOG = "goodchangelog.md"
+
+        GoodMdChangeLogChecker().check_version()
+
+        with lines_printed_to("badchangelog.rst") as out:
+            out("2.0.1")
+            out("=====")
+            out()
+            out("Small patch to version two.")
+            out()
+            out("2.0.0")
+            out("=====")
+            out()
+            out("Second big release.")
+            out()
+
+        class BadChangeLogChecker(ChangeLogChecker):
+            PYPROJECT = "pyproject.toml"
+            CHANGELOG = "badchangelog.rst"
+
+        with pytest.raises(AssertionError) as exc:
+            BadChangeLogChecker().check_version()
+        assert str(exc.value) == "Missing entry for version 1.0.2 in badchangelog.rst."
+
+        with lines_printed_to("goodreversedchangelog.rst") as out:
+            out("1.0.0")
+            out("=====")
+            out()
+            out("First big release.")
+            out()
+            out("1.0.1")
+            out("=====")
+            out()
+            out("Small patch to version one.")
+            out()
+            out("1.0.2")
+            out("=====")
+            out()
+            out("Another small patch to version one.")
+            out()
+
+        class GoodReversedChangeLogChecker(ChangeLogChecker):
+            PYPROJECT = "pyproject.toml"
+            CHANGELOG = "goodreversedchangelog.rst"
+
+        GoodReversedChangeLogChecker().check_version()
+
+
+def test_as_module_name():
+
+    assert DocsChecker.as_module_name('/foo/bar/baz/alpha.py', relative_to_prefix="/foo/bar") == 'baz.alpha'
+    assert DocsChecker.as_module_name('/x/y/baz/alpha.py', relative_to_prefix="/foo/bar") == 'x.y.baz.alpha'
+
+
+def test_is_allowed_submodule():
+
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/tests/helpers.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/test/helpers.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/test_files/helpers.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/test_foo.py") is False
+
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/__init__.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/__foo__.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/_foo.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/.foo.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/-foo.py") is False
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/4foo.py") is False
+
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/init.py") is True
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/baz") is True
+    assert DocsChecker.is_allowed_submodule_file("/foo/bar/baz.txt") is True
+
+
+def test_find_uses():
+
+    glob_pattern = os.path.join(TEST_DIR, 'data_files/sample_source_files/*.py')
+    raw = find_uses(where=glob_pattern,
+                    patterns=DEBUGGING_PATTERNS)
+    output = {remove_prefix(TEST_DIR + os.sep, file): problems for file, problems in raw.items()}
+    assert output == {
+        'data_files/sample_source_files/file1.py': [
+            {'line': '    print("first use")',
+             'line_number': 2,
+             'summary': 'call to print'},
+            {'line': '    print("second use")',
+             'line_number': 3,
+             'summary': 'call to print'},
+            {'line': '    print("third use", z)',
+             'line_number': 11,
+             'summary': 'call to print'},
+            {'line': '    import pdb; pdb.set_trace()',
+             'line_number': 12,
+             'summary': 'active use of pdb.set_trace'}
+        ],
+        'data_files/sample_source_files/file2.py': [
+            {'line': '    print("third use", z)',
+             'line_number': 5,
+             'summary': 'call to print'},
+            {'line': '    pdb.set_trace()  # Second tallied use',
+             'line_number': 13,
+             'summary': 'active use of pdb.set_trace'},
+            {'line': '    pdb.set_trace()  # Third tallied use',
+             'line_number': 17,
+             'summary': 'active use of pdb.set_trace'}
+        ]
+    }
+
+
+def test_confirm_no_uses():
+
+    with pytest.raises(AssertionError) as exc_info:
+
+        glob_pattern = os.path.join(TEST_DIR, 'data_files/sample_source_files/*.py')
+        confirm_no_uses(where=glob_pattern,
+                        patterns=DEBUGGING_PATTERNS)
+
+    lines = str(exc_info.value).split('\n')
+    assert len(lines) == 3
+    assert lines[0] == "7 problems detected:"
+
+    prefix = f" In {TEST_DIR}/data_files/sample_source_files/"
+    lines = [remove_prefix(prefix, line) for line in sorted(lines[1:])]
+
+    assert lines[0] == "file1.py, 3 calls to print and 1 active use of pdb.set_trace."
+    assert lines[1] == "file2.py, 1 call to print and 2 active uses of pdb.set_trace."
+
+
+def test_debugging_artifact_checker():
+
+    mfs = MockFileSystem()
+
+    with mfs.mock_exists_open_remove():
+        with mock.patch("glob.glob") as mock_glob:
+            with printed_output() as printed:
+
+                dac = DebuggingArtifactChecker(sources_subdir="foo")
+
+                mock_glob.return_value = []
+                dac.check_for_debugging_patterns()
+
+                with lines_printed_to("foo/bar.py") as out:
+                    out('x = 1')
+                mock_glob.return_value = ["foo/bar.py"]
+                dac.check_for_debugging_patterns()
+
+                assert printed.lines == []
+
+                with lines_printed_to("foo/bar.py") as out:
+                    out('x = 1')
+                    out('print("foo")')
+                with pytest.raises(Exception) as exc:
+                    dac.check_for_debugging_patterns()
+                assert isinstance(exc.value, AssertionError)
+                assert str(exc.value) == "1 problem detected:\n In foo/bar.py, 1 call to print."
+
+                assert printed.lines == []  # We might at some point print the actual problems, but we don't now.
+
+                with lines_printed_to("foo/bar.py") as out:
+                    out('x = 1')
+                    out('import pdb; pdb.set_trace()')
+                with pytest.raises(Exception) as exc:
+                    dac.check_for_debugging_patterns()
+                assert isinstance(exc.value, AssertionError)
+                assert str(exc.value) == "1 problem detected:\n In foo/bar.py, 1 active use of pdb.set_trace."
+
+                assert printed.lines == []  # We might at some point print the actual problems, but we don't now.

--- a/test/test_qa_checkers.py
+++ b/test/test_qa_checkers.py
@@ -151,6 +151,13 @@ def test_is_allowed_submodule():
     assert DocsChecker.is_allowed_submodule_file("/foo/bar/test_files/helpers.py") is False
     assert DocsChecker.is_allowed_submodule_file("/foo/bar/test_foo.py") is False
 
+    assert DocsChecker.is_allowed_submodule_file("__init__.py") is False
+    assert DocsChecker.is_allowed_submodule_file("__foo__.py") is False
+    assert DocsChecker.is_allowed_submodule_file("_foo.py") is False
+    assert DocsChecker.is_allowed_submodule_file(".foo.py") is False
+    assert DocsChecker.is_allowed_submodule_file("-foo.py") is False
+    assert DocsChecker.is_allowed_submodule_file("4foo.py") is False
+
     assert DocsChecker.is_allowed_submodule_file("/foo/bar/__init__.py") is False
     assert DocsChecker.is_allowed_submodule_file("/foo/bar/__foo__.py") is False
     assert DocsChecker.is_allowed_submodule_file("/foo/bar/_foo.py") is False
@@ -180,7 +187,7 @@ def test_find_uses():
             {'line': '    print("third use", z)',
              'line_number': 11,
              'summary': 'call to print'},
-            {'line': '    import pdb; pdb.set_trace()',
+            {'line': '    import pdb; pdb.set_trace()',  # noQA
              'line_number': 12,
              'summary': 'active use of pdb.set_trace'}
         ],
@@ -188,10 +195,10 @@ def test_find_uses():
             {'line': '    print("third use", z)',
              'line_number': 5,
              'summary': 'call to print'},
-            {'line': '    pdb.set_trace()  # Second tallied use',
+            {'line': '    pdb.set_trace()  # Second tallied use',  # noQA
              'line_number': 13,
              'summary': 'active use of pdb.set_trace'},
-            {'line': '    pdb.set_trace()  # Third tallied use',
+            {'line': '    pdb.set_trace()  # Third tallied use',  # noQA
              'line_number': 17,
              'summary': 'active use of pdb.set_trace'}
         ]
@@ -249,7 +256,7 @@ def test_debugging_artifact_checker():
 
                 with lines_printed_to("foo/bar.py") as out:
                     out('x = 1')
-                    out('import pdb; pdb.set_trace()')
+                    out('import pdb; pdb.set_trace()')  # noQA
                 with pytest.raises(Exception) as exc:
                     dac.check_for_debugging_patterns()
                 assert isinstance(exc.value, AssertionError)

--- a/test/test_qa_checkers.py
+++ b/test/test_qa_checkers.py
@@ -1,4 +1,3 @@
-import io
 import os
 import pytest
 

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -239,11 +239,37 @@ def test_controlled_time_creation():
 
 def test_controlled_time_just_now():
 
-    t = ControlledTime()
+    t = ControlledTime(tick_seconds=1)
 
     t0 = t.just_now()
     t1 = t.just_now()
     assert (t1 - t0).total_seconds() == 0
+
+    t0 = t.time()
+    t1 = t.time()  # one second should have passed
+    t2 = t.time()  # one more second should have passed
+
+    assert t1 - t0 == 1
+    assert t2 - t1 == 1
+
+
+def test_just_utcnow():
+
+    t = ControlledTime()
+    t0 = t.utcnow()
+    assert t.just_utcnow() == t0
+
+    assert ControlledTime.ProxyDatetimeClass(t).utcnow() == t0 + datetime.timedelta(seconds=1)
+
+
+def test_controlled_time_time():
+
+    t = ControlledTime()
+
+    t0 = t.time()
+    t1 = t.time()
+
+    assert t1 - t0 == 1
 
 
 def test_controlled_time_now():

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1381,21 +1381,6 @@ def test_version_checker_no_changelog():
     MyChangeLogChecker.check_version()
 
 
-def test_version_checker_use_dcicutils_changelog():
-
-    class MyVersionChecker(VersionChecker):
-        PYPROJECT = os.path.join(os.path.dirname(__file__), "../pyproject.toml")
-        CHANGELOG = os.path.join(os.path.dirname(__file__), "../CHANGELOG.rst")
-
-    MyVersionChecker.check_version()
-
-    class MyChangeLogChecker(ChangeLogChecker):
-        PYPROJECT = os.path.join(os.path.dirname(__file__), "../pyproject.toml")
-        CHANGELOG = os.path.join(os.path.dirname(__file__), "../CHANGELOG.rst")
-
-    MyChangeLogChecker.check_version()
-
-
 def test_version_checker_with_missing_changelog():
 
     mfs = MockFileSystem(files={'pyproject.toml': '[tool.poetry]\nname = "foo"\nversion = "1.2.3"'})

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -15,20 +15,18 @@ import uuid
 
 from dcicutils import qa_utils
 from dcicutils.exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix
-from dcicutils.misc_utils import Retry, PRINT, file_contents, REF_TZ, remove_prefix
+from dcicutils.misc_utils import Retry, PRINT, file_contents, REF_TZ
 from dcicutils.qa_utils import (
     mock_not_called, override_environ, override_dict, show_elapsed_time, timed,
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom, MockUUIDModule, MockedCommandArgs,
     MockResponse, printed_output, MockBotoS3Client, MockKeysNotImplemented, MockBoto3, known_bug_expected,
     raises_regexp, VersionChecker, check_duplicated_items_by_key, guess_local_timezone_for_testing,
-    find_uses, confirm_no_uses, logged_messages, input_mocked, ChangeLogChecker,
+    logged_messages, input_mocked, ChangeLogChecker,
 )
 # The following line needs to be separate from other imports. It is PART OF A TEST.
 from dcicutils.qa_utils import notice_pytest_fixtures   # Use care if editing this line. It is PART OF A TEST.
 from unittest import mock
-from .conftest_settings import TEST_DIR
 from .fixtures.sample_fixtures import MockMathError, MockMath, math_enabled
-from .test_misc import DEBUGGING_PATTERNS
 
 
 notice_pytest_fixtures(math_enabled)   # Use care if editing this line. It is PART OF A TEST.
@@ -1542,60 +1540,6 @@ def test_mocked_command_args():
     assert args.foobar == 'xy'  # noQA - PyCharm can't see we declared this arg
 
 
-def test_find_uses():
-
-    glob_pattern = os.path.join(TEST_DIR, 'data_files/sample_source_files/*.py')
-    raw = find_uses(where=glob_pattern,
-                    patterns=DEBUGGING_PATTERNS)
-    output = {remove_prefix(TEST_DIR + os.sep, file): problems for file, problems in raw.items()}
-    assert output == {
-        'data_files/sample_source_files/file1.py': [
-            {'line': '    print("first use")',
-             'line_number': 2,
-             'summary': 'call to print'},
-            {'line': '    print("second use")',
-             'line_number': 3,
-             'summary': 'call to print'},
-            {'line': '    print("third use", z)',
-             'line_number': 11,
-             'summary': 'call to print'},
-            {'line': '    import pdb; pdb.set_trace()',
-             'line_number': 12,
-             'summary': 'active use of pdb.set_trace'}
-        ],
-        'data_files/sample_source_files/file2.py': [
-            {'line': '    print("third use", z)',
-             'line_number': 5,
-             'summary': 'call to print'},
-            {'line': '    pdb.set_trace()  # Second tallied use',
-             'line_number': 13,
-             'summary': 'active use of pdb.set_trace'},
-            {'line': '    pdb.set_trace()  # Third tallied use',
-             'line_number': 17,
-             'summary': 'active use of pdb.set_trace'}
-        ]
-    }
-
-
-def test_confirm_no_uses():
-
-    with pytest.raises(AssertionError) as exc_info:
-
-        glob_pattern = os.path.join(TEST_DIR, 'data_files/sample_source_files/*.py')
-        confirm_no_uses(where=glob_pattern,
-                        patterns=DEBUGGING_PATTERNS)
-
-    lines = str(exc_info.value).split('\n')
-    assert len(lines) == 3
-    assert lines[0] == "7 problems detected:"
-
-    prefix = f" In {TEST_DIR}/data_files/sample_source_files/"
-    lines = [remove_prefix(prefix, line) for line in sorted(lines[1:])]
-
-    assert lines[0] == "file1.py, 3 calls to print and 1 active use of pdb.set_trace."
-    assert lines[1] == "file2.py, 1 call to print and 2 active uses of pdb.set_trace."
-
-
 MY_MODULE = sys.modules['test.test_qa_utils']
 
 
@@ -1645,13 +1589,13 @@ def test_logged_messages():
             logger.warning("bar")
 
     with logged_messages(warning=["bar"], module=MY_MODULE, logvar='logger', allow_warn=True):
-        logger.warn("bar")
+        logger.warn("bar")  # noQA - yes, code should use .warning() not .warn(), but we're testing a check for that
 
     with pytest.raises(AssertionError):
         with logged_messages(warning=["bar"], module=MY_MODULE, logvar='logger', allow_warn=False):
-            logger.warn("bar")
+            logger.warn("bar")  # noQA - yes, code should use .warning() not .warn(), but we're testing a check for that
 
     with pytest.raises(AssertionError):
         with logged_messages(warning=["bar"], module=MY_MODULE, logvar='logger'):
             # allow_warn defaults to False
-            logger.warn("bar")
+            logger.warn("bar")  # noQA - yes, code should use .warning() not .warn(), but we're testing a check for that


### PR DESCRIPTION
* Some functionality moved from `qa_utils` to `qa_checkers`. In each case, to be compatible, the `qa_utils` module will continue to have the entity availble for import until the next major release.

  * Class `VersionChecker`
  * Class `ChangeLogChecker`
  * Function `confirm_no_uses`
  * Function `find_uses`
  * Variable `QA_EXCEPTION_PATTERN`

  As an official matter, use of these moved entities from by importing them from `dcicutils.qa_utils` is deprecated. Please update programs to import these from `dcicutils.qa_checkers` instead.

* New functionality in `qa_checkers`:

  * New class `DocsChecker`
  * New class `DebuggingArtifactChecker`

* In `misc_utils`:

  * New function `lines_printed_to`.

* New `pytest` marker `static` for static tests.

* New `make` target `test-static` to run tests marked with `@pytest.mark.static`.

* New GithubActions (GA) workflow: `static_checks.yml`

* There are a lot of extra tests added, some that are not relevant to this stuff, because the coverage tool was fussing at me about not getting good coverage.