### PR TITLE
Improved IntegratedFixture and static check cleanups (C4-932)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,30 @@ Change Log
 ----------
 
 
+5.2.1
+=====
+
+`PR 222: Improved IntegratedFixture and static check cleanups <https://github.com/4dn-dcic/utils/pull/222>`_
+
+* Show fewer uninteresting tracebacks on static test failures.
+
+* Small incompatible changes to recently released qa-related items:
+
+  * In ``qa_checkers.confirm_no_uses``, remove the new ``if_used`` argument in favor of a simpler implementation.
+
+  * Slightly rerefactored the class hierarchy so that ``StaticChecker`` is a smaller class that doesn't have quite
+    as much functionality, and ``StaticSourcesChecker`` corresponds to what ``StaticChecker`` previously did.
+
+  Since this is all testing-only, not something used in production, and since there are believed to not yet be uses
+  outside the repo, we're treating this as a bug fix (patch version bump) not an incompatible change (which would
+  entail a major version bump and a lot of fussing for nothing).
+
+* Make class initialization of ``IntegratedFixture`` happen at instance-creation time.
+  That simplifies the loading actions needed. Those can happen in ``conftest.py`` rather than in
+  ``dcicutils.ff_mocks``, which in turn should allow ``dcicutils.ff_mocks`` to be imported without error,
+  fixing `C4-932 <https://hms-dbmi.atlassian.net/browse/C4-932>`_
+
+
 5.2.0
 =====
 
@@ -267,9 +291,11 @@ covering what changed in 4.0, which is considerably more.
   * ``test-for-ga`` is an indirect way to call ``test-units-with-coverage``, and will be what the GithubActions
     workflow calls.
 
-* Configurable environmental support for orchestrated C4 applications (Fourfront and CGAP) in ``env_utils`` (C4-689).
+* Configurable environmental support for orchestrated C4 applications (Fourfront and CGAP) in ``env_utils``
+  (`C4-689 <https://hms-dbmi.atlassian.net/browse/C4-689>`_).
 
-* Extend that support to allow mirroring to be enabled (C4-734).
+* Extend that support to allow mirroring to be enabled
+  (`C4-734 <https://hms-dbmi.atlassian.net/browse/C4-734>`_).
 
 The net result is a configurable environment in which the env descriptor in the global env bucket can contain
 these new items:
@@ -800,14 +826,16 @@ Specifics:
 
 * Removes support for previously-deprecated variable ``GOLDEN_DB`` which only ``torb`` was still using.
   ``_FF_GOLDEN_DB`` could be used as a direct replacement in an emergency,
-  but only for legacy environments. This is not a good solution for orchestrated environments (C4-689).
+  but only for legacy environments. This is not a good solution for orchestrated environments
+  (`C4-689 <https://hms-dbmi.atlassian.net/browse/C4-689>`_).
 
 * The variables ``FF_MAGIC_CNAME``, ``CGAP_MAGIC_CNAME``, ``FF_GOLDEN_DB``, and ``CGAP_GOLDEN_DB``,
   which had no uses outside of ``dcicutils`` itself,
   now have underscores ahead of their names to emphasize that they are internal to ``dcicutils`` only.
   ``_FF_MAGIC_CNAME``, ``_CGAP_MAGIC_CNAME``, ``_FF_GOLDEN_DB``, and ``_CGAP_GOLDEN_DB``, respectively,
   could be used as a direct replacement in an emergency,
