### PR TITLE
Fixes related to qa_utils.Eventually (C4-983)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Change Log
 ----------
 
 
-6.6.1
+6.7.0
 =====
 
 * In ``dcicutils.qa_utils``:
@@ -24,6 +24,11 @@ Change Log
   * Add a method ``consistent`` that is a class method / decorator (named ``Eventually.consistent``).
 
   * Add testing, particularly of the timing.
+
+* In ``dcicutils.cloudformation_utils``:
+
+  * When searching for checkrunners, be more forgiving about abbreviations for development (dev)
+    and production (prd, prod).
 
 
 6.6.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Change Log
 ----------
 
 
+6.6.1
+=====
+
+* In ``dcicutils.qa_utils``, make the ``error_message`` argument
+  to ``Eventually.call_assertion`` actually work.
+
+
 6.6.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Change Log
 
     * Fix a bug where it didn't wait between iterations.
 
-  * Add a method ``consistent`` that is a class method / decorator.
+  * Add a method ``consistent`` that is a class method / decorator (named ``Eventually.consistent``).
 
   * Add testing, particularly of the timing.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,20 @@ Change Log
 6.6.1
 =====
 
-* In ``dcicutils.qa_utils``, make the ``error_message`` argument
-  to ``Eventually.call_assertion`` actually work.
+* In ``dcicutils.qa_utils``:
+
+  * For method ``Eventually_call_assertion``:
+
+    * Make the ``error_message=`` argument actually work.
+
+    * The ``threshold_seconds=`` argument is now deprecated.
+      Please prefer ``tries=`` and/or ``wait_seconds=``.
+
+    * Fix a bug where it didn't wait between iterations.
+
+  * Add a method ``consistent`` that is a class method / decorator.
+
+  * Add testing, particularly of the timing.
 
 
 6.6.0

--- a/dcicutils/cloudformation_utils.py
+++ b/dcicutils/cloudformation_utils.py
@@ -261,8 +261,8 @@ class AbstractOrchestrationManager:
             lambda_response = lambda_client.list_functions(Marker=lambda_response_next_marker)
         return matching_function_names
 
-    CHECK_RUNNER_DEV_PATTERN = re.compile(".*foursight.*development.*CheckRunner.*")
-    CHECK_RUNNER_PROD_PATTERN = re.compile(".*foursight.*production.*CheckRunner.*")
+    CHECK_RUNNER_DEV_PATTERN = re.compile(".*foursight.*dev(elopment)?.*CheckRunner.*")   # match dev, development
+    CHECK_RUNNER_PROD_PATTERN = re.compile(".*foursight.*pro?d(uction)?.*CheckRunner.*")  # match prd, prod, production
 
     ENCACHE_RUNNER_NAME = True
 

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -13,6 +13,7 @@ import logging
 import os
 import pytest
 import pytz
+import re
 import sys
 import time
 import uuid
@@ -2659,11 +2660,12 @@ class Eventually:
         for _ in range(threshold_seconds):
             try:
                 assertion_function()
+                break
             except error_class as e:
                 msg = get_error_message(e)
+                if error_message and not re.search(error_message, msg):
+                    raise
                 PRINT(msg)
                 errors.append(msg)
-            else:
-                break
         else:
             raise AssertionError(f"Eventual consistency not achieved after {threshold_seconds} seconds.")

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2697,8 +2697,7 @@ class Eventually:
         errors = []
         for _ in range(tries):
             try:
-                assertion_function()
-                break
+                return assertion_function()
             except error_class as e:
                 msg = get_error_message(e)
                 if error_message and not re.search(error_message, msg):
@@ -2742,11 +2741,11 @@ class Eventually:
 
             @functools.wraps(fn)
             def _wrapped(error_message=None, error_class=None, tries=None, wait_seconds=None):
-                cls.call_assertion(fn,
-                                   error_message=error_message or default_error_message,
-                                   error_class=error_class or default_error_class,
-                                   tries=tries or default_tries,
-                                   wait_seconds=wait_seconds or default_wait_seconds)
+                return cls.call_assertion(fn,
+                                          error_message=error_message or default_error_message,
+                                          error_class=error_class or default_error_class,
+                                          tries=tries or default_tries,
+                                          wait_seconds=wait_seconds or default_wait_seconds)
 
             return _wrapped
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "6.6.0"
+version = "6.6.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "6.6.1"
+version = "6.6.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "6.6.0.1b0"
+version = "6.6.0.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "6.6.0.1b1"
+version = "6.7.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1705,4 +1705,21 @@ def test_eventually():
     with pytest.raises(AssertionError):
         Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency - 1, error_class=Exception)
 
