### PR TITLE
Minor fix to override_dict for overriding os.environ value with non-str type.

### DIFF
--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -956,6 +956,10 @@ def override_dict(d, **overrides):
             if v is None:
                 d.pop(k, None)  # Delete key k, tolerating it being already gone
             else:
+                # If the value is not a string and the target dictionary is os.environ
+                # then cast the value to a string as os.environ values can only be strings.
+                if not isinstance(v, str) and d == os.environ:
+                    v = str(v)
                 d[k] = v
         yield
     finally:

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -958,7 +958,7 @@ def override_dict(d, **overrides):
             else:
                 # If the value is not a string and the target dictionary is os.environ
                 # then cast the value to a string as os.environ values can only be strings.
-                if not isinstance(v, str) and d == os.environ:
+                if not isinstance(v, str) and d is os.environ:
                     v = str(v)
                 d[k] = v
         yield


### PR DESCRIPTION
This came up in 4dn-cloud-infra where custom/config.json had a non-string value (e.g. `s3.bucket.encryption` set to `false`).