-  but only for legacy environments. This is not a good solution for orchestrated environments (C4-689).
+  but only for legacy environments. This is not a good solution for orchestrated environments
+  (`C4-689 <https://hms-dbmi.atlassian.net/browse/C4-689>`_).
 
 * The function name ``use_input`` has been renamed ``prompt_for_input`` and the preferred place to
   import it from is now ``misc_utils``, not ``beanstalk_utils``. (This is just a synonym for the
@@ -868,8 +896,8 @@ Specifics:
 2.3.1
 =====
 
-* In ``s3_utils``, fix C4-706, where short names of environments were not accepted
-  as env arguments to s3Utils in legacy CGAP.
+* In ``s3_utils``, fix `C4-706 <https://hms-dbmi.atlassian.net/browse/C4-706>`_,
+  where short names of environments were not accepted as env arguments to s3Utils in legacy CGAP.
 
 
 2.3.0
@@ -1028,7 +1056,7 @@ Specifics:
 2.0.0
 =====
 
-**PR 150: Add json_leaf_subst, conjoined_list and disjoined_list**
+`PR 150: Add json_leaf_subst, conjoined_list and disjoined_list <https://github.com/4dn-dcic/utils/pull/150>`_
 
 We do not believe this is an incompatible major version, but there is a lot here, an hence some opportunity for
 difference in behavior to have crept in. As such, we opted to call this a new major version to highlight where
@@ -1127,7 +1155,7 @@ that big change happened.
 1.20.0
 ======
 
-**PR 148: Support auth0 client and secret in deployment_utils**
+`PR 148: Support auth0 client and secret in deployment_utils <https://github.com/4dn-dcic/utils/pull/148>`_
 
 * In ``deployment_utils``, add support for managing auth0 client and secret:
 
@@ -1146,8 +1174,8 @@ that big change happened.
 1.19.0
 ======
 
-**PR 147: Init s3Utils via GLOBAL_ENV_BUCKET and misc S3_BUCKET_ORG support (C4-554)**
-**PR 146: Better S3 bucket management in deployment_utils**
+`PR 147: Init s3Utils via GLOBAL_ENV_BUCKET and misc S3_BUCKET_ORG support (C4-554) <https://github.com/4dn-dcic/utils/pull/147>`_
+`PR 146: Better S3 bucket management in deployment_utils <https://github.com/4dn-dcic/utils/pull/146>`_
 
 * In ``cloudformation_utils``:
 
@@ -1231,7 +1259,7 @@ that big change happened.
 1.18.1
 ======
 
-**PR 145: Fix internal import problems**
+`PR 145: Fix internal import problems <https://github.com/4dn-dcic/utils/pull/145>`_
 
 * Make ``lang_utils`` import ``ignored`` from ``misc_utils``, not ``qa_utils``.
 * Make ``deployment_utils`` import ``override_environ`` from ``misc_utils``, not ``qa_utils``.
@@ -1242,7 +1270,7 @@ that big change happened.
 1.18.0
 ======
 
-**PR 141: Port Application Dockerization utils**
+`PR 141: Port Application Dockerization utils <https://github.com/4dn-dcic/utils/pull/141>`_
 
 * Add additional ECS related APIs needed for orchestration/deployment.
 
@@ -1250,7 +1278,7 @@ that big change happened.
 1.17.0
 ======
 
-**PR 144: Add known_bug_expected and related support**
+`PR 144: Add known_bug_expected and related support <https://github.com/4dn-dcic/utils/pull/144>`_
 
 * In ``misc_utils``:
 
@@ -1278,7 +1306,7 @@ that big change happened.
 1.16.0
 ======
 
-**PR 142: Move override_environ and override_dict to misc_utils**
+`PR 142: Move override_environ and override_dict to misc_utils <https://github.com/4dn-dcic/utils/pull/142>`_
 
 * In ``misc_utils``:
 
@@ -1299,7 +1327,7 @@ that big change happened.
 1.15.1
 ======
 
-**PR 138: JH Docker Mount Update**
+`PR 138: JH Docker Mount Update <https://github.com/4dn-dcic/utils/pull/138>`_
 
 * In ``jh_utils.find_valid_file_or_extra_file``,
   account for file metadata containing an
@@ -1309,7 +1337,7 @@ that big change happened.
 1.15.0
 ======
 
-**PR 140: Add misc_utils.is_valid_absolute_uri (C4-651)**
+`PR 140: Add misc_utils.is_valid_absolute_uri (C4-651) <https://github.com/4dn-dcic/utils/pull/140>`_
 
 * Adds ``misc_utils.is_valid_absolute_uri``
   for RFC 3986 compliance.
@@ -1318,7 +1346,7 @@ that big change happened.
 1.14.1
 ======
 
-**PR 139: Add ES cluster resize capability**
+`PR 139: Add ES cluster resize capability <https://github.com/4dn-dcic/utils/pull/139>`_
 
 * Adds ElasticSearchServiceClient, a wrapper for boto3.client('es')
 * Implements resize_elasticsearch_cluster, issuing an update to the relevant settings
@@ -1329,7 +1357,7 @@ that big change happened.
 1.14.0
 ======
 
-**PR 137: Docker, ECR, ECS Utils**
+`PR 137: Docker, ECR, ECS Utils <https://github.com/4dn-dcic/utils/pull/137>`_
 
 * Adds 3 new modules with basic functionality needed for further development on the alpha stack
 * Deprecates Python 3.4
@@ -1338,7 +1366,7 @@ that big change happened.
 1.13.0
 ======
 
-**PR 136: Support for VirtualApp.post**
+`PR 136: Support for VirtualApp.post <https://github.com/4dn-dcic/utils/pull/136>`_
 
 * Add a ``post`` method to ``VirtualApp`` for situations where ``post_json``
   is not appropriate.
@@ -1348,7 +1376,7 @@ that big change happened.
 1.12.0
 ======
 
-**PR 135: Support for ElasticSearchDataCache**
+`PR 135: Support for ElasticSearchDataCache <https://github.com/4dn-dcic/utils/pull/135>`_
 
 * Support for ``ElasticSearchDataCache`` and the ``es_data_cache`` decorator
   in the new ``snapshot_utils`` module to allow local snapshot isolation on
@@ -1377,7 +1405,7 @@ that big change happened.
 1.11.2
 ======
 
-**PR 134: Fixes to env_utils.data_set_for_env for CGAP (C4-634)**
+`PR 134: Fixes to env_utils.data_set_for_env for CGAP (C4-634) <https://github.com/4dn-dcic/utils/pull/134>`_
 
 * Fix ``env_utils.data_set_for_env`` which were returning ``'test'``
   for ``fourfront-cgapwolf`` and ``fourfront-cgaptest``.
@@ -1387,7 +1415,7 @@ that big change happened.
 1.11.1
 ======
 
-**PR 133: Fix ControlledTime.utcnow on AWS (C4-623)**
+`PR 133: Fix ControlledTime.utcnow on AWS (C4-623) <https://github.com/4dn-dcic/utils/pull/133>`_
 
 * Fix ``qa_utils.ControlledTime.utcnow`` on AWS (C4-623).
 
@@ -1395,7 +1423,7 @@ that big change happened.
 1.11.0
 ======
 
-**PR 132: Miscellaneous support for cgap-portal, and some unit testing (part of C4-601)**
+`PR 132: Miscellaneous support for cgap-portal, and some unit testing (part of C4-601) <https://github.com/4dn-dcic/utils/pull/132>`_
 
 * For ``jh_utils``:
 
@@ -1415,7 +1443,7 @@ that big change happened.
 1.10.0
 ======
 
-**PR 131: Misc functionality in service of C4-183**
+`PR 131: Misc functionality in service of C4-183 <https://github.com/4dn-dcic/utils/pull/131>`_
 
 * In ``dcicutils.misc_utils``:
 
@@ -1427,7 +1455,7 @@ that big change happened.
 
 1.9.2
 =====
-**PR 130: Fix bug that sometimes results in duplicated search results (C4-336)**
+`PR 130: Fix bug that sometimes results in duplicated search results (C4-336) <https://github.com/4dn-dcic/utils/pull/130>`_
 
 * Fixes bug C4-336, in which sometimes ``ff_utils.search_metadata``, by doing a series of
   Elastic Search calls that it pastes together into a single result,
@@ -1437,7 +1465,7 @@ that big change happened.
 1.9.1
 =====
 
-**PR 129: Fix problematic pytest dependency (C4-521)**
+`PR 129: Fix problematic pytest dependency (C4-521) <https://github.com/4dn-dcic/utils/pull/129>`_
 
 * Fix problem in 1.9.0 with unwanted dependency on
   ``pytest.PytestConfigWarning`` (C4-521).
@@ -1448,7 +1476,7 @@ that big change happened.
 1.9.0
 =====
 
-**PR 128: Changelog Warnings (C4-511) and Publish Fixes (C4-512)**
+`PR 128: Changelog Warnings (C4-511) and Publish Fixes (C4-512) <https://github.com/4dn-dcic/utils/pull/128>`_
 
 * Make changelog problems issue a warning rather than fail testing.
 * Make publication for GitHub Actions (GA) not query interactively for confirmation.
@@ -1465,52 +1493,58 @@ Those tests were refactored, and the following additional support was added:
 1.8.4
 =====
 
-**PR 127: Beanstalk Bugfix**
+`PR 127: Beanstalk Bugfix <https://github.com/4dn-dcic/utils/pull/127>`_
 
 * Parses Beanstalk API correctly and passes region.
+
 
 1.8.3
 =====
 
 **No PR: Just fixes to GA PyPi deploy**
 
+
 1.8.2
 =====
 
-**PR 126: C4-503 Grab Environment API**
+`PR 126: C4-503 Grab Environment API <https://github.com/4dn-dcic/utils/pull/126>`_
 
 * Adds get_beanstalk_environment_variables, which will return information
   necessary to simulate any application given the caller has the appropriate
   access keys.
 * Removes an obsolete tag from create_db_snapshot, which was set erroneously.
 
+
 1.8.1
 =====
 
-**PR 125: Edits to getting_started doc**
+`PR 125: Edits to getting_started doc <https://github.com/4dn-dcic/utils/pull/125>`_
 
 * Edited getting_started.rst doc to reflect updated account creation protocol.
+
 
 1.8.0
 =====
 
-**PR 124: Add url_path_join**
+`PR 124: Add url_path_join <https://github.com/4dn-dcic/utils/pull/124>`_
 
 * Add ``misc_utils.url_path_join`` for merging parts of URLs.
 * Add ``make retest`` to rerun failed tests from previous test run.
 
+
 1.7.1
 =====
 
-**PR 123: Add GA for build**
+`PR 123: Add GA for build <https://github.com/4dn-dcic/utils/pull/123>`_
 
 * Adds 3 Github Actions for building the library, building docs
   and deploying to PyPi
 
+
 1.7.0
 =====
 
-**PR 122: Speed up ff_utils unit tests, and misc small bits of functionality**
+`PR 122: Speed up ff_utils unit tests, and misc small bits of functionality <https://github.com/4dn-dcic/utils/pull/122>`_
 
 * Added an ``integratedx`` mark to possible marks in ``pytest.ini``. These
   are the same as ``integrated`` but they represent test cases that have
@@ -1559,7 +1593,7 @@ Those tests were refactored, and the following additional support was added:
 1.6.0
 =====
 
-**PR 121: More time functions**
+`PR 121: More time functions <https://github.com/4dn-dcic/utils/pull/121>`_
 
 In ``misc_utils``:
 
@@ -1578,7 +1612,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.5.1
 =====
 
-**PR 120: Update ES-py Version**
+`PR 120: Update ES-py Version <https://github.com/4dn-dcic/utils/pull/120>`_
 
 * Updates elasticsearch library to 6.8.1 to take a bug fix.
 
@@ -1586,7 +1620,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.5.0
 =====
 
-**PR 119: More env_utils support**
+`PR 119: More env_utils support** <https://github.com/4dn-dcic/utils/pull/119>`_
 
 * Add ``env_utils.classify_server_url``.
 
@@ -1594,7 +1628,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.4.0
 =====
 
-**PR 118: Various bits of functionality in support of 4dn-status (C4-363)**
+`PR 118: Various bits of functionality in support of 4dn-status (C4-363) <https://github.com/4dn-dcic/utils/pull/118>`_
 
 * New feature in ``qa_utils``:
 
@@ -1616,7 +1650,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.3.1
 =====
 
-**PR 117: Repair handling of sentry_dsn in deployment_utils (C4-361)**
+`PR 117: Repair handling of sentry_dsn in deployment_utils (C4-361) <https://github.com/4dn-dcic/utils/pull/117>`_
 
 * Fixes to ``deployment_utils``:
 
@@ -1638,7 +1672,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.3.0
 =====
 
-**PR 115: Miscellaneous fixes 2020-10-06**
+`PR 115: Miscellaneous fixes 2020-10-06 <https://github.com/4dn-dcic/utils/pull/115>`_
 
 * Fix a lurking bug in ``beanstalk_utils`` where ``delete_db`` had the wrong scope.
 * Add ``qa_utils.raises_regexp`` for conceptual compatibility with ``AssertRaises`` in ``unittest``.
@@ -1658,7 +1692,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.2.1
 =====
 
-**PR 114: Port some utility**
+`PR 114: Port some utility <https://github.com/4dn-dcic/utils/pull/114>`_
 
 * New ``ff_utils`` functions
   for common pages/info we'd like to obtain:
@@ -1672,7 +1706,7 @@ The rationale for these changes is that if we deploy at other locations, it may 
 1.2.0
 =====
 
-**PR 113: Deprecations, updates + CNAME swap**
+`PR 113: Deprecations, updates + CNAME swap <https://github.com/4dn-dcic/utils/pull/113>`_
 
 * Implements an ``obsolete`` decorator,
   applied to many functions in ``beanstalk_utils``.
@@ -1680,7 +1714,8 @@ The rationale for these changes is that if we deploy at other locations, it may 
   that do not work with ES6
 * Pull full ``CNAME`` swap code from ``Torb`` into ``dcicutils``.
 
-**PR 112: Miscellaneous utilities ported from cgap-portal and SubmitCGAP repos**
+
+`PR 112: Miscellaneous utilities ported from cgap-portal and SubmitCGAP repos <https://github.com/4dn-dcic/utils/pull/112>`_
 
 This still has a beta version number 1.1.0b1.
 
@@ -1695,7 +1730,8 @@ Ported functionality from ``cgap-portal`` and ``SubmitCGAP`` repos:
   argument without calling ``len``.
 * Tests for ``misc_utils.VirtualApp.put_json``.
 
-**PR 111: ES6 - Fix create_es_client**
+
+`PR 111: ES6 - Fix create_es_client <https://github.com/4dn-dcic/utils/pull/111>`_
 
 This is a major change, with beta version number 1.0.0.b1:
 
@@ -1705,7 +1741,7 @@ This is a major change, with beta version number 1.0.0.b1:
 0.41.0
 ======
 
-**PR 110: Add VirtualApp.put_json (C4-272)**
+`PR 110: Add VirtualApp.put_json (C4-272) <https://github.com/4dn-dcic/utils/pull/110>`_
 
 * Add ``misc_utils.VirtualApp.put_json``.
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:  # builds
 
 test:  # runs default tests, which are the unit tests
 	make test-units
+	make test-static
 
 test-for-ga:
 	poetry run flake8 dcicutils
@@ -72,6 +73,7 @@ test-static:
 	@git log -1 --decorate | head -1
 	@date
 	poetry run pytest -vv -r w -m "static"
+	poetry run flake8 dcicutils
 	@git log -1 --decorate | head -1
 	@date
 

--- a/dcicutils/deployment_utils.py
+++ b/dcicutils/deployment_utils.py
@@ -433,7 +433,7 @@ class IniFileManager:
         Args:
             template_file_name (str): The name of the template file to drive the construction.
             init_file_name (str): The name of the .ini file to build.
-            env_bucket (str): The S3 bucket in which informatoin about the env_name and env_ecosystem can be obtained.
+            env_bucket (str): The S3 bucket in which information about the env_name and env_ecosystem can be obtained.
             env_ecosystem (str): The portal ecosystem in which this portal's environment collaborates.
             env_name (str): The portal environment name for which this .ini file should work.
             bs_env (str): The beanstalk environment name for which this .ini file should work. Deprecated. Use env_name.
@@ -567,7 +567,7 @@ class IniFileManager:
         Args:
             template_file_name: The template file to guide the output.
             init_file_stream: A stream to send output to.
-            env_bucket (str): The S3 bucket in which informatoin about the env_name and env_ecosystem can be obtained.
+            env_bucket (str): The S3 bucket in which information about the env_name and env_ecosystem can be obtained.
             env_ecosystem (str): The portal ecosystem in which this portal's environment collaborates.
             env_name (str): The portal environment name for which this .ini file should work.
             bs_env (str): The beanstalk environment name for which this .ini file should work. Deprecated. Use env_name.

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -523,7 +523,7 @@ class TestRecorder:
                         PRINT(f"Consuming replay record {parsed_json.get('verb')} {parsed_json.get('url')}")
                     return parsed_json
 
-                # Read back initial record with sufficient integratoin context information for replaying
+                # Read back initial record with sufficient integration context information for replaying
                 mocked_integrated_ff = get_next_json()
 
                 def mock_replayed(verb):
@@ -656,7 +656,7 @@ class TestRecorder:
                         PRINT(f"Consuming replay record {parsed_json.get('verb')} {parsed_json.get('url')}")
                     return parsed_json
 
-                # Read back initial record with sufficient integratoin context information for replaying
+                # Read back initial record with sufficient integration context information for replaying
                 mocked_integrated_ff = get_next_json()
 
                 def mocked_replayed_authorized_request(url, *, verb, **kwargs):
@@ -726,10 +726,14 @@ class AbstractIntegratedFixture:
     HIGLASS_ACCESS_KEY = None
     INTEGRATED_FF_ITEMS = None
 
+    _INITIALIZED = False
+
     @classmethod
     def initialize_class(cls):
 
-        if NO_SERVER_FIXTURES:
+        if cls._INITIALIZED:
+            return cls
+        elif NO_SERVER_FIXTURES:
             return 'NO_SERVER_FIXTURES'
 
         cls.S3_CLIENT = s3_utils.s3Utils(env=cls.ENV_NAME)
@@ -747,8 +751,13 @@ class AbstractIntegratedFixture:
             'es_url': cls.ES_URL,
         }
 
+        cls._INITIALIZED = True
+
+        return cls
+
     @classmethod
     def verify_portal_access(cls, portal_access_key):
+        cls.initialize_class()
         if NO_SERVER_FIXTURES:
             return 'NO_SERVER_FIXTURES'
 
@@ -760,6 +769,7 @@ class AbstractIntegratedFixture:
                             f' Requesting the homepage gave status of: {response.status_code}')
 
     def __init__(self, name):
+        self.initialize_class()
         self.name = name
 
     def __str__(self):
@@ -800,7 +810,3 @@ class IntegratedFixture(AbstractIntegratedFixture):
     ENV_NAME = 'fourfront-mastertest'
     ENV_INDEX_NAMESPACE = 'fourfront-mastertest'
     ENV_PORTAL_URL = 'https://mastertest.4dnucleome.org'
-
-
-IntegratedFixture.initialize_class()
-IntegratedFixture.verify_portal_access(IntegratedFixture.PORTAL_ACCESS_KEY)

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -393,6 +393,7 @@ class TestRecorder:
                 # Call common subroutine shared by integrated and unit test
                 check_something(integrated_ff)
 
+        @pytest.mark.recorded
         @pytest.mark.unit
         def test_something_unit():
             with TestRecorder().replayed_requests('test_post_delete_purge_links_metadata') as mocked_integrated_ff:

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -729,7 +729,7 @@ class AbstractIntegratedFixture:
     _INITIALIZED = False
 
     @classmethod
-    def initialize_class(cls):
+    def _initialize_class(cls):
 
         if cls._INITIALIZED:
             return cls
@@ -756,10 +756,14 @@ class AbstractIntegratedFixture:
         return cls
 
     @classmethod
-    def verify_portal_access(cls, portal_access_key):
-        cls.initialize_class()
+    def verify_portal_access(cls, portal_access_key=None):
+
         if NO_SERVER_FIXTURES:
             return 'NO_SERVER_FIXTURES'
+
+        cls._initialize_class()
+
+        portal_access_key = portal_access_key or cls.PORTAL_ACCESS_KEY
 
         response = authorized_request(
             portal_access_key['server'],
@@ -769,7 +773,7 @@ class AbstractIntegratedFixture:
                             f' Requesting the homepage gave status of: {response.status_code}')
 
     def __init__(self, name):
-        self.initialize_class()
+        self._initialize_class()
         self.name = name
 
     def __str__(self):

--- a/dcicutils/qa_checkers.py
+++ b/dcicutils/qa_checkers.py
@@ -47,7 +47,7 @@ class ChangeLogChecker:
     # on particular versions of pytest, and we don't export a delivery
     # constraint of a particular pytest version. So RuntimeWarning is a
     # safer setting for now. -kmp 14-Jan-2021
-    WARNING_CATEGORY = RuntimeWarning
+    WARNING_CATEGORY: Type[Warning] = RuntimeWarning
 
     @classmethod
     def check_version(cls):
@@ -329,7 +329,7 @@ class DebuggingArtifactChecker(StaticChecker):
         },
     ]
 
-    WARNING_CATEGORY = SyntaxWarning
+    WARNING_CATEGORY: Type[Warning] = SyntaxWarning
 
     def __init__(self, sources_subdir: str, *,
                  root_dir: Optional[str] = None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -48,16 +40,16 @@ lxml = ["lxml"]
 
 [[package]]
 name = "boto3"
-version = "1.23.10"
+version = "1.24.83"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.26.10,<1.27.0"
+botocore = ">=1.27.83,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.5.0,<0.6.0"
+s3transfer = ">=0.6.0,<0.7.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
@@ -356,11 +348,11 @@ xray = ["mypy-boto3-xray (>=1.18.18)"]
 
 [[package]]
 name = "botocore"
-version = "1.26.10"
+version = "1.27.83"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">= 3.7"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
@@ -368,7 +360,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.13.8)"]
+crt = ["awscrt (==0.14.0)"]
 
 [[package]]
 name = "botocore-stubs"
@@ -383,7 +375,7 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -391,11 +383,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.12"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
-python-versions = ">=3.5.0"
+python-versions = ">=3.6.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -410,14 +402,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.2"
+version = "6.5.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
@@ -514,19 +506,19 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.20"
-description = "Python Git Library"
+version = "3.1.27"
+description = "GitPython is a python library used to interact with Git repositories"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\""}
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -558,11 +550,11 @@ python-versions = "*"
 
 [[package]]
 name = "jmespath"
-version = "0.10.0"
+version = "1.0.1"
 description = "JSON Matching Expressions"
 category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.7"
 
 [[package]]
 name = "mccabe"
@@ -624,25 +616,24 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.7"
-description = "Python parsing module"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
-version = "7.0.1"
+version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
@@ -657,7 +648,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "4.0.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
@@ -668,15 +659,15 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
-version = "3.6.1"
+version = "3.9.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 pytest = ">=5.0"
@@ -686,15 +677,15 @@ dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "pytest-runner"
-version = "5.3.2"
+version = "6.0.0"
 description = "Invoke py.test as distutils command with dependency resolution"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-virtualenv", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-virtualenv", "types-setuptools", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "python-dateutil"
@@ -709,7 +700,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.1"
+version = "2022.2.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -733,21 +724,21 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rfc3986"
@@ -762,11 +753,11 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "s3transfer"
-version = "0.5.2"
+version = "0.6.0"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">= 3.7"
 
 [package.dependencies]
 botocore = ">=1.12.36,<2.0a.0"
@@ -825,23 +816,23 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.3"
+version = "2.0.1"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "4.3.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.11"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -849,20 +840,20 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, 
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "waitress"
-version = "2.0.0"
+version = "2.1.2"
 description = "Waitress WSGI server"
 category = "main"
 optional = false
-python-versions = ">=3.6.0"
+python-versions = ">=3.7.0"
 
 [package.extras]
-testing = ["coverage (>=5.0)", "pytest-cover", "pytest"]
-docs = ["pylons-sphinx-themes (>=1.0.9)", "docutils", "Sphinx (>=1.8.1)"]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["pytest", "pytest-cover", "coverage (>=5.0)"]
 
 [[package]]
 name = "webob"
@@ -878,16 +869,16 @@ testing = ["pytest (>=3.1.0)", "coverage", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "websocket-client"
-version = "1.3.1"
+version = "1.4.1"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
-optional = ["wsaccel", "python-socks"]
-docs = ["sphinx-rtd-theme (>=0.5)", "Sphinx (>=3.4)"]
 
 [[package]]
 name = "webtest"
@@ -909,15 +900,15 @@ tests = ["nose (<1.3.0)", "coverage", "mock", "pastedeploy", "wsgiproxy2", "pyqu
 
 [[package]]
 name = "zipp"
-version = "3.6.0"
+version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
@@ -925,9 +916,6 @@ python-versions = ">=3.7,<3.10"
 content-hash = "7dc70bacccfee09d43af039ec491580586ffacd67c7c4d84b6838dc1c6dc3946"
 
 [metadata.files]
-atomicwrites = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
@@ -941,81 +929,84 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 boto3 = [
-    {file = "boto3-1.23.10-py3-none-any.whl", hash = "sha256:40d08614f17a69075e175c02c5d5aab69a6153fd50e40fa7057b913ac7bf40e7"},
-    {file = "boto3-1.23.10.tar.gz", hash = "sha256:2a4395e3241c20eef441d7443a5e6eaa0ee3f7114653fb9d9cef41587526f7bd"},
+    {file = "boto3-1.24.83-py3-none-any.whl", hash = "sha256:a29214908224da132ecc025f4da266f4124c26d22205002bfd02aed5743a2e47"},
+    {file = "boto3-1.24.83.tar.gz", hash = "sha256:b10d9ecaba3f0ed844192828d2c2b26bfa1dfd2b40ccccc25507575f28097e32"},
 ]
 boto3-stubs = [
     {file = "boto3-stubs-1.18.23.tar.gz", hash = "sha256:38915f107b36160ff2ba749fdb0de49d6dca4214fb16564d4f31f22f4f25099c"},
     {file = "boto3_stubs-1.18.23-py3-none-any.whl", hash = "sha256:4bed5a3aa0a3c9516791b22e9cd0aba7b93dd4d30669fc032118568bcf678a36"},
 ]
 botocore = [
-    {file = "botocore-1.26.10-py3-none-any.whl", hash = "sha256:8a4a984bf901ccefe40037da11ba2abd1ddbcb3b490a492b7f218509c99fc12f"},
-    {file = "botocore-1.26.10.tar.gz", hash = "sha256:5df2cf7ebe34377470172bd0bbc582cf98c5cbd02da0909a14e9e2885ab3ae9c"},
+    {file = "botocore-1.27.83-py3-none-any.whl", hash = "sha256:9a1fb823c68aef1227f2d63af856a485e09f43792f257a821b53ea86481c66bd"},
+    {file = "botocore-1.27.83.tar.gz", hash = "sha256:c57f74322cf672405f0ec7ee8fda7d80d323a9c664a90926c11313ca3bfbca91"},
 ]
 botocore-stubs = [
     {file = "botocore-stubs-1.21.22.tar.gz", hash = "sha256:10d97e57cd79c66b6b78fe0fcac3ab22e421af222c03e93afe3d05bdb5dadc48"},
     {file = "botocore_stubs-1.21.22-py3-none-any.whl", hash = "sha256:41ce3ad97ffe04c07a7939367d47aa6a049f4e939e184433f44f03e7149a2920"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
+    {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
 ]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 coverage = [
-    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
-    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
-    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
-    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
-    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
-    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
-    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
-    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
-    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
-    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
-    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
-    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
-    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
-    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
-    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
-    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
-    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
-    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
-    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
-    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
-    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
-    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
-    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
-    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
-    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
-    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
-    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
-    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
-    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
-    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
-    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
-    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
-    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
-    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
-    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
-    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
-    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
-    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
-    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
-    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
-    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
-    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
-    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
-    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
-    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
-    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
-    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
+    {file = "coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53"},
+    {file = "coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a"},
+    {file = "coverage-6.5.0-cp310-cp310-win32.whl", hash = "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32"},
+    {file = "coverage-6.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e"},
+    {file = "coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b"},
+    {file = "coverage-6.5.0-cp311-cp311-win32.whl", hash = "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578"},
+    {file = "coverage-6.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b"},
+    {file = "coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f"},
+    {file = "coverage-6.5.0-cp37-cp37m-win32.whl", hash = "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b"},
+    {file = "coverage-6.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e"},
+    {file = "coverage-6.5.0-cp38-cp38-win32.whl", hash = "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d"},
+    {file = "coverage-6.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f"},
+    {file = "coverage-6.5.0-cp39-cp39-win32.whl", hash = "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72"},
+    {file = "coverage-6.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"},
+    {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
+    {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
 ]
 coveralls = [
     {file = "coveralls-3.3.1-py2.py3-none-any.whl", hash = "sha256:f42015f31d386b351d4226389b387ae173207058832fbf5c8ec4b40e27b16026"},
@@ -1045,12 +1036,12 @@ gitdb = [
     {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.20-py3-none-any.whl", hash = "sha256:b1e1c269deab1b08ce65403cf14e10d2ef1f6c89e33ea7c5e5bb0222ea593b8a"},
-    {file = "GitPython-3.1.20.tar.gz", hash = "sha256:df0e072a200703a65387b0cfdf0466e3bab729c0458cf6b7349d0e9877636519"},
+    {file = "GitPython-3.1.27-py3-none-any.whl", hash = "sha256:5b68b000463593e05ff2b261acff0ff0972df8ab1b70d3cdbd41b546c8b8fc3d"},
+    {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
 ]
 idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
@@ -1061,8 +1052,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 jmespath = [
-    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
-    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
@@ -1089,32 +1080,32 @@ pyflakes = [
     {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
-    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
-    {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
-    {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
-    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
+    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
 ]
 pytest-mock = [
-    {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
-    {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
+    {file = "pytest-mock-3.9.0.tar.gz", hash = "sha256:c899a0dcc8a5f22930acd020b500abd5f956911f326864a3b979e4866e14da82"},
+    {file = "pytest_mock-3.9.0-py3-none-any.whl", hash = "sha256:1a1b9264224d026932d6685a0f9cef3b61d91563c3e74af9fe5afb2767e13812"},
 ]
 pytest-runner = [
-    {file = "pytest-runner-5.3.2.tar.gz", hash = "sha256:48934ec94301f6727d30615af1960539ff62063f6c9b71b7227174e51ba5fb34"},
-    {file = "pytest_runner-5.3.2-py3-none-any.whl", hash = "sha256:c7d785ea6c612396c11ddbaf467764d2cc746ef96a713fbe1a296c221503b7c3"},
+    {file = "pytest-runner-6.0.0.tar.gz", hash = "sha256:b4d85362ed29b4c348678de797df438f0f0509497ddb8c647096c02a6d87b685"},
+    {file = "pytest_runner-6.0.0-py3-none-any.whl", hash = "sha256:4c059cf11cf4306e369c0f8f703d1eaf8f32fad370f41deb5f007044656aca6b"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
-    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
-    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
+    {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
+    {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
 ]
 pywin32 = [
     {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
@@ -1162,16 +1153,16 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 rfc3986 = [
     {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
     {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 s3transfer = [
-    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
-    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
+    {file = "s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},
+    {file = "s3transfer-0.6.0.tar.gz", hash = "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1194,34 +1185,34 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
-    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
-    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 waitress = [
-    {file = "waitress-2.0.0-py3-none-any.whl", hash = "sha256:29af5a53e9fb4e158f525367678b50053808ca6c21ba585754c77d790008c746"},
-    {file = "waitress-2.0.0.tar.gz", hash = "sha256:69e1f242c7f80273490d3403c3976f3ac3b26e289856936d1f620ed48f321897"},
+    {file = "waitress-2.1.2-py3-none-any.whl", hash = "sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a"},
+    {file = "waitress-2.1.2.tar.gz", hash = "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"},
 ]
 webob = [
     {file = "WebOb-1.8.7-py2.py3-none-any.whl", hash = "sha256:73aae30359291c14fa3b956f8b5ca31960e420c28c1bec002547fb04928cf89b"},
     {file = "WebOb-1.8.7.tar.gz", hash = "sha256:b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323"},
 ]
 websocket-client = [
-    {file = "websocket-client-1.3.1.tar.gz", hash = "sha256:6278a75065395418283f887de7c3beafb3aa68dada5cacbe4b214e8d26da499b"},
-    {file = "websocket_client-1.3.1-py3-none-any.whl", hash = "sha256:074e2ed575e7c822fc0940d31c3ac9bb2b1142c303eafcf3e304e6ce035522e8"},
+    {file = "websocket-client-1.4.1.tar.gz", hash = "sha256:f9611eb65c8241a67fb373bef040b3cf8ad377a9f6546a12b620b6511e8ea9ef"},
+    {file = "websocket_client-1.4.1-py3-none-any.whl", hash = "sha256:398909eb7e261f44b8f4bd474785b6ec5f5b499d4953342fe9755e01ef624090"},
 ]
 webtest = [
     {file = "WebTest-2.0.35-py2.py3-none-any.whl", hash = "sha256:44ddfe99b5eca4cf07675e7222c81dd624d22f9a26035d2b93dc8862dc1153c6"},
     {file = "WebTest-2.0.35.tar.gz", hash = "sha256:aac168b5b2b4f200af4e35867cf316712210e3d5db81c1cbdff38722647bb087"},
 ]
 zipp = [
-    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
-    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.0"
+version = "5.2.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.1"
+version = "5.2.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.0.1b0"
+version = "5.2.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -85,6 +85,7 @@ markers = [
   "static: mark as a test that is testing the static form of code, not its runtime functionality",
   "stg_or_prd_testing_needs_repair: some or all of a test that was failing on stg/prd has been temporarily disabled",
   "recordable: uses recording technology so that if RECORDING_ENABLED=TRUE, a new test recording is made",
+  "recorded: a test in which previously recorded values will be used in place of certain external callouts",
 ]
 norecursedirs = ["*env", "site-packages", ".cache", ".git", ".idea", "*.egg-info"]
 # We don't use pytest-pep8, but if we ever did, its pep8xxx options could be specified here, as in:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,8 +8,7 @@ from dcicutils.ff_mocks import IntegratedFixture
 from .conftest_settings import TEST_DIR, INTEGRATED_ENV
 
 
-IntegratedFixture.initialize_class()
-IntegratedFixture.verify_portal_access(IntegratedFixture.PORTAL_ACCESS_KEY)
+IntegratedFixture.verify_portal_access()
 
 
 def _portal_health_get(namespace, portal_url, key):
@@ -90,7 +89,7 @@ def integrated_s3_info(integrated_names):
 
     test_filename = integrated_names['filename']
 
-    s3_obj = IntegratedFixture.S3_CLIENT
+    s3_obj = IntegratedFixture('integrated_ff').S3_CLIENT
     # for now, always upload these files
     s3_obj.s3.put_object(Bucket=s3_obj.outfile_bucket, Key=test_filename,
                          Body=str.encode('thisisatest'))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,10 @@ from dcicutils.ff_mocks import IntegratedFixture
 from .conftest_settings import TEST_DIR, INTEGRATED_ENV
 
 
+IntegratedFixture.initialize_class()
+IntegratedFixture.verify_portal_access(IntegratedFixture.PORTAL_ACCESS_KEY)
+
+
 def _portal_health_get(namespace, portal_url, key):
     healh_json_url = f"{portal_url}/health?format=json"
     response = requests.get(healh_json_url)

--- a/test/conftest_settings.py
+++ b/test/conftest_settings.py
@@ -5,9 +5,11 @@ from dcicutils.ff_mocks import IntegratedFixture
 
 TEST_DIR = os.path.join(os.path.dirname(__file__))
 
-INTEGRATED_ENV = IntegratedFixture.ENV_NAME
-INTEGRATED_ENV_INDEX_NAMESPACE = IntegratedFixture.ENV_INDEX_NAMESPACE
-INTEGRATED_ENV_PORTAL_URL = IntegratedFixture.ENV_PORTAL_URL
-INTEGRATED_ES = IntegratedFixture.ES_URL
+_integrated_fixture = IntegratedFixture('integrated_ff')
+
+INTEGRATED_ENV = _integrated_fixture.ENV_NAME
+INTEGRATED_ENV_INDEX_NAMESPACE = _integrated_fixture.ENV_INDEX_NAMESPACE
+INTEGRATED_ENV_PORTAL_URL = _integrated_fixture.ENV_PORTAL_URL
+INTEGRATED_ES = _integrated_fixture.ES_URL
 
 REPOSITORY_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -6,5 +6,5 @@ from unittest import mock
 def test_abstract_integrated_fixture_no_server_fixtures():
 
     with mock.patch.object(ff_mocks_module, "NO_SERVER_FIXTURES"):  # too late to set env variable, but this'll do.
-        assert AbstractIntegratedFixture.initialize_class() == 'NO_SERVER_FIXTURES'
+        assert AbstractIntegratedFixture._initialize_class() == 'NO_SERVER_FIXTURES'  # noQA - yes, it's protected
         assert AbstractIntegratedFixture.verify_portal_access('not-a-dictionary') == 'NO_SERVER_FIXTURES'

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -700,6 +700,7 @@ def test_post_delete_purge_links_metadata_integrated(integrated_ff):
         check_post_delete_purge_links_metadata(integrated_ff)
 
 
+@pytest.mark.recorded
 @pytest.mark.unit
 def test_post_delete_purge_links_metadata_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
@@ -782,6 +783,7 @@ def test_upsert_metadata_integrated(integrated_ff):
         check_upsert_metadata(integrated_ff)
 
 
+@pytest.mark.recorded
 @pytest.mark.unit
 def test_upsert_metadata_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
@@ -1312,6 +1314,7 @@ def test_faceted_search_exp_set_integrated(integrated_ff):
         check_faceted_search_exp_set(integrated_ff)
 
 
+@pytest.mark.recorded
 @pytest.mark.unit
 def test_faceted_search_exp_set_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
@@ -1446,6 +1449,7 @@ def test_faceted_search_users_integrated(integrated_ff):
         check_faceted_search_users(integrated_ff)
 
 
+@pytest.mark.recorded
 @pytest.mark.unit
 def test_faceted_search_users_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -9,6 +9,8 @@ from .conftest_settings import REPOSITORY_ROOT_DIR
 @pytest.mark.static
 def test_utils_doc():
 
+    __tracebackhide__ = True
+
     class UtilsDocsChecker(DocsChecker):
         SKIP_SUBMODULES = ['jh_utils', 'env_utils_legacy']
 
@@ -19,7 +21,10 @@ def test_utils_doc():
 
 @pytest.mark.static
 def test_utils_debugging_artifacts():
-    checker = DebuggingArtifactChecker(sources_subdir="dcicutils")
+
+    __tracebackhide__ = True
+
+    checker = DebuggingArtifactChecker(sources_subdir="dcicutils", if_used='warning')
     checker.check_for_debugging_patterns()
 
     checker = DebuggingArtifactChecker(sources_subdir="test", skip_files="data_files/", filter_patterns=['pdb'])
@@ -28,6 +33,8 @@ def test_utils_debugging_artifacts():
 
 @pytest.mark.static
 def test_changelog_consistency():
+
+    __tracebackhide__ = True
 
     class MyChangeLogChecker(ChangeLogChecker):
         PYPROJECT = os.path.join(REPOSITORY_ROOT_DIR, "pyproject.toml")

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -2103,7 +2103,7 @@ def test_get_error_message_and_print_error_message():
 
     empty_dict = {}
 
-    test_error(  # The empty_dict['foo'] will unconditonally err, so we don't need the value to get used
+    test_error(  # The empty_dict['foo'] will unconditionally err, so we don't need the value to get used
                error_descriptor=lambda: empty_dict['foo'],
                # There is no difference between short and long forms for primitive error classes that have no module id.
                expected="KeyError: 'foo'",


### PR DESCRIPTION
* Show less uninteresting traceback info for static tests.
* Small incompatible change to recently released `qa_checkers.confirm_no_uses` to remove the `if_used` argument in favor of a simpler implementation. Since this is testing-only, not something used in production, and since there are believed to be no uses outside the repo, no major version bump.
* Make class initialization of `IntegratedFixture` happen at instance instantiation time. That simplifies the loading actions needed. Those can happen in `conftest.py` rather than in `ff_mocks`, which should allow `dcicutils.ff_mocks` to be imported more easily ([C4-932](https://hms-dbmi.atlassian.net/browse/C4-932)).