### PR TITLE
Make mocked_s3utils_with_sse available in ff_mocks.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ dcicutils
 Change Log
 ----------
 
+
 6.10.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ dcicutils
 Change Log
 ----------
 
+6.9.0
+=====
+
+* Move ``mocked_s3utils_with_sse`` from ``test_ff_utils.py`` to ``ff_mocks.py``.
+
+
 6.8.0
 =====
 

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -190,6 +190,23 @@ def mocked_s3utils(environments=None, require_sse=False, other_access_key_names=
                                         yield mock_boto3
 
 
+DEFAULT_SSE_ENVIRONMENTS_TO_MOCK = ['fourfront-foo', 'fourfront-bar']
+
+
+@contextlib.contextmanager
+def mocked_s3utils_with_sse(beanstalks=None, environments=None, require_sse=True, files=None):
+    # beanstalks= is deprecated. Use environments= instead.
+    environments = (DEFAULT_SSE_ENVIRONMENTS_TO_MOCK
+                    if beanstalks is None and environments is None
+                    else (beanstalks or []) + (environments or []))
+    with mocked_s3utils(environments=environments, require_sse=require_sse) as mock_boto3:
+        s3 = mock_boto3.client('s3')
+        assert isinstance(s3, MockBotoS3Client)
+        for filename, string in (files or {}).items():
+            s3.s3_files.files[filename] = string.encode('utf-8')
+        yield mock_boto3
+
+
 # Here we set up some variables, auxiliary functions, and mocks containing common values needed for testing
 # of the next several functions so that the functions don't have to set them up over
 # and over again in each test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "6.9.0.2b0"  # to become "6.10.0"
+version = "6.10.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "6.8.0"
+version = "6.8.0.1b0"  # to become "6.9.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -1,4 +1,3 @@
-import contextlib
 import copy
 import json
 import os
@@ -9,11 +8,10 @@ import time
 
 from botocore.exceptions import ClientError
 from dcicutils import es_utils, ff_utils, s3_utils
-from dcicutils.ff_mocks import mocked_s3utils, TestScenarios, RequestsTestRecorder
+from dcicutils.ff_mocks import mocked_s3utils_with_sse, TestScenarios, RequestsTestRecorder
 from dcicutils.misc_utils import make_counter, remove_prefix, remove_suffix, check_true
 from dcicutils.qa_utils import (
     check_duplicated_items_by_key, ignored, raises_regexp, MockResponse, MockBoto3, MockBotoSQSClient,
-    MockBotoS3Client,
 )
 from types import GeneratorType
 from unittest import mock
@@ -239,16 +237,17 @@ def test_unified_authentication_decoding(integrated_ff):
                 ff_utils.unified_authentication(None, any_env)
             assert 'Must provide a valid authorization key or ff' in str(exec_info.value)
 
-
-@contextlib.contextmanager
-def mocked_s3utils_with_sse(beanstalks=None, require_sse=True, files=None):
-    with mocked_s3utils(environments=beanstalks or ['fourfront-foo', 'fourfront-bar'],
-                        require_sse=require_sse) as mock_boto3:
-        s3 = mock_boto3.client('s3')
-        assert isinstance(s3, MockBotoS3Client)
-        for filename, string in (files or {}).items():
-            s3.s3_files.files[filename] = string.encode('utf-8')
-        yield mock_boto3
+# moved to ff_mocks.py
+#
+# @contextlib.contextmanager
+# def mocked_s3utils_with_sse(beanstalks=None, require_sse=True, files=None):
+#     with mocked_s3utils(environments=beanstalks or ['fourfront-foo', 'fourfront-bar'],
+#                         require_sse=require_sse) as mock_boto3:
+#         s3 = mock_boto3.client('s3')
+#         assert isinstance(s3, MockBotoS3Client)
+#         for filename, string in (files or {}).items():
+#             s3.s3_files.files[filename] = string.encode('utf-8')
+#         yield mock_boto3
 
 
 def test_unified_authentication_unit():

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -24,7 +24,7 @@ from dcicutils.env_utils_legacy import (
 )
 from dcicutils.exceptions import SynonymousEnvironmentVariablesMismatched, CannotInferEnvFromManyGlobalEnvs
 from dcicutils.ff_mocks import make_mock_es_url, make_mock_portal_url
-from dcicutils.misc_utils import ignored, ignorable, override_environ
+from dcicutils.misc_utils import ignored, ignorable, override_environ, exported
 from dcicutils.qa_utils import MockBoto3, MockResponse, known_bug_expected
 from dcicutils.s3_utils import s3Utils, HealthPageKey
 from requests.exceptions import ConnectionError
@@ -33,6 +33,14 @@ from .helpers import (
     using_fresh_ff_state_for_testing, using_fresh_cgap_state_for_testing, using_fresh_ff_deployed_state_for_testing,
 )
 from .test_ff_utils import mocked_s3utils_with_sse
+
+
+# This was moved to ff_mocks.py, but some things may still import from here.
+# Importing from here is deprecated. It should be imported from ff_Mocks going forward.
+# Minimally this exported marker should be retained until major version 7 of dcicutils,
+# though as a practical matter because we have to import that context manager here for testing,
+# it's unlikely to break even after we remove this marker. -kmp 10-Feb-2023
+exported(mocked_s3utils_with_sse)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
I want to be able to use some of this better mocking tech in other repos, so I moved it to a place where I could access it.