### PR TITLE
Refactored recording tech

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,20 @@ Change Log
 ----------
 
 
+5.3.0
+=====
+
+`PR 223: Refactored recording tech <https://github.com/4dn-dcic/utils/pull/223>`_
+
+* Refactor ``TestRecorder`` into an ``AbstractTestRecorder`` with two concrete classes,
+  ``RequestsTestRecorder`` and ``AuthorizedRequestsTestRecorder``. The new refactor means
+  it'll be easier to write other subclasses.
+
+  The new classes take their arguments slightly differently, but all test cases are updated,
+  and this was previously broken in (so not used in) other repositories and it can't break
+  anything elsewhere to change the conventions. We're treating this as a simple bug fix.
+
+
 5.2.1
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Change Log
   and this was previously broken in (so not used in) other repositories and it can't break
   anything elsewhere to change the conventions. We're treating this as a simple bug fix.
 
+* Deprecated unused class ``MockBoto4DNLegacyElasticBeanstalkClient``.
+
 
 5.2.1
 =====

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test-static:
 	@date
 	poetry run pytest -vv -r w -m "static"
 	poetry run flake8 dcicutils
+	poetry run flake8 test --exclude=data_files
 	@git log -1 --decorate | head -1
 	@date
 

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -487,9 +487,12 @@ class AbstractTestRecorder:
         self.dt.sleep(expected_event['duration'])
         error_message = expected_event.get('error_message')
         if error_message:
+            PRINT(f" simulating error {error_message!r}")
             raise Exception(error_message)
         else:
-            return expected_event['result']
+            result = expected_event['result']
+            PRINT(f" => {result}")
+            return result
 
     @contextlib.contextmanager
     def mock_replay_stuff_in_queues(self):

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -445,7 +445,7 @@ class AbstractTestRecorder:
             self.recording_enabled = old_enabled
             self.recording_level = old_level
 
-    def mocked_recorded_stuff_in_queues(self, ff_env_index_namespace, check_secondary):
+    def mocked_recording_stuff_in_queues(self, ff_env_index_namespace, check_secondary):
         # This mock assumes the queue checks don't err. If we find they do, it needs to be a bit more elaborate.
         start = datetime.datetime.now()
         result = ff_utils.internal_compute_stuff_in_queues(ff_env_index_namespace=ff_env_index_namespace,
@@ -471,11 +471,11 @@ class AbstractTestRecorder:
 
     @contextlib.contextmanager
     def mock_record_stuff_in_queues(self):
-        with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_stuff_in_queues:
-            mock_stuff_in_queues.side_effect = self.mocked_recorded_stuff_in_queues
+        with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_recording_stuff_in_queues:
+            mock_recording_stuff_in_queues.side_effect = self.mocked_recording_stuff_in_queues
             yield
 
-    def mocked_replayed_stuff_in_queues(self, ff_env_index_namespace, check_secondary):
+    def mocked_replaying_stuff_in_queues(self, ff_env_index_namespace, check_secondary):
         PRINT(f"Replaying stuff-in-queues {ff_env_index_namespace} {check_secondary}")
         verb = 'stuff-in-queues'
         expected_event = self.get_next_json()
@@ -491,8 +491,8 @@ class AbstractTestRecorder:
 
     @contextlib.contextmanager
     def mock_replay_stuff_in_queues(self):
-        with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_replayed_stuff_in_queues:
-            mock_replayed_stuff_in_queues.side_effect = self.mocked_replayed_stuff_in_queues
+        with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_replaying_stuff_in_queues:
+            mock_replaying_stuff_in_queues.side_effect = self.mocked_replaying_stuff_in_queues
             yield
 
     def get_next_json(self):

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -462,11 +462,12 @@ class AbstractTestRecorder:
             "duration": duration,
             "result": result
         }
+        prefix = f"{self.recording_level * '>'} " if self.recording_level else ""
         if self.recording_enabled:
-            PRINT(f"Recording stuff-in-queues")
+            PRINT(f"{prefix}Recording stuff-in-queues")
             PRINT(json.dumps(event), file=self.recording_fp)
         else:
-            PRINT(f"{'>' * self.recording_level} NOT recording stuff-in-queues")
+            PRINT(f"{prefix}NOT recording stuff-in-queues")
         return result
 
     @contextlib.contextmanager

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -11,7 +11,9 @@ import time
 from dcicutils.env_utils import EnvUtils, full_env_name, is_stg_or_prd_env
 from dcicutils.ff_utils import authorized_request
 from dcicutils.lang_utils import disjoined_list, conjoined_list
-from dcicutils.misc_utils import ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool
+from dcicutils.misc_utils import (
+    ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool, local_attrs
+)
 from dcicutils.qa_utils import (
     MockBoto3, MockBotoElasticBeanstalkClient, MockBotoS3Client, ControlledTime, MockResponse,
     make_mock_beanstalk, make_mock_beanstalk_cname, make_mock_beanstalk_environment_variables,
@@ -426,6 +428,8 @@ class TestRecorder:
         self.recordings_dir = recordings_dir or self.DEFAULT_RECORDINGS_DIR
         self.recording_enabled = self.RECORDING_ENABLED
         self.recording_level = 0
+        self.recording_fp = None
+        self.dt = None
 
     @contextlib.contextmanager
     def creating_record(self):
@@ -439,263 +443,204 @@ class TestRecorder:
             self.recording_enabled = old_enabled
             self.recording_level = old_level
 
+    def mocked_recorded_stuff_in_queues(self, ff_env_index_namespace, check_secondary):
+        # This mock assumes the queue checks don't err. If we find they do, it needs to be a bit more elaborate.
+        start = datetime.datetime.now()
+        result = ff_utils.internal_compute_stuff_in_queues(ff_env_index_namespace=ff_env_index_namespace,
+                                                           check_secondary=check_secondary)
+        duration = (datetime.datetime.now() - start).total_seconds()
+        duration = math.floor(duration * 10) / 10.0  # round to tenths of a second
+        event = {"verb": 'stuff-in-queues', "url": None,
+                 "data": {"ff_env_index_namespace": ff_env_index_namespace,
+                          "check_secondary": check_secondary},
+                 "duration": duration, "result": result}
+        if self.recording_enabled:
+            PRINT(f"Recording stuff-in-queues")
+            PRINT(json.dumps(event), file=self.recording_fp)
+        else:
+            PRINT(f"{'>' * self.recording_level} NOT recording stuff-in-queues")
+        return result
+
+    @contextlib.contextmanager
+    def mock_record_stuff_in_queues(self):
+        with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_stuff_in_queues:
+            mock_stuff_in_queues.side_effect = self.mocked_recorded_stuff_in_queues
+            yield
+
+    def mocked_replayed_stuff_in_queues(self, ff_env_index_namespace, check_secondary):
+        PRINT(f"Replaying stuff-in-queues {ff_env_index_namespace} {check_secondary}")
+        verb = 'stuff-in-queues'
+        expected_event = self.get_next_json()
+        expected_verb = expected_event['verb']
+        if verb != expected_verb:
+            raise AssertionError(f"Actual call {verb} does not match expected call {expected_verb}")
+        self.dt.sleep(expected_event['duration'])
+        error_message = expected_event.get('error_message')
+        if error_message:
+            raise Exception(error_message)
+        else:
+            return expected_event['result']
+
+    @contextlib.contextmanager
+    def mock_replay_stuff_in_queues(self):
+        with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_replayed_stuff_in_queues:
+            mock_replayed_stuff_in_queues.side_effect = self.mocked_replayed_stuff_in_queues
+            yield
+
+    def get_next_json(self):
+        line = self.recording_fp.readline()
+        if not line:
+            raise AssertionError("Out of replayable records.")
+        parsed_json = json.loads(line)
+        if parsed_json.get('verb') is None:
+            PRINT(f"Consuming special non-request replay record.")
+        else:
+            PRINT(f"Consuming replay record {parsed_json.get('verb')} {parsed_json.get('url')}")
+        return parsed_json
+
+    @contextlib.contextmanager
+    def setup_recording(self, test_name, initial_context=None):
+        with io.open(os.path.join(self.recordings_dir, test_name), 'w') as recording_fp:
+            with local_attrs(self, recording_fp=recording_fp):
+                # Write an initial record with sufficient context information for replaying
+                PRINT(json.dumps(initial_context or {}), file=recording_fp)
+                yield
+
+    def do_mocked_record(self, action, verb, url, **kwargs):
+        start = datetime.datetime.now()
+        data = kwargs.get('data')
+        try:
+            with self.creating_record():
+                response = action()
+            status = response.status_code
+            result = response.json()
+            duration = (datetime.datetime.now() - start).total_seconds()
+            duration = math.floor(duration * 10) / 10.0  # round to tenths of a second
+            event = {"verb": verb, "url": url, "data": data,
+                     "duration": duration, "status": status, "result": result}
+            if self.recording_enabled:
+                PRINT(f"Recording {verb} {url}")
+                PRINT(json.dumps(event), file=self.recording_fp)
+            else:
+                PRINT(f"{'>' * self.recording_level} NOT recording authorized {verb} {url}")
+            return response
+        except Exception as e:
+            error_type = full_class_name(e)
+            error_message = str(e)
+            duration = (datetime.datetime.now() - start).total_seconds()
+            event = {"verb": verb, "url": url, "data": data,
+                     "duration": duration, "error_type": error_type, "error_message": error_message}
+            if self.recording_enabled:
+                PRINT(f"Recording authorized {verb} {url} error result")
+                PRINT(json.dumps(event), file=self.recording_fp)
+            else:
+                PRINT(f"{'>' * self.recording_level} NOT recording authorized {verb} {url} error result")
+            raise
+
+    @contextlib.contextmanager
+    def setup_replay(self, test_name, mock_time):
+        with controlled_time_mocking(enabled=mock_time) as dt:
+            with io.open(os.path.join(self.recordings_dir, test_name)) as recording_fp:
+                with local_attrs(self, recording_fp=recording_fp, dt=dt):
+                    PRINT()  # Start output on a fresh line
+                    # Read back initial record with sufficient integration context information for replaying
+                    initial_context = self.get_next_json()
+                    yield initial_context
+
+    def do_mocked_replay(self, verb, url, **kwargs):
+        ignored(kwargs)
+        PRINT(f"Replaying {verb} {url}")
+        expected_event = self.get_next_json()
+        expected_verb = expected_event['verb']
+        expected_url = expected_event['url']
+        if verb != expected_verb or url != expected_url:
+            raise AssertionError(f"Actual call {verb} {url} does not match"
+                                 f" expected call {expected_verb} {expected_url}")
+        if expected_event.get('data') != kwargs.get('data'):  # might or might not have data
+            raise AssertionError(f"Data mismatch on call {verb} {url}.")
+        self.dt.sleep(expected_event['duration'])
+        error_message = expected_event.get('error_message')
+        if error_message:
+            raise Exception(error_message)
+        else:
+            return MockResponse(status_code=expected_event['status'], json=expected_event['result'])
+
+    def copy_integrated_ff_masking_credentials(self, integrated_ff):
+        return {
+            "ff_key": {"key": "some-key", "secret": "some-secret", "server": integrated_ff["ff_key"]["server"]},
+            "ff_env": integrated_ff["ff_env"],
+            "ff_env_index_namespace": integrated_ff["ff_env_index_namespace"]
+        }
+
     @contextlib.contextmanager
     def recorded_requests(self, test_name, integrated_ff):
-        with io.open(os.path.join(self.recordings_dir, test_name), 'w') as recording_fp:
+        with self.setup_recording(test_name=test_name,
+                                  initial_context=self.copy_integrated_ff_masking_credentials(integrated_ff)):
 
-            # Write an initial record with sufficient integration context information for replaying
-            PRINT(json.dumps({
-                "ff_key": {"key": "some-key", "secret": "some-secret", "server": integrated_ff["ff_key"]["server"]},
-                "ff_env": integrated_ff["ff_env"],
-                "ff_env_index_namespace": integrated_ff["ff_env_index_namespace"]
-            }), file=recording_fp)
+            def do_request(verb, url, **kwargs):
+                return self.REAL_REQUEST_VERBS[verb](url, **kwargs)
 
             def mock_recorded(verb):
                 def _mocked(url, **kwargs):
-                    start = datetime.datetime.now()
-                    data = kwargs.get('data')
-                    try:
-                        response = self.REAL_REQUEST_VERBS[verb](url, **kwargs)
-                        status = response.status_code
-                        result = response.json()
-                        PRINT(f"Recording {verb} {url}")
-                        duration = (datetime.datetime.now() - start).total_seconds()
-                        duration = math.floor(duration * 10) / 10.0  # round to tenths of a second
-                        event = {"verb": verb, "url": url, "data": data,
-                                 "duration": duration, "status": status, "result": result}
-                        if self.recording_enabled:
-                            PRINT(json.dumps(event), file=recording_fp)
-                        return response
-                    except Exception as e:
-                        error_type = full_class_name(e)
-                        error_message = str(e)
-                        duration = (datetime.datetime.now() - start).total_seconds()
-                        event = {"verb": verb, "url": url, "data": data,
-                                 "duration": duration, "error_type": error_type, "error_message": error_message}
-                        if self.recording_enabled:
-                            PRINT(json.dumps(event), file=recording_fp)
-                        raise
+                    return self.do_mocked_record(action=do_request, verb=verb, url=url, **kwargs)
                 _mocked.__name__ = f"_mocked_{verb}_after_recording"
                 return _mocked
-
-            def mocked_stuff_in_queues(ff_env_index_namespace, check_secondary):
-                # This mock assumes the queue checks don't err. If we find they do, it needs to be a bit more elaborate.
-                start = datetime.datetime.now()
-                result = ff_utils.internal_compute_stuff_in_queues(ff_env_index_namespace=ff_env_index_namespace,
-                                                                   check_secondary=check_secondary)
-                duration = (datetime.datetime.now() - start).total_seconds()
-                duration = math.floor(duration * 10) / 10.0  # round to tenths of a second
-                event = {"verb": 'stuff-in-queues', "url": None,
-                         "data": {"ff_env_index_namespace": ff_env_index_namespace,
-                                  "check_secondary": check_secondary},
-                         "duration": duration, "result": result}
-                if self.recording_enabled:
-                    PRINT(f"Recording stuff-in-queues")
-                    PRINT(json.dumps(event), file=recording_fp)
-                else:
-                    PRINT(f"{'>' * self.recording_level} NOT recording stuff-in-queues")
-                return result
 
             with mocked_authorized_request_verbs(GET=mock_recorded('GET'),
                                                  PATCH=mock_recorded('PATCH'),
                                                  POST=mock_recorded('POST'),
                                                  PUT=mock_recorded('PUT'),
                                                  DELETE=mock_recorded('DELETE')):
-                with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_stuff_in_queues:
-                    mock_stuff_in_queues.side_effect = mocked_stuff_in_queues
+                with self.mock_record_stuff_in_queues():
                     yield
 
     @contextlib.contextmanager
     def replayed_requests(self, test_name, mock_time=True):
-        with controlled_time_mocking(enabled=mock_time) as dt:
-            with io.open(os.path.join(self.recordings_dir, test_name)) as recording_fp:
+        with self.setup_replay(test_name=test_name, mock_time=mock_time) as mocked_integrated_ff:
 
-                PRINT()  # Start output on a fresh line
+            def mock_replayed(verb):
 
-                def get_next_json():
-                    line = recording_fp.readline()
-                    if not line:
-                        raise AssertionError("Out of replayable records.")
-                    parsed_json = json.loads(line)
-                    if parsed_json.get('verb') is None:
-                        PRINT(f"Consuming special non-request replay record.")
-                    else:
-                        PRINT(f"Consuming replay record {parsed_json.get('verb')} {parsed_json.get('url')}")
-                    return parsed_json
+                def _mocked(url, **kwargs):
+                    return self.do_mocked_replay(verb=verb, url=url, **kwargs)
 
-                # Read back initial record with sufficient integration context information for replaying
-                mocked_integrated_ff = get_next_json()
+                _mocked.__name__ = f"_mocked_{verb}_by_replay"
+                return _mocked
 
-                def mock_replayed(verb):
-
-                    def _mocked(url, **kwargs):
-                        ignored(kwargs)
-                        PRINT(f"Replaying {verb} {url}")
-                        expected_event = get_next_json()
-                        expected_verb = expected_event['verb']
-                        expected_url = expected_event['url']
-                        if verb != expected_verb or url != expected_url:
-                            raise AssertionError(f"Actual call {verb} {url} does not match"
-                                                 f" expected call {expected_verb} {expected_url}")
-                        if expected_event.get('data') != kwargs.get('data'):  # might or might not have data
-                            raise AssertionError(f"Data mismatch on call {verb} {url}.")
-                        dt.sleep(expected_event['duration'])
-                        error_message = expected_event.get('error_message')
-                        if error_message:
-                            raise Exception(error_message)
-                        else:
-                            return MockResponse(status_code=expected_event['status'], json=expected_event['result'])
-
-                    _mocked.__name__ = f"_mocked_{verb}_by_replay"
-                    return _mocked
-
-                def mocked_replayed_stuff_in_queues(ff_env_index_namespace, check_secondary):
-                    PRINT(f"Replaying stuff-in-queues {ff_env_index_namespace} {check_secondary}")
-                    verb = 'stuff-in-queues'
-                    expected_event = get_next_json()
-                    expected_verb = expected_event['verb']
-                    if verb != expected_verb:
-                        raise AssertionError(f"Actual call {verb} does not match expected call {expected_verb}")
-                    dt.sleep(expected_event['duration'])
-                    error_message = expected_event.get('error_message')
-                    if error_message:
-                        raise Exception(error_message)
-                    else:
-                        return expected_event['result']
-
-                with mocked_authorized_request_verbs(GET=mock_replayed('GET'),
-                                                     PATCH=mock_replayed('PATCH'),
-                                                     POST=mock_replayed('POST'),
-                                                     PUT=mock_replayed('PUT'),
-                                                     DELETE=mock_replayed('DELETE')):
-                    with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_replayed_stuff_in_queues:
-                        mock_replayed_stuff_in_queues.side_effect = mocked_replayed_stuff_in_queues
-                        yield mocked_integrated_ff
+            with mocked_authorized_request_verbs(GET=mock_replayed('GET'),
+                                                 PATCH=mock_replayed('PATCH'),
+                                                 POST=mock_replayed('POST'),
+                                                 PUT=mock_replayed('PUT'),
+                                                 DELETE=mock_replayed('DELETE')):
+                with self.mock_replay_stuff_in_queues():
+                    yield mocked_integrated_ff
 
     @contextlib.contextmanager
     def recorded_authorized_requests(self, test_name, integrated_ff):
-        with io.open(os.path.join(self.recordings_dir, test_name), 'w') as recording_fp:
+        with self.setup_recording(test_name=test_name,
+                                  initial_context=self.copy_integrated_ff_masking_credentials(integrated_ff)):
 
-            # Write an initial record with sufficient integration context information for replaying
-            PRINT(json.dumps({
-                "ff_key": {"key": "some-key", "secret": "some-secret", "server": integrated_ff["ff_key"]["server"]},
-                "ff_env": integrated_ff["ff_env"],
-                "ff_env_index_namespace": integrated_ff["ff_env_index_namespace"]
-            }), file=recording_fp)
+            def do_authorized_request(verb, url, **kwargs):
+                return ff_utils.internal_compute_authorized_request(url, verb=verb, **kwargs)
 
             def mocked_authorized_request(url, *, verb, **kwargs):
-                start = datetime.datetime.now()
-                data = kwargs.get('data')
-                try:
-                    with self.creating_record():
-                        response = ff_utils.internal_compute_authorized_request(url, verb=verb, **kwargs)
-                    status = response.status_code
-                    result = response.json()
-                    duration = (datetime.datetime.now() - start).total_seconds()
-                    duration = math.floor(duration * 10) / 10.0  # round to tenths of a second
-                    event = {"verb": verb, "url": url, "data": data,
-                             "duration": duration, "status": status, "result": result}
-                    if self.recording_enabled:
-                        PRINT(f"Recording authorized {verb} {url}")
-                        PRINT(json.dumps(event), file=recording_fp)
-                    else:
-                        PRINT(f"{'>' * self.recording_level} NOT recording authorized {verb} {url}")
-                    return response
-                except Exception as e:
-                    error_type = full_class_name(e)
-                    error_message = str(e)
-                    duration = (datetime.datetime.now() - start).total_seconds()
-                    event = {"verb": verb, "url": url, "data": data,
-                             "duration": duration, "error_type": error_type, "error_message": error_message}
-                    if self.recording_enabled:
-                        PRINT(f"Recording authorized {verb} {url} error result")
-                        PRINT(json.dumps(event), file=recording_fp)
-                    else:
-                        PRINT(f"{'>' * self.recording_level} NOT recording authorized {verb} {url} error result")
-                    raise
-
-            def mocked_stuff_in_queues(ff_env_index_namespace, check_secondary):
-                # This mock assumes the queue checks don't err. If we find they do, it needs to be a bit more elaborate.
-                start = datetime.datetime.now()
-                result = ff_utils.internal_compute_stuff_in_queues(ff_env_index_namespace=ff_env_index_namespace,
-                                                                   check_secondary=check_secondary)
-                duration = (datetime.datetime.now() - start).total_seconds()
-                duration = math.floor(duration * 10) / 10.0  # round to tenths of a second
-                event = {"verb": 'stuff-in-queues', "url": None,
-                         "data": {"ff_env_index_namespace": ff_env_index_namespace,
-                                  "check_secondary": check_secondary},
-                         "duration": duration, "result": result}
-                if self.recording_enabled:
-                    PRINT(f"Recording stuff-in-queues")
-                    PRINT(json.dumps(event), file=recording_fp)
-                else:
-                    PRINT(f"{'>' * self.recording_level} NOT recording stuff-in-queues")
-                return result
+                return self.do_mocked_record(action=do_authorized_request, verb=verb, url=url, **kwargs)
 
             with mock.patch.object(ff_utils, "mockable_authorized_request") as mock_authorized_request:
-                with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_stuff_in_queues:
-                    mock_authorized_request.side_effect = mocked_authorized_request
-                    mock_stuff_in_queues.side_effect = mocked_stuff_in_queues
+                mock_authorized_request.side_effect = mocked_authorized_request
+                with self.mock_record_stuff_in_queues():
                     yield
 
     @contextlib.contextmanager
     def replayed_authorized_requests(self, test_name, mock_time=False):
-        with controlled_time_mocking(enabled=mock_time) as dt:
-            with io.open(os.path.join(self.recordings_dir, test_name)) as recording_fp:
+        with self.setup_replay(test_name=test_name, mock_time=mock_time) as mocked_integrated_ff:
 
-                PRINT()  # Start output on a fresh line
+            def mocked_replayed_authorized_request(url, *, verb, **kwargs):
+                return self.do_mocked_replay(verb=verb, url=url, **kwargs)
 
-                def get_next_json():
-                    line = recording_fp.readline()
-                    if not line:
-                        raise AssertionError("Out of replayable records.")
-                    parsed_json = json.loads(line)
-                    if parsed_json.get('verb') is None:
-                        PRINT(f"Consuming special non-request replay record.")
-                    else:
-                        PRINT(f"Consuming replay record {parsed_json.get('verb')} {parsed_json.get('url')}")
-                    return parsed_json
-
-                # Read back initial record with sufficient integration context information for replaying
-                mocked_integrated_ff = get_next_json()
-
-                def mocked_replayed_authorized_request(url, *, verb, **kwargs):
-                    ignored(kwargs)
-                    PRINT(f"Replaying {verb} {url}")
-                    expected_event = get_next_json()
-                    expected_verb = expected_event['verb']
-                    expected_url = expected_event['url']
-                    if verb != expected_verb or url != expected_url:
-                        raise AssertionError(f"Actual call {verb} {url} does not match"
-                                             f" expected call {expected_verb} {expected_url}")
-                    if expected_event.get('data') != kwargs.get('data'):  # might or might not have data
-                        raise AssertionError(f"Data mismatch on call {verb} {url}.")
-                    dt.sleep(expected_event['duration'])
-                    error_message = expected_event.get('error_message')
-                    if error_message:
-                        raise Exception(error_message)
-                    else:
-                        return MockResponse(status_code=expected_event['status'], json=expected_event['result'])
-
-                def mocked_replayed_stuff_in_queues(ff_env_index_namespace, check_secondary):
-                    PRINT(f"Replaying stuff-in-queues {ff_env_index_namespace} {check_secondary}")
-                    verb = 'stuff-in-queues'
-                    expected_event = get_next_json()
-                    expected_verb = expected_event['verb']
-                    if verb != expected_verb:
-                        raise AssertionError(f"Actual call {verb} does not match expected call {expected_verb}")
-                    dt.sleep(expected_event['duration'])
-                    error_message = expected_event.get('error_message')
-                    if error_message:
-                        raise Exception(error_message)
-                    else:
-                        return expected_event['result']
-
-                with mock.patch.object(ff_utils, "mockable_authorized_request") as mock_authorized_request:
-                    with mock.patch.object(ff_utils, "mockable_stuff_in_queues") as mock_stuff_in_queues:
-                        mock_authorized_request.side_effect = mocked_replayed_authorized_request
-                        mock_stuff_in_queues.side_effect = mocked_replayed_stuff_in_queues
-                        yield mocked_integrated_ff
+            with mock.patch.object(ff_utils, "mockable_authorized_request") as mock_authorized_request:
+                mock_authorized_request.side_effect = mocked_replayed_authorized_request
+                with self.mock_replay_stuff_in_queues():
+                    yield mocked_integrated_ff
 
 
 def _portal_health_get(namespace, portal_url, key):

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -12,7 +12,7 @@ from dcicutils.env_utils import EnvUtils, full_env_name, is_stg_or_prd_env
 from dcicutils.ff_utils import authorized_request
 from dcicutils.lang_utils import disjoined_list, conjoined_list
 from dcicutils.misc_utils import (
-    ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool, local_attrs
+    ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool, local_attrs, check_true,
 )
 from dcicutils.qa_utils import (
     MockBoto3, MockBotoElasticBeanstalkClient, MockBotoS3Client, ControlledTime, MockResponse,
@@ -572,6 +572,18 @@ class AbstractTestRecorder:
             raise Exception(error_message)
         else:
             return MockResponse(status_code=expected_event['status'], json=expected_event['result'])
+
+    @contextlib.contextmanager
+    def recorded_requests(self, test_name, initial_context):
+        ignored(test_name, initial_context)
+        raise NotImplementedError("AbstractTestRecorder.recorded_requests needs to be customized in a subclass.")
+        yield  # noQA - Yes, it's not reachable, but the function still needs to yield
+
+    @contextlib.contextmanager
+    def replayed_requests(self, test_name, mock_time=False):
+        ignored(test_name, mock_time)
+        raise NotImplementedError("AbstractTestRecorder.replayed_requests needs to be customized in a subclass.")
+        yield  # noQA - Yes, it's not reachable, but the function still needs to yield
 
 
 class IntegratedTestRecorder(AbstractTestRecorder):

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -35,7 +35,9 @@ _MOCK_APPLICATION_OPTIONS_PARTIAL = (
 NO_SERVER_FIXTURES = environ_bool("NO_SERVER_FIXTURES")
 
 
+# TODO: I don't think anything is using this class. -kmp 2-Oct-2022
 class MockBoto4DNLegacyElasticBeanstalkClient(MockBotoElasticBeanstalkClient):  # noQA - missing some abstract methods
+    """Deprecated test class. This will go away in the future. If you're using that, make sure the dev team knows."""
 
     DEFAULT_MOCKED_BEANSTALKS = [
         make_mock_beanstalk("fourfront-cgapdev"),

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -481,8 +481,9 @@ class AbstractTestRecorder:
         verb = 'stuff-in-queues'
         expected_event = self.get_next_json()
         expected_verb = expected_event['verb']
+        expected_url = expected_event.get('url')
         if verb != expected_verb:
-            raise AssertionError(f"Actual call {verb} does not match expected call {expected_verb}")
+            raise AssertionError(f"Actual call {verb} does not match expected call {expected_verb} {expected_url}")
         self.dt.sleep(expected_event['duration'])
         error_message = expected_event.get('error_message')
         if error_message:

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -577,13 +577,13 @@ class AbstractTestRecorder:
     def recorded_requests(self, test_name, initial_context):
         ignored(test_name, initial_context)
         raise NotImplementedError("AbstractTestRecorder.recorded_requests needs to be customized in a subclass.")
-        yield  # noQA - Yes, it's not reachable, but the function still needs to yield
+        yield  # noQA - Yes, it's not reachable, but the function still needs to yield. Also: # pragma: no cover
 
     @contextlib.contextmanager
     def replayed_requests(self, test_name, mock_time=False):
         ignored(test_name, mock_time)
         raise NotImplementedError("AbstractTestRecorder.replayed_requests needs to be customized in a subclass.")
-        yield  # noQA - Yes, it's not reachable, but the function still needs to yield
+        yield  # noQA - Yes, it's not reachable, but the function still needs to yield. Also: # pragma: no cover
 
 
 class IntegratedTestRecorder(AbstractTestRecorder):

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -12,7 +12,7 @@ from dcicutils.env_utils import EnvUtils, full_env_name, is_stg_or_prd_env
 from dcicutils.ff_utils import authorized_request
 from dcicutils.lang_utils import disjoined_list, conjoined_list
 from dcicutils.misc_utils import (
-    ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool, local_attrs, check_true,
+    ignored, override_environ, remove_prefix, full_class_name, PRINT, environ_bool, local_attrs,
 )
 from dcicutils.qa_utils import (
     MockBoto3, MockBotoElasticBeanstalkClient, MockBotoS3Client, ControlledTime, MockResponse,

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1265,7 +1265,7 @@ def get_authentication_with_server(auth=None, ff_env=None):
     return auth
 
 
-def stuff_in_queues(ff_env_index_namespace, check_secondary=False):
+def stuff_in_queues(ff_env_index_namespace, check_secondary=False) -> bool:
     """
     Used to guarantee up-to-date metadata by checking the contents of the indexer queues.
     If items are currently waiting in the primary queue, return False.
@@ -1274,12 +1274,12 @@ def stuff_in_queues(ff_env_index_namespace, check_secondary=False):
     return mockable_stuff_in_queues(ff_env_index_namespace=ff_env_index_namespace, check_secondary=check_secondary)
 
 
-def mockable_stuff_in_queues(ff_env_index_namespace, check_secondary):
+def mockable_stuff_in_queues(ff_env_index_namespace, check_secondary) -> bool:
     return internal_compute_stuff_in_queues(ff_env_index_namespace=ff_env_index_namespace,
                                             check_secondary=check_secondary)
 
 
-def internal_compute_stuff_in_queues(ff_env_index_namespace, check_secondary):
+def internal_compute_stuff_in_queues(ff_env_index_namespace, check_secondary) -> bool:
     if not ff_env_index_namespace:
         raise ValueError(f"Must provide a full fourfront environment name to this function"
                          f" (such as 'fourfront-webdev'). You gave: {ff_env_index_namespace!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,12 @@ norecursedirs = ["*env", "site-packages", ".cache", ".git", ".idea", "*.egg-info
 # pep8maxlinelength = 120
 testpaths = ["test"]
 
+[tool.coverage.report]
+# https://coverage.readthedocs.io/en/latest/config.html
+exclude_lines = [
+  "if __name__ == .__main__.:",
+  "pragma: no cover"
+]
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.0.2b0"
+version = "5.2.0.2b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.1.2b4"  # to become 5.3.0
+version = "5.3.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.1.2b2"
+version = "5.2.1.2b3"  # to become 5.3.0
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.0.1b0"
+version = "5.2.0.2b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "5.2.1.2b3"  # to become 5.3.0
+version = "5.2.1.2b4"  # to become 5.3.0
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -6,12 +6,13 @@ import pytest
 from dcicutils import ff_mocks as ff_mocks_module, ff_utils as ff_utils_module
 from dcicutils.ff_utils import stuff_in_queues
 from dcicutils.ff_mocks import (
-    AbstractIntegratedFixture, AbstractTestRecorder, IntegratedTestRecorder,
+    AbstractIntegratedFixture, AbstractTestRecorder, IntegratedTestRecorder, TestScenarios,
     mocked_authorized_request_verbs, controlled_time_mocking,
 )
 from dcicutils.misc_utils import ignored, local_attrs, PRINT
 from dcicutils.qa_utils import MockResponse, MockFileSystem, ControlledTime, printed_output
 from unittest import mock
+from .helpers import using_fresh_legacy_state_for_testing
 
 
 def test_abstract_integrated_fixture_no_server_fixtures():
@@ -468,3 +469,48 @@ def test_mocked_replay():
     with pytest.raises(AssertionError) as exc:
         r.do_mocked_replay(verb='POST', url="http://foo", data='something-else')
     assert str(exc.value) == "Data mismatch on call POST http://foo."
+
+
+@using_fresh_legacy_state_for_testing()
+def test_test_scenario_methods():
+
+    assert TestScenarios.mocked_auth_key('foo') == 'fookey'
+    assert TestScenarios.mocked_auth_key('fourfront-foo') == 'fookey'
+    assert TestScenarios.mocked_auth_key('fourfront-cgapfoo') == 'cgapfookey'
+    assert TestScenarios.mocked_auth_key('cgap-foo') == 'cgap-fookey'
+
+    assert TestScenarios.mocked_auth_secret('foo') == 'foosecret'
+    assert TestScenarios.mocked_auth_secret('fourfront-foo') == 'foosecret'
+    assert TestScenarios.mocked_auth_secret('fourfront-cgapfoo') == 'cgapfoosecret'
+    assert TestScenarios.mocked_auth_secret('cgap-foo') == 'cgap-foosecret'
+
+    assert TestScenarios.mocked_auth_server('foo') == 'http://foo.4dnucleome.org/'
+    assert TestScenarios.mocked_auth_server('fourfront-foo') == 'http://foo.4dnucleome.org/'
+    assert TestScenarios.mocked_auth_server('fourfront-cgapfoo') == 'http://cgapfoo.4dnucleome.org/'
+    assert TestScenarios.mocked_auth_server('cgap-foo') == 'http://cgap-foo.4dnucleome.org/'
+
+    assert TestScenarios.mocked_auth_key_secret_tuple('foo') == ('fookey', 'foosecret')
+    assert TestScenarios.mocked_auth_key_secret_tuple('fourfront-foo') == ('fookey', 'foosecret')
+    assert TestScenarios.mocked_auth_key_secret_tuple('fourfront-cgapfoo') == ('cgapfookey', 'cgapfoosecret')
+    assert TestScenarios.mocked_auth_key_secret_tuple('cgap-foo') == ('cgap-fookey', 'cgap-foosecret')
+
+    assert TestScenarios.mocked_auth_key_secret_server_dict('foo') == {
+        'key': 'fookey',
+        'secret': 'foosecret',
+        'server': 'http://foo.4dnucleome.org/',
+    }
+    assert TestScenarios.mocked_auth_key_secret_server_dict('fourfront-foo') == {
+        'key': 'fookey',
+        'secret': 'foosecret',
+        'server': 'http://foo.4dnucleome.org/',
+    }
+    assert TestScenarios.mocked_auth_key_secret_server_dict('fourfront-cgapfoo') == {
+        'key': 'cgapfookey',
+        'secret': 'cgapfoosecret',
+        'server': 'http://cgapfoo.4dnucleome.org/',
+    }
+    assert TestScenarios.mocked_auth_key_secret_server_dict('cgap-foo') == {
+        'key': 'cgap-fookey',
+        'secret': 'cgap-foosecret',
+        'server': 'http://cgap-foo.4dnucleome.org/',
+    }

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -1,5 +1,9 @@
+import pytest
+
 from dcicutils import ff_mocks as ff_mocks_module
 from dcicutils.ff_mocks import AbstractIntegratedFixture
+from dcicutils.misc_utils import ignored
+# from dcicutils.s3_utils import s3Utils
 from unittest import mock
 
 
@@ -8,3 +12,41 @@ def test_abstract_integrated_fixture_no_server_fixtures():
     with mock.patch.object(ff_mocks_module, "NO_SERVER_FIXTURES"):  # too late to set env variable, but this'll do.
         assert AbstractIntegratedFixture._initialize_class() == 'NO_SERVER_FIXTURES'  # noQA - yes, it's protected
         assert AbstractIntegratedFixture.verify_portal_access('not-a-dictionary') == 'NO_SERVER_FIXTURES'
+
+
+def test_abstract_integrated_fixture_misc():
+
+    with mock.patch.object(AbstractIntegratedFixture, "_initialize_class"):
+        fixture = AbstractIntegratedFixture(name='foo')
+        fixture.S3_CLIENT = mock.MagicMock()
+
+        sample_portal_access_key = {'key': 'abc', 'secret': 'shazam', 'server': 'http://genes.example.com/'}
+        sample_higlass_access_key = {'key': 'xyz', 'secret': 'bingo', 'server': 'http://higlass.genes.example.com/'}
+
+        fixture.S3_CLIENT.get_access_keys.return_value = sample_portal_access_key
+        assert fixture.portal_access_key() == sample_portal_access_key
+
+        fixture.S3_CLIENT.get_higlass_key.return_value = sample_higlass_access_key
+        assert fixture.higlass_access_key() == sample_higlass_access_key
+
+        fixture.INTEGRATED_FF_ITEMS = {'alpha': 'a', 'beta': 'b', 'some_key': '99999'}
+        assert fixture['alpha'] == 'a'
+        assert fixture['beta'] == 'b'
+        with pytest.raises(Exception):
+            ignored(fixture['gamma'])
+        assert fixture['self'] == fixture
+
+        with mock.patch.object(ff_mocks_module, "id", lambda _: "1234"):
+            assert str(fixture) == ("{'self': <AbstractIntegratedFixture 'foo' 1234>,"
+                                    " 'alpha': 'a',"
+                                    " 'beta': 'b',"
+                                    " 'some_key': <redacted>"
+                                    "}")
+
+        assert repr(fixture) == "AbstractIntegratedFixture(name='foo')"
+
+        class MyIntegratedFixture(AbstractIntegratedFixture):
+            pass
+
+        assert repr(MyIntegratedFixture('bar')) == "MyIntegratedFixture(name='bar')"
+

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -49,4 +49,3 @@ def test_abstract_integrated_fixture_misc():
             pass
 
         assert repr(MyIntegratedFixture('bar')) == "MyIntegratedFixture(name='bar')"
-

--- a/test/test_ff_mocks.py
+++ b/test/test_ff_mocks.py
@@ -1,8 +1,9 @@
 import pytest
 
 from dcicutils import ff_mocks as ff_mocks_module
-from dcicutils.ff_mocks import AbstractIntegratedFixture
+from dcicutils.ff_mocks import AbstractIntegratedFixture, AbstractTestRecorder
 from dcicutils.misc_utils import ignored
+from dcicutils.qa_utils import MockResponse
 # from dcicutils.s3_utils import s3Utils
 from unittest import mock
 
@@ -26,6 +27,8 @@ def test_abstract_integrated_fixture_misc():
         fixture.S3_CLIENT.get_access_keys.return_value = sample_portal_access_key
         assert fixture.portal_access_key() == sample_portal_access_key
 
+        env_name = 'fourfront-foobar'
+        fixture.__class__.ENV_NAME = env_name
         fixture.S3_CLIENT.get_higlass_key.return_value = sample_higlass_access_key
         assert fixture.higlass_access_key() == sample_higlass_access_key
 
@@ -45,7 +48,28 @@ def test_abstract_integrated_fixture_misc():
 
         assert repr(fixture) == "AbstractIntegratedFixture(name='foo')"
 
+        with mock.patch.object(ff_mocks_module, "authorized_request") as mock_authorized_request:
+            # Code 418 = "I'm a teapot", which is at least good for testing.
+            mock_authorized_request.return_value = MockResponse(status_code=418)
+            with pytest.raises(Exception) as exc:
+                assert fixture.verify_portal_access({'server': 'http://server.not.available'})
+            assert str(exc.value) == (f'Environment {env_name} is not ready for integrated status.'
+                                      f' Requesting the homepage gave status of: 418')
+
         class MyIntegratedFixture(AbstractIntegratedFixture):
             pass
 
         assert repr(MyIntegratedFixture('bar')) == "MyIntegratedFixture(name='bar')"
+
+
+def test_abstract_test_recorder_misc():
+
+    r = AbstractTestRecorder()
+
+    with pytest.raises(NotImplementedError):
+        with r.recorded_requests('foo', None):
+            pass
+
+    with pytest.raises(NotImplementedError):
+        with r.replayed_requests('foo', None):
+            pass

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -9,7 +9,7 @@ import time
 
 from botocore.exceptions import ClientError
 from dcicutils import es_utils, ff_utils, s3_utils
-from dcicutils.ff_mocks import mocked_s3utils, TestScenarios, TestRecorder
+from dcicutils.ff_mocks import mocked_s3utils, TestScenarios, RequestsTestRecorder
 from dcicutils.misc_utils import make_counter, remove_prefix, remove_suffix, check_true
 from dcicutils.qa_utils import (
     check_duplicated_items_by_key, ignored, raises_regexp, MockResponse, MockBoto3, MockBotoSQSClient,
@@ -696,7 +696,7 @@ SAMPLE_RECORD = {
 @pytest.mark.integratedx
 @pytest.mark.flaky
 def test_post_delete_purge_links_metadata_integrated(integrated_ff):
-    with TestRecorder().recorded_requests('test_post_delete_purge_links_metadata', integrated_ff):
+    with RequestsTestRecorder().recorded_requests('test_post_delete_purge_links_metadata', integrated_ff):
         check_post_delete_purge_links_metadata(integrated_ff)
 
 
@@ -704,7 +704,7 @@ def test_post_delete_purge_links_metadata_integrated(integrated_ff):
 def test_post_delete_purge_links_metadata_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
     # so it's best to just let it run at the rate it wants to run at. That seems to make it pass. -kmp 15-May-2022
-    with TestRecorder().replayed_requests('test_post_delete_purge_links_metadata') as mocked_integrated_ff:
+    with RequestsTestRecorder().replayed_requests('test_post_delete_purge_links_metadata') as mocked_integrated_ff:
         check_post_delete_purge_links_metadata(mocked_integrated_ff)
 
 
@@ -778,7 +778,7 @@ def check_post_delete_purge_links_metadata(integrated_ff):
 @pytest.mark.integratedx
 @pytest.mark.flaky
 def test_upsert_metadata_integrated(integrated_ff):
-    with TestRecorder().recorded_requests('test_upsert_metadata', integrated_ff):
+    with RequestsTestRecorder().recorded_requests('test_upsert_metadata', integrated_ff):
         check_upsert_metadata(integrated_ff)
 
 
@@ -786,7 +786,7 @@ def test_upsert_metadata_integrated(integrated_ff):
 def test_upsert_metadata_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
     # so it's best to just let it run at the rate it wants to run at. That seems to make it pass. -kmp 15-May-2022
-    with TestRecorder().replayed_requests('test_upsert_metadata') as mocked_integrated_ff:
+    with RequestsTestRecorder().replayed_requests('test_upsert_metadata') as mocked_integrated_ff:
         check_upsert_metadata(mocked_integrated_ff)
 
 
@@ -1308,7 +1308,7 @@ def test_get_search_facet_values(integrated_ff):
 @pytest.mark.integratedx
 @pytest.mark.flaky
 def test_faceted_search_exp_set_integrated(integrated_ff):
-    with TestRecorder().recorded_requests('test_faceted_search_exp_set', integrated_ff):
+    with RequestsTestRecorder().recorded_requests('test_faceted_search_exp_set', integrated_ff):
         check_faceted_search_exp_set(integrated_ff)
 
 
@@ -1316,7 +1316,7 @@ def test_faceted_search_exp_set_integrated(integrated_ff):
 def test_faceted_search_exp_set_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
     # so it's best to just let it run at the rate it wants to run at. That seems to make it pass. -kmp 15-May-2022
-    with TestRecorder().replayed_requests('test_faceted_search_exp_set') as mocked_integrated_ff:
+    with RequestsTestRecorder().replayed_requests('test_faceted_search_exp_set') as mocked_integrated_ff:
         check_faceted_search_exp_set(mocked_integrated_ff)
 
 
@@ -1442,7 +1442,7 @@ def check_faceted_search_exp_set(integrated_ff):
 @pytest.mark.integratedx
 @pytest.mark.flaky
 def test_faceted_search_users_integrated(integrated_ff):
-    with TestRecorder().recorded_requests('test_faceted_search_users', integrated_ff):
+    with RequestsTestRecorder().recorded_requests('test_faceted_search_users', integrated_ff):
         check_faceted_search_users(integrated_ff)
 
 
@@ -1450,7 +1450,7 @@ def test_faceted_search_users_integrated(integrated_ff):
 def test_faceted_search_users_unit():
     # This test is quite time-dependent, and using ControlledTime does not seem to sufficiently mock that,
     # so it's best to just let it run at the rate it wants to run at. That seems to make it pass. -kmp 15-May-2022
-    with TestRecorder().replayed_requests('test_faceted_search_users') as mocked_integrated_ff:
+    with RequestsTestRecorder().replayed_requests('test_faceted_search_users') as mocked_integrated_ff:
         check_faceted_search_users(mocked_integrated_ff)
 
 


### PR DESCRIPTION
This refactors the test recording technology so that it would be easier to make more kinds (e.g., if we want something to use in `cgap-portal`). It may have to still change more later, but @willronchetti and I talked about it and agreed it's better just to freeze it its current form for now so it gets into master and doesn't stuffer bit rot, and worry about that later.