-    Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency, error_class=Exception)
+    # Beyond here we're testing the error_message="something" argument,
+    # which allows us to only wait for a specific eventual message.
+
+    def test_error_message_argument(*, expected_message=None):
+        Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency, error_class=Exception,
+                                  error_message=expected_message)
+
+    actual_message = "Oops. Occasionally this fails."
+
+    test_error_message_argument()
+
+    test_error_message_argument(expected_message=actual_message)
+
+    with pytest.raises(Exception) as e:
+        # If we're Eventually expecting an unrelated message,
+        # the actual error we get will just pass through and won't be retried.
+        test_error_message_argument(expected_message="SOME OTHER MESSAGE")
+    assert str(e.value) == actual_message

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1779,3 +1779,13 @@ def test_eventually():
 
             delta3 = after3 - before3  # 100 tries * 0.1 sec plus 1 sec to check current time, so about 11 sec
             assert delta3 > ten_seconds
+
+            class MyStore:
+                VALUE = 0
+
+            @Eventually.consistent()
+            def foo():
+                MyStore.VALUE += 1
+                return MyStore.VALUE
+
+            assert foo(tries=3) == 1  # The value will increment exactly once because it succeeds first try.

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1692,34 +1692,90 @@ def test_mock_id():
 
 def test_eventually():
 
-    def foo():
-        return 17
+    dt = ControlledTime()
+    with mock.patch("datetime.datetime", dt):
+        with mock.patch("time.sleep", dt.sleep):
 
-    flakey_success_frequency = 3
+            def foo():
+                return 17
 
-    flakey_foo = Occasionally(foo, success_frequency=flakey_success_frequency)
+            flakey_success_frequency = 3
 
-    def my_assertions():
-        assert flakey_foo() == 17
+            flakey_foo = Occasionally(foo, success_frequency=flakey_success_frequency)
 
-    with pytest.raises(AssertionError):
-        Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency - 1, error_class=Exception)
+            def my_assertions():
+                assert flakey_foo() == 17
 
-    # Beyond here we're testing the error_message="something" argument,
-    # which allows us to only wait for a specific eventual message.
+            with pytest.raises(AssertionError):
+                Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency - 1,
+                                          error_class=Exception)
 
-    def test_error_message_argument(*, expected_message=None):
-        Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency, error_class=Exception,
-                                  error_message=expected_message)
+            # Beyond here we're testing the error_message="something" argument,
+            # which allows us to only wait for a specific eventual message.
 
-    actual_message = "Oops. Occasionally this fails."
+            def test_error_message_argument(*, expected_message=None):
+                Eventually.call_assertion(my_assertions, threshold_seconds=flakey_success_frequency,
+                                          error_class=Exception,
+                                          error_message=expected_message)
 
-    test_error_message_argument()
+            actual_message = "Oops. Occasionally this fails."
 
-    test_error_message_argument(expected_message=actual_message)
+            test_error_message_argument()
 
-    with pytest.raises(Exception) as e:
-        # If we're Eventually expecting an unrelated message,
-        # the actual error we get will just pass through and won't be retried.
-        test_error_message_argument(expected_message="SOME OTHER MESSAGE")
-    assert str(e.value) == actual_message
+            test_error_message_argument(expected_message=actual_message)
+
+            with pytest.raises(Exception) as e:
+                # If we're Eventually expecting an unrelated message,
+                # the actual error we get will just pass through and won't be retried.
+                test_error_message_argument(expected_message="SOME OTHER MESSAGE")
+            assert str(e.value) == actual_message
+
+            # Here we want to test how much time passes if all tests are tried.
+            # The default is 10 tries at 1-second intervals, so should be at least 10 seconds.
+
+            one_second = dt.timedelta(seconds=1)
+            five_seconds = dt.timedelta(seconds=5)
+            ten_seconds = dt.timedelta(seconds=10)
+            before = dt.now()
+
+            def always_failing():
+                raise AssertionError("Failed.")
+
+            with pytest.raises(Exception):
+                Eventually.call_assertion(always_failing)
+
+            after = dt.now()
+            delta = after - before
+            assert delta >= ten_seconds
+
+            @Eventually.consistent()
+            def also_failing():
+                raise AssertionError("Also failed.")
+
+            before = dt.now()
+            with pytest.raises(AssertionError):
+                also_failing()
+            after = dt.now()
+            delta = after - before  # 10 secs for the computation plus 1 sec to check current time, so about 11 secs
+            assert delta > ten_seconds
+
+            @Eventually.consistent(wait_seconds=0.1)
+            def quickly_failing():
+                raise AssertionError("Also failed.")
+
+            before2 = dt.now()
+            with pytest.raises(AssertionError):
+                quickly_failing()
+            after2 = dt.now()
+
+            delta2 = after2 - before2  # 1 sec for the computation plus 1 sec to check current time, so about 2 sec
+            assert delta2 > one_second
+            assert delta2 < five_seconds
+
+            before3 = dt.now()
+            with pytest.raises(AssertionError):
+                quickly_failing(tries=100)
+            after3 = dt.now()
+
+            delta3 = after3 - before3  # 100 tries * 0.1 sec plus 1 sec to check current time, so about 11 sec
+            assert delta3 > ten_seconds

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -927,7 +927,7 @@ def test_s3_utils_buckets_ff_live_ecosystem_not_production():
         es_url = s3u.env_manager.es_url
         print(f"Checking {es_url}...")
         # NOTE: The right answers differ here from production, but as long as the short name is in there, that's enough.
-        pattern = f"https://vpc-es-.*{short_env_name(env_name).replace('-', '.*')}.*[.]amazonaws[.]com:443"
+        pattern = f"https://vpc-[eo]s-.*{short_env_name(env_name).replace('-', '.*')}.*[.]amazonaws[.]com:443"
         print(f"pattern={pattern}")
         assert es_url and re.match(pattern, es_url)
         assert s3u.env_manager.env_name == full_env
@@ -972,7 +972,7 @@ def test_s3_utils_buckets_ff_live_ecosystem_production():
         es_url = s3u.env_manager.es_url
         print(f"Checking {es_url}...")
         # tokenify(full_env_name(env_name)) matches better, but as long as short env name is there, it's enough.
-        pattern = f"https://vpc-es-.*{short_env_name(env_name).replace('-', '.*')}.*[.]amazonaws[.]com:443"
+        pattern = f"https://vpc-[eo]s-.*{short_env_name(env_name).replace('-', '.*')}.*[.]amazonaws[.]com:443"
         print(f"pattern={pattern}")
         assert es_url and re.match(pattern, es_url)
         assert is_stg_or_prd_env(s3u.env_manager.env_name)

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -925,12 +925,25 @@ def test_s3_utils_buckets_ff_live_ecosystem_not_production():
         assert isinstance(s3u.env_manager, EnvManager)
         assert isinstance(s3u.env_manager.s3, botocore.client.BaseClient)  # It's hard to test for S3 specifically
         es_url = s3u.env_manager.es_url
-        print(f"Checking {es_url}...")
-        # NOTE: The right answers differ here from production, but as long as the short name is in there, that's enough.
-        pattern = f"https://vpc-[eo]s-.*{short_env_name(env_name).replace('-', '.*')}.*[.]amazonaws[.]com:443"
+        print(f"Checking {es_url} ...")
+        # NOTE: The right answers differ here from production, but as long as something approximately like
+        #       the short name is in there, that's enough.
+        names_part = _make_similar_names_alternation(env_name)
+        pattern = f"https://vpc-[eo]s-.*({names_part}).*[.]amazonaws[.]com:443"
         print(f"pattern={pattern}")
         assert es_url and re.match(pattern, es_url)
         assert s3u.env_manager.env_name == full_env
+
+
+def _make_similar_names_alternation(env_name):
+    # e.g.,
+    #  _make_similar_names_alternation('production')   # if the full_env_name is fourfront-production
+    #  returns
+    #    pro?d(uction)?.green|fourfront.pro?d(uction)?.green
+    return "|".join([(x.replace('-', '.')  # match any char where a "-" is in the env name
+                      .replace('production', 'pro?d(uction)?')  # allow abbreviating production
+                      .replace('development', 'dev(elopment)?'))  # allow abbreviating development
+                     for x in [short_env_name(env_name), full_env_name(env_name)]])
 
 
 @using_fresh_ff_deployed_state_for_testing()
@@ -972,7 +985,8 @@ def test_s3_utils_buckets_ff_live_ecosystem_production():
         es_url = s3u.env_manager.es_url
         print(f"Checking {es_url}...")
         # tokenify(full_env_name(env_name)) matches better, but as long as short env name is there, it's enough.
-        pattern = f"https://vpc-[eo]s-.*{short_env_name(env_name).replace('-', '.*')}.*[.]amazonaws[.]com:443"
+        names_part = _make_similar_names_alternation(env_name)
+        pattern = f"https://vpc-[eo]s-.*({names_part}).*[.]amazonaws[.]com:443"
         print(f"pattern={pattern}")
         assert es_url and re.match(pattern, es_url)
         assert is_stg_or_prd_env(s3u.env_manager.env_name)


### PR DESCRIPTION
* In `dcicutils.qa_utils`:

  * For method `Eventually_call_assertion`:

    * Make the `error_message=` argument actually work.

    * The `threshold_seconds=` argument is now deprecated. Please prefer `tries=` and/or `wait_seconds=`.

    * Fix a bug where it didn't wait between iterations.

  * Add a method `consistent` that is a class method / decorator (as `Eventually.consistent()`).

  * Add testing (in `test_qa_utils.py`), particularly of the timing.