### PR TITLE
Add parallel map facility in new task_utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,33 @@ Change Log
 ----------
 
 
+7.2.0
+=====
+
+* In ``exceptions``:
+
+  * New class ``MultiError``
+
+* In ``qa_utils``:
+
+  * New class ``Timer``
+
+* In ``misc_utils``:
+
+  * New generator function ``chunked``
+
+* New module ``task_utils``:
+
+  * New class ``Task``
+  * New class ``TaskManager``
+  * New function ``pmap``
+  * New function ``pmap_list``
+  * New function ``map_chunked``
+
+* Adjust expectations for environment ``hotseat``
+  in live ecosystem integration testing by ``tests/test_s3_utils.py``
+
+
 7.1.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Change Log
   * New class ``TaskManager``
   * New function ``pmap``
   * New function ``pmap_list``
-  * New function ``map_chunked``
+  * New function ``pmap_chunked``
 
 * Adjust expectations for environment ``hotseat``
   in live ecosystem integration testing by ``tests/test_s3_utils.py``

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -2181,3 +2181,18 @@ def deduplicate_list(lst):
     :return: de-duplicated list
     """
     return list(set(lst))
+
+
+def chunked(seq, chunk_size=1):
+    if not isinstance(chunk_size, int) or chunk_size < 1:
+        raise ValueError(f"The chunk_size, {chunk_size}, must be a positive integer.")
+    chunk = []
+    i = 0
+    for item in seq:
+        chunk.append(item)
+        i = (i + 1) % chunk_size
+        if i == 0:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2751,3 +2751,35 @@ class Eventually:
             return _wrapped
 
         return _wrapper
+
+
+class Timer:
+
+    def __init__(self):
+        self.start = None
+        self.end = None
+
+    def start_timer(self):
+        # Resets it even if it was already set.
+        self.end = None
+        self.start = datetime.datetime.now()
+
+    def stop_timer(self):
+        # Does not move the time if already stopped. Safe to call twice.
+        if self.end is None:
+            self.end = datetime.datetime.now()
+
+    def __enter__(self):
+        self.start_timer()
+        return self
+
+    def __exit__(self, *exc):
+        ignored(exc)
+        self.stop_timer()
+        return False
+
+    def duration_seconds(self):
+        if self.start is None:
+            return None
+        end = datetime.datetime.now() if self.end is None else self.end
+        return (end - self.start).total_seconds()

--- a/dcicutils/task_utils.py
+++ b/dcicutils/task_utils.py
@@ -1,0 +1,108 @@
+import threading
+
+from dcicutils.exceptions import MultiError
+from dcicutils.misc_utils import check_true, environ_bool, PRINT
+
+# TODO:
+#  * timeoouts
+#  * chunking
+#  * revised error handling for chunking
+
+PMAP_VERBOSE = environ_bool("PMAP_VERBOSE")
+
+
+class _Task:
+    def __init__(self, *, manager, thread=None, position, function, arg1, more_args=None):
+        self.position = position
+        self.thread = thread
+        self.function = function
+        self.arg1 = arg1
+        self.more_args = more_args or []
+        self.ready = False
+        self.result = None
+        self.error = None
+        self.manager: TaskManager = manager
+
+    def set_result(self, result):
+        self.result = result
+        self.ready = True
+
+    def set_error(self, error):
+        self.error = error
+        self.ready = True
+
+    def call(self):
+        if self.ready:
+            raise RuntimeError("{self} has already been called.")
+        else:
+            try:
+                self.set_result(self.function(self.arg1, *self.more_args))
+            except Exception as e:
+                self.set_error(e)
+
+
+class TaskManager:
+
+    MAX_CONCURRENT_THREADS = 10
+
+    def __init__(self, fail_fast=True, raise_error=True):
+        if fail_fast and not raise_error:
+            raise ValueError("raise_erorr cannot be false if fail_fast is true.")
+        self.fail_fast = fail_fast
+        self.raise_error = raise_error
+
+    _ARG_TYPE = (list, tuple)
+    _ARG_TYPE_ERROR_MESSAGE = "Each arguments to pmap must be a list or a tuple."
+    _ARG_LEN_ERROR_MESSAGE = "All arguments to pmap must be of the same length."
+
+    @classmethod
+    def pmap(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True):
+        """
+        Maps a function across given arguments with each call performed in a separate thread.
+        If errors occur, they are trapped and appropriate information is communicated to the main thread.
+
+         * If fail_fast is False, any errors for each call are detected, not just the first error.
+           Otherwise, as soon as some error is detected, it is raised.
+         * If raise_error is False, the errors detected are returned rather than being raised.
+
+        :param fn: The function to map
+        :param seq: A sequence of first arguments to be given to the fn.
+        :param more_seqs: Additional sequences (seq2, seq3, ...) of arguments if fn requires (arg2, arg3, ...)
+        :param fail_fast: Whether to stop as soon as an error is noticed.
+        :param raise_error: Whether to raise errors that are detected. If false, the error object become results.
+        """
+        return TaskManager(fail_fast=fail_fast, raise_error=raise_error)._do_map(fn, seq, *more_seqs)
+
+    def _do_map(self, fn, seq1, *more_seqs):
+        check_true(isinstance(seq1, self._ARG_TYPE), self._ARG_TYPE_ERROR_MESSAGE, error_class=ValueError)
+        check_true(all(isinstance(seq, self._ARG_TYPE) for seq in more_seqs), self._ARG_TYPE_ERROR_MESSAGE,
+                   error_class=ValueError)
+        n = len(seq1)
+        check_true(all(len(seq) == n for seq in more_seqs), self._ARG_LEN_ERROR_MESSAGE, error_class=ValueError)
+        records = [_Task(manager=self, position=i, function=fn, arg1=seq1[i],
+                         more_args=[seq[i] for seq in more_seqs])
+                   for i in range(n)]
+        for record in records:
+            record.thread = threading.Thread(target=lambda x: x.call(), args=(record,))
+        for record in records:
+            if PMAP_VERBOSE:  # pragma: no cover
+                PRINT(f"Starting {record.thread} for arg {record.position}...")
+            record.thread.start()  # make sure they all start
+        for record in records:
+            if PMAP_VERBOSE:
+                PRINT(f"Joining {record.thread} for arg {record.position}...")
+            record.thread.join()
+            if record.error and self.fail_fast:
+                raise record.error
+        if not self.raise_error:
+            return list(map(lambda record: record.error or record.result, records))
+        errors = [record.error for record in records if record.ready and record.error]
+        if not errors:
+            return [record.result for record in records]
+        elif len(errors) == 1:
+            raise errors[0]
+        else:
+            raise MultiError(*errors)
+
+
+pmap = TaskManager.pmap

--- a/dcicutils/task_utils.py
+++ b/dcicutils/task_utils.py
@@ -23,7 +23,7 @@ from dcicutils.misc_utils import chunked, environ_bool, PRINT
 # To use the chunking, you might instead have written
 #
 #    result = []
-#    for chunk in map_chunks(lambda x: x + 1, range(100)):
+#    for chunk in pmap_chunks(lambda x: x + 1, range(100)):
 #      result += chunk
 #
 # Caveats:
@@ -115,21 +115,21 @@ class TaskManager:
 
     @classmethod
     def pmap(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):
-        for chunk in cls.map_chunks(fn, seq, *more_seqs, fail_fast=fail_fast, raise_error=raise_error,
-                                    chunk_size=chunk_size):
+        for chunk in cls.pmap_chunks(fn, seq, *more_seqs, fail_fast=fail_fast, raise_error=raise_error,
+                                     chunk_size=chunk_size):
             for item in chunk:
                 yield item
 
     @classmethod
     def pmap_list(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):
         result = []
-        for chunk in cls.map_chunks(fn, seq, *more_seqs, fail_fast=fail_fast, raise_error=raise_error,
-                                    chunk_size=chunk_size):
+        for chunk in cls.pmap_chunks(fn, seq, *more_seqs, fail_fast=fail_fast, raise_error=raise_error,
+                                     chunk_size=chunk_size):
             result += chunk
         return result
 
     @classmethod
-    def map_chunks(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):  # generator
+    def pmap_chunks(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):  # generator
         """
         Maps a function across given arguments with each call performed in a separate thread.
         If errors occur, they are trapped and appropriate information is communicated to the main thread.
@@ -146,9 +146,9 @@ class TaskManager:
         :param chunk_size: How many items to do at once. If unsupplied, the .DEFAULT_CHUNK_SIZE will be used.
         """
         manager = TaskManager(fail_fast=fail_fast, raise_error=raise_error, chunk_size=chunk_size)
-        return manager._map_chunks(fn, seq, *more_seqs)
+        return manager._pmap_chunks(fn, seq, *more_seqs)
 
-    def _map_chunks(self, fn, seq1, *more_seqs):
+    def _pmap_chunks(self, fn, seq1, *more_seqs):
         call_id = self.new_call_id()
         chunk_post = 0
         more_seq_generators = [(x for x in seq) for seq in more_seqs]
@@ -198,6 +198,6 @@ class TaskManager:
             chunk_post += n
 
 
-map_chunks = TaskManager.map_chunks
+pmap_chunks = TaskManager.pmap_chunks
 pmap = TaskManager.pmap
 pmap_list = TaskManager.pmap_list

--- a/dcicutils/task_utils.py
+++ b/dcicutils/task_utils.py
@@ -11,7 +11,7 @@ from dcicutils.misc_utils import check_true, environ_bool, PRINT
 PMAP_VERBOSE = environ_bool("PMAP_VERBOSE")
 
 
-class _Task:
+class Task:
     def __init__(self, *, manager, thread=None, position, function, arg1, more_args=None):
         self.position = position
         self.thread = thread
@@ -42,6 +42,8 @@ class _Task:
 
 
 class TaskManager:
+
+    TASK_CLASS = Task
 
     MAX_CONCURRENT_THREADS = 10
 
@@ -79,8 +81,8 @@ class TaskManager:
                    error_class=ValueError)
         n = len(seq1)
         check_true(all(len(seq) == n for seq in more_seqs), self._ARG_LEN_ERROR_MESSAGE, error_class=ValueError)
-        records = [_Task(manager=self, position=i, function=fn, arg1=seq1[i],
-                         more_args=[seq[i] for seq in more_seqs])
+        records = [Task(manager=self, position=i, function=fn, arg1=seq1[i],
+                        more_args=[seq[i] for seq in more_seqs])
                    for i in range(n)]
         for record in records:
             record.thread = threading.Thread(target=lambda x: x.call(), args=(record,))

--- a/dcicutils/task_utils.py
+++ b/dcicutils/task_utils.py
@@ -1,12 +1,12 @@
 import threading
 
 from dcicutils.exceptions import MultiError
-from dcicutils.misc_utils import check_true, environ_bool, PRINT
+from dcicutils.lang_utils import n_of
+from dcicutils.misc_utils import chunked, environ_bool, PRINT
 
 # TODO:
 #  * timeoouts
-#  * chunking
-#  * revised error handling for chunking
+#  * does not kill threads on abort. they have to run their course.
 
 PMAP_VERBOSE = environ_bool("PMAP_VERBOSE")
 
@@ -45,20 +45,32 @@ class TaskManager:
 
     TASK_CLASS = Task
 
-    MAX_CONCURRENT_THREADS = 10
+    DEFAULT_CHUNK_SIZE = 10
 
-    def __init__(self, fail_fast=True, raise_error=True):
+    def __init__(self, fail_fast=True, raise_error=True, chunk_size=None):
         if fail_fast and not raise_error:
             raise ValueError("raise_erorr cannot be false if fail_fast is true.")
         self.fail_fast = fail_fast
         self.raise_error = raise_error
-
-    _ARG_TYPE = (list, tuple)
-    _ARG_TYPE_ERROR_MESSAGE = "Each arguments to pmap must be a list or a tuple."
-    _ARG_LEN_ERROR_MESSAGE = "All arguments to pmap must be of the same length."
+        self.chunk_size = chunk_size or self.DEFAULT_CHUNK_SIZE
 
     @classmethod
-    def pmap(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True):
+    def pmap(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):
+        for chunk in cls.map_chunks(fn, seq, *more_seqs, fail_fast=fail_fast, raise_error=raise_error,
+                                    chunk_size=chunk_size):
+            for item in chunk:
+                yield item
+
+    @classmethod
+    def pmap_list(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):
+        result = []
+        for chunk in cls.map_chunks(fn, seq, *more_seqs, fail_fast=fail_fast, raise_error=raise_error,
+                                    chunk_size=chunk_size):
+            result += chunk
+        return result
+
+    @classmethod
+    def map_chunks(cls, fn, seq, *more_seqs, fail_fast=True, raise_error=True, chunk_size=None):  # generator
         """
         Maps a function across given arguments with each call performed in a separate thread.
         If errors occur, they are trapped and appropriate information is communicated to the main thread.
@@ -72,39 +84,55 @@ class TaskManager:
         :param more_seqs: Additional sequences (seq2, seq3, ...) of arguments if fn requires (arg2, arg3, ...)
         :param fail_fast: Whether to stop as soon as an error is noticed.
         :param raise_error: Whether to raise errors that are detected. If false, the error object become results.
+        :param chunk_size: How many items to do at once. If unsupplied, the .DEFAULT_CHUNK_SIZE will be used.
         """
-        return TaskManager(fail_fast=fail_fast, raise_error=raise_error)._do_map(fn, seq, *more_seqs)
+        manager = TaskManager(fail_fast=fail_fast, raise_error=raise_error, chunk_size=chunk_size)
+        return manager._map_chunks(fn, seq, *more_seqs)
 
-    def _do_map(self, fn, seq1, *more_seqs):
-        check_true(isinstance(seq1, self._ARG_TYPE), self._ARG_TYPE_ERROR_MESSAGE, error_class=ValueError)
-        check_true(all(isinstance(seq, self._ARG_TYPE) for seq in more_seqs), self._ARG_TYPE_ERROR_MESSAGE,
-                   error_class=ValueError)
-        n = len(seq1)
-        check_true(all(len(seq) == n for seq in more_seqs), self._ARG_LEN_ERROR_MESSAGE, error_class=ValueError)
-        records = [Task(manager=self, position=i, function=fn, arg1=seq1[i],
-                        more_args=[seq[i] for seq in more_seqs])
-                   for i in range(n)]
-        for record in records:
-            record.thread = threading.Thread(target=lambda x: x.call(), args=(record,))
-        for record in records:
-            if PMAP_VERBOSE:  # pragma: no cover
-                PRINT(f"Starting {record.thread} for arg {record.position}...")
-            record.thread.start()  # make sure they all start
-        for record in records:
-            if PMAP_VERBOSE:
-                PRINT(f"Joining {record.thread} for arg {record.position}...")
-            record.thread.join()
-            if record.error and self.fail_fast:
-                raise record.error
-        if not self.raise_error:
-            return list(map(lambda record: record.error or record.result, records))
-        errors = [record.error for record in records if record.ready and record.error]
-        if not errors:
-            return [record.result for record in records]
-        elif len(errors) == 1:
-            raise errors[0]
-        else:
-            raise MultiError(*errors)
+    def _map_chunks(self, fn, seq1, *more_seqs):
+        chunk_post = 0
+        more_seq_generators = [(x for x in seq) for seq in more_seqs]
+        for chunk in chunked(seq1, chunk_size=self.chunk_size):
+            n = len(chunk)
+            records = [Task(manager=self, position=chunk_post + i, function=fn, arg1=chunk_element,
+                            more_args=[next(seq_generator) for seq_generator in more_seq_generators])
+                       for i, chunk_element in enumerate(chunk)]
+            for record in records:
+                record.thread = threading.Thread(target=lambda x: x.call(), args=(record,))
+            for record in records:
+                if PMAP_VERBOSE:  # pragma: no cover
+                    PRINT(f"Starting {record.thread} for arg {record.position}...")
+                record.thread.start()  # make sure they all start
+            for record in records:
+                if PMAP_VERBOSE:
+                    PRINT(f"Joining {record.thread} for arg {record.position}...")
+                record.thread.join()
+                if record.error and self.fail_fast:
+                    if PMAP_VERBOSE:
+                        PRINT(f"While accumulating records, an error was found and is being raised due to fail_fast.")
+                    raise record.error
+            if not self.raise_error:
+                if PMAP_VERBOSE:
+                    PRINT(f"Because fail_fast is false, returning list of {n_of(n, 'error or result')}"
+                          f" for chunk {chunk}.")
+                yield list(map(lambda record: record.error or record.result, records))
+            else:
+                errors = [record.error for record in records if record.ready and record.error]
+                if not errors:
+                    if PMAP_VERBOSE:
+                        PRINT(f"No errors to raise in chunk {chunk}.")
+                    yield [record.result for record in records]
+                elif len(errors) == 1:
+                    if PMAP_VERBOSE:
+                        PRINT(f"Just one error to raise in chunk {chunk}.")
+                    raise errors[0]
+                else:
+                    if PMAP_VERBOSE:
+                        PRINT(f"Multiple errors to raise as a MultiError in chunk {chunk}.")
+                    raise MultiError(*errors)
+            chunk_post += n
 
 
+map_chunks = TaskManager.map_chunks
 pmap = TaskManager.pmap
+pmap_list = TaskManager.pmap_list

--- a/docs/source/dcicutils.rst
+++ b/docs/source/dcicutils.rst
@@ -247,6 +247,13 @@ snapshot_utils
   :members:
 
 
+task_utils
+^^^^^^^^^^
+
+.. automodule:: dcicutils.task_utils
+  :members:
+
+
 trace_utils
 ^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.1.0"
+version = "7.1.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.1.0.1b0"  # to become 7.2.0
+version = "7.2.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.1.0.1b0"
+version = "7.1.0.1b0"  # to become 7.2.0
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -2,7 +2,7 @@ from dcicutils.exceptions import (
     ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAfterFix, WrongErrorSeenAfterFix,
     ConfigurationError, SynonymousEnvironmentVariablesMismatched, InferredBucketConflict,
     CannotInferEnvFromNoGlobalEnvs, CannotInferEnvFromManyGlobalEnvs, MissingGlobalEnv, GlobalBucketAccessError,
-    InvalidParameterError, AppKeyMissing, AppServerKeyMissing, AppEnvKeyMissing
+    InvalidParameterError, AppKeyMissing, AppServerKeyMissing, AppEnvKeyMissing, MultiError,
 )
 from dcicutils.creds_utils import CGAPKeyManager
 
@@ -288,3 +288,27 @@ def test_app_server_key_missing():
 
     assert str(error) == ("Missing credential in file %s for CGAP server %s."
                           % (CGAPKeyManager._default_keys_file(), some_server))
+
+
+def test_MultiError():
+
+    e1 = ValueError("bad value")
+    e2 = RuntimeError("foo")
+    e3 = TypeError("wrong thing")
+
+    m1 = MultiError(e1)
+    m2 = MultiError(e1, e2)
+    m3 = MultiError(m2, e3)
+    m4 = MultiError(m2, e3, flatten=False)
+
+    assert isinstance(m1, MultiError)
+    assert m1.errors == [e1]
+
+    assert isinstance(m2, MultiError)
+    assert m2.errors == [e1, e2]
+
+    assert isinstance(m3, MultiError)
+    assert m3.errors == [e1, e2, e3]
+
+    assert isinstance(m4, MultiError)
+    assert m4.errors == [m2, e3]

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -29,7 +29,7 @@ from dcicutils.misc_utils import (
     string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists, lines_printed_to,
     classproperty, classproperty_cached, classproperty_cached_each_subclass, Singleton, NamedObject, obsolete,
     ObsoleteError, CycleError, TopologicalSorter, keys_and_values_to_dict, dict_to_keys_and_values, is_c4_arn,
-    deduplicate_list,
+    deduplicate_list, chunked,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output,
@@ -3232,3 +3232,45 @@ def test_deduplicate_list():
         # Lists with elements that are mutable objects that cannot be hashed as sets can't be dedupliated.
         # For example, a list of lists.  This is because set([['a'], ['b'], ['c']]) will fail.
         deduplicate_list([['a'], ['b'], ['c']])
+
+
+def test_chunked():
+
+    foo = []
+    for x in chunked([1, 2, 3, 4, 5, 6], chunk_size=2):
+        foo.append(x)
+    assert foo == [[1, 2], [3, 4], [5, 6]]
+
+    foo = []
+    for x in chunked([1, 2, 3, 4, 5, 6, 7], chunk_size=2):
+        foo.append(x)
+    assert foo == [[1, 2], [3, 4], [5, 6], [7]]
+
+    foo = []
+    for x in chunked([], chunk_size=2):
+        foo.append(x)
+    assert foo == []
+
+    foo = []
+    for x in chunked([1, 2, 3, 4, 5, 6], chunk_size=3):
+        for y in chunked(x, chunk_size=2):
+            foo.append(y)
+    assert foo == [[1, 2], [3], [4, 5], [6]]
+
+    foo = []
+    for x in chunked([1, 2, 3, 4, 5, 6, 7], chunk_size=3):
+        for y in chunked(x, chunk_size=2):
+            foo.append(y)
+    assert foo == [[1, 2], [3], [4, 5], [6], [7]]
+
+    foo = []
+    for x in chunked([1, 2, 3, 4, 5, 6], chunk_size=2):
+        for y in chunked(x, chunk_size=3):
+            foo.append(y)
+    assert foo == [[1, 2], [3, 4], [5, 6]]
+
+    foo = []
+    for x in chunked([1, 2, 3, 4, 5, 6, 7], chunk_size=2):
+        for y in chunked(x, chunk_size=3):
+            foo.append(y)
+    assert foo == [[1, 2], [3, 4], [5, 6], [7]]

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -1003,9 +1003,9 @@ C4_853_FIX_INFO = {
         {'metadata_fix': True, 'tibanna_fix': False},
 
     'fourfront-hotseat':
-        {'metadata_fix': True, 'tibanna_fix': False},
+        {'metadata_fix': True, 'tibanna_fix': True},
     'hotseat':
-        {'metadata_fix': True, 'tibanna_fix': False},
+        {'metadata_fix': True, 'tibanna_fix': True},
 }
 
 

--- a/test/test_task_utils.py
+++ b/test/test_task_utils.py
@@ -4,7 +4,7 @@ import time
 from dcicutils.exceptions import MultiError
 from dcicutils.misc_utils import print_error_message
 from dcicutils.qa_utils import Timer
-from dcicutils.task_utils import Task, TaskManager, map_chunks, pmap, pmap_list
+from dcicutils.task_utils import Task, TaskManager, pmap_chunks, pmap, pmap_list
 
 
 def _add1(x):
@@ -52,7 +52,7 @@ def test_map_chunks_simple():
     for chunk_size in [2, 3]:
         i = 1
         n_chunks = 0
-        for chunk in map_chunks(_add1, [1, 2, 3, 4, 5, 6], chunk_size=chunk_size):
+        for chunk in pmap_chunks(_add1, [1, 2, 3, 4, 5, 6], chunk_size=chunk_size):
             n_chunks += 1
             assert isinstance(chunk, list)
             assert len(chunk) == chunk_size

--- a/test/test_task_utils.py
+++ b/test/test_task_utils.py
@@ -213,7 +213,7 @@ def test_pmap_parallelism():
         expected = calibrated_slowness * n_chunks
         # We could compute margin of error, too, by timing each iteration in calibration, but we'll guess for now.
         # -kmp 17-Apr-2023
-        margin_of_error = 1.03
+        margin_of_error = 1.0333
         # Allow for float round-off error on low side and additional computational overhead in the loop on high side
         lo_factor = 0.8
         expected_lo = expected * lo_factor

--- a/test/test_task_utils.py
+++ b/test/test_task_utils.py
@@ -217,7 +217,7 @@ def test_pmap_parallelism():
         # Allow for float round-off error on low side and additional computational overhead in the loop on high side
         lo_factor = 0.8
         expected_lo = expected * lo_factor
-        hi_factor = (margin_of_error ** chunk_size) # with k items per chunk, margin of error multiplies k times
+        hi_factor = (margin_of_error ** chunk_size)  # with k items per chunk, margin of error multiplies k times
         expected_hi = expected * hi_factor
         print(f"Total seconds ({chunk_size:2d} at a time): {n_secs:.6f},"
               f" expected e={expected:.3f}"

--- a/test/test_task_utils.py
+++ b/test/test_task_utils.py
@@ -1,10 +1,7 @@
 import pytest
 
 from dcicutils.exceptions import MultiError
-from dcicutils.task_utils import (
-    TaskManager, pmap,
-    _Task,  # noQA - testing protected member
-)
+from dcicutils.task_utils import Task, TaskManager, pmap
 
 
 def _add1(x):
@@ -15,24 +12,33 @@ def _adder(x, y):
     return x + y
 
 
-def test_pmapper():
+try:
+    _add1(1, 'a')  # noQA - this is going to fail. we want to see what error it raises
+except Exception as e:
+    _BadArgument = type(e)
+    assert _BadArgument != MultiError
+    # In other words...
+    assert isinstance(e, _BadArgument) and not isinstance(e, MultiError)
 
-    manager = TaskManager()  # Tests creation
 
-    assert manager.fail_fast
-    assert manager.raise_error
-
-
-def test_task():
+def test_Task():
 
     manager = TaskManager()
 
-    task = _Task(position=0, function=_add1, arg1=7, manager=manager)
+    task = Task(position=0, function=_add1, arg1=7, manager=manager)
 
     assert task.position == 0
     assert task.function == _add1
     assert task.arg1 == 7
     assert task.more_args == []
+
+
+def test_TaskManager():
+
+    manager = TaskManager()  # Tests creation
+
+    assert manager.fail_fast
+    assert manager.raise_error
 
 
 def test_pmap():
@@ -48,28 +54,19 @@ def test_pmap():
     assert pmap(_adder, [1, 2, 3], [4, 5, 6]) == [5, 7, 9]
 
 
-try:
-    _add1(1, 'a')  # noQA - this is going to fail. we want to see what error it raises
-except Exception as e:
-    wrong_type_arg = type(e)
-    assert wrong_type_arg != MultiError
-    # In other words...
-    assert isinstance(e, wrong_type_arg) and not isinstance(e, MultiError)
-
-
 def test_pmap_raise():
 
-    with pytest.raises(wrong_type_arg):
+    with pytest.raises(_BadArgument):
         pmap(_add1, [1, 'a'])
 
-    with pytest.raises(wrong_type_arg):
+    with pytest.raises(_BadArgument):
         pmap(_add1, ['a', 'b'], fail_fast=True)
 
     with pytest.raises(MultiError) as exc:
         pmap(_add1, ['a', 'b'], fail_fast=False)
     e0, e1 = exc.value.errors
-    assert isinstance(e0, wrong_type_arg)  # same error as before
-    assert isinstance(e1, wrong_type_arg)  # another of same
+    assert isinstance(e0, _BadArgument)  # same error as before
+    assert isinstance(e1, _BadArgument)  # another of same
     assert e0 != e1
 
 
@@ -81,14 +78,14 @@ def test_pmap_no_raise():
 
     r1, r2 = pmap(_add1, [1, 'a'], raise_error=False, fail_fast=False)
     assert r1 == 2
-    assert isinstance(r2, wrong_type_arg)
+    assert isinstance(r2, _BadArgument)
 
     r1, r2 = pmap(_add1, ['a', 'b'], raise_error=False, fail_fast=False)
-    assert isinstance(r1, wrong_type_arg)
-    assert isinstance(r2, wrong_type_arg)
+    assert isinstance(r1, _BadArgument)
+    assert isinstance(r2, _BadArgument)
 
 
 def test_pmap_fail_fast():
 
-    with pytest.raises(wrong_type_arg):
+    with pytest.raises(_BadArgument):
         pmap(_add1, ['a', 'b'], fail_fast=True)  # just reports the first error it finds

--- a/test/test_task_utils.py
+++ b/test/test_task_utils.py
@@ -1,0 +1,94 @@
+import pytest
+
+from dcicutils.exceptions import MultiError
+from dcicutils.task_utils import (
+    TaskManager, pmap,
+    _Task,  # noQA - testing protected member
+)
+
+
+def _add1(x):
+    return x + 1
+
+
+def _adder(x, y):
+    return x + y
+
+
+def test_pmapper():
+
+    manager = TaskManager()  # Tests creation
+
+    assert manager.fail_fast
+    assert manager.raise_error
+
+
+def test_task():
+
+    manager = TaskManager()
+
+    task = _Task(position=0, function=_add1, arg1=7, manager=manager)
+
+    assert task.position == 0
+    assert task.function == _add1
+    assert task.arg1 == 7
+    assert task.more_args == []
+
+
+def test_pmap():
+
+    with pytest.raises(Exception):
+        pmap(_add1)  # noQA - testing that the list of sequences is required.
+
+    assert pmap(_add1, [1, 2, 3]) == [2, 3, 4]
+
+    with pytest.raises(Exception):
+        pmap(_adder, [1, 2, 3], [1, 2])  # noQA - testing arg length mismatch
+
+    assert pmap(_adder, [1, 2, 3], [4, 5, 6]) == [5, 7, 9]
+
+
+try:
+    _add1(1, 'a')  # noQA - this is going to fail. we want to see what error it raises
+except Exception as e:
+    wrong_type_arg = type(e)
+    assert wrong_type_arg != MultiError
+    # In other words...
+    assert isinstance(e, wrong_type_arg) and not isinstance(e, MultiError)
+
+
+def test_pmap_raise():
+
+    with pytest.raises(wrong_type_arg):
+        pmap(_add1, [1, 'a'])
+
+    with pytest.raises(wrong_type_arg):
+        pmap(_add1, ['a', 'b'], fail_fast=True)
+
+    with pytest.raises(MultiError) as exc:
+        pmap(_add1, ['a', 'b'], fail_fast=False)
+    e0, e1 = exc.value.errors
+    assert isinstance(e0, wrong_type_arg)  # same error as before
+    assert isinstance(e1, wrong_type_arg)  # another of same
+    assert e0 != e1
+
+
+def test_pmap_no_raise():
+
+    with pytest.raises(Exception) as exc:
+        pmap(_add1, [], raise_error=False, fail_fast=True)
+    assert str(exc.value) == "raise_erorr cannot be false if fail_fast is true."
+
+    r1, r2 = pmap(_add1, [1, 'a'], raise_error=False, fail_fast=False)
+    assert r1 == 2
+    assert isinstance(r2, wrong_type_arg)
+
+    r1, r2 = pmap(_add1, ['a', 'b'], raise_error=False, fail_fast=False)
+    assert isinstance(r1, wrong_type_arg)
+    assert isinstance(r2, wrong_type_arg)
+
+
+def test_pmap_fail_fast():
+
+    with pytest.raises(wrong_type_arg):
+        pmap(_add1, ['a', 'b'], fail_fast=True)  # just reports the first error it finds

--- a/test/test_task_utils.py
+++ b/test/test_task_utils.py
@@ -1,7 +1,8 @@
 import pytest
 
 from dcicutils.exceptions import MultiError
-from dcicutils.task_utils import Task, TaskManager, pmap
+from dcicutils.misc_utils import print_error_message
+from dcicutils.task_utils import Task, TaskManager, map_chunks, pmap, pmap_list
 
 
 def _add1(x):
@@ -41,51 +42,123 @@ def test_TaskManager():
     assert manager.raise_error
 
 
-def test_pmap():
+def test_map_chunks_simple():
 
-    with pytest.raises(Exception):
-        pmap(_add1)  # noQA - testing that the list of sequences is required.
+    for chunk_size in [2, 3]:
+        i = 1
+        n_chunks = 0
+        for chunk in map_chunks(_add1, [1, 2, 3, 4, 5, 6], chunk_size=chunk_size):
+            n_chunks += 1
+            assert isinstance(chunk, list)
+            assert len(chunk) == chunk_size
+            for elem in chunk:
+                i += 1
+                assert elem == i
+        assert n_chunks == 6 / chunk_size
 
-    assert pmap(_add1, [1, 2, 3]) == [2, 3, 4]
 
-    with pytest.raises(Exception):
-        pmap(_adder, [1, 2, 3], [1, 2])  # noQA - testing arg length mismatch
+def test_pmap_simple():
 
-    assert pmap(_adder, [1, 2, 3], [4, 5, 6]) == [5, 7, 9]
+    print()
+    res = pmap(_add1, [1, 2, 3])
+    print(f"res={res}")
+    assert not isinstance(res, list)
+    assert next(res) == 2
+    assert next(res) == 3
+    assert next(res) == 4
+    assert next(res, None) is None
 
 
-def test_pmap_raise():
+def test_pmap_list_simple():
+
+    assert pmap_list(_add1, [1, 2, 3]) == [2, 3, 4]
+
+    assert pmap_list(_adder, [1, 2, 3], [4, 5, 6]) == [5, 7, 9]
+
+
+def test_pmap_list_raise():
 
     with pytest.raises(_BadArgument):
-        pmap(_add1, [1, 'a'])
+        pmap_list(_add1, [1, 'a'])
 
     with pytest.raises(_BadArgument):
-        pmap(_add1, ['a', 'b'], fail_fast=True)
+        pmap_list(_add1, ['a', 'b'], fail_fast=True)
 
     with pytest.raises(MultiError) as exc:
-        pmap(_add1, ['a', 'b'], fail_fast=False)
+        pmap_list(_add1, ['a', 'b'], fail_fast=False)
     e0, e1 = exc.value.errors
     assert isinstance(e0, _BadArgument)  # same error as before
     assert isinstance(e1, _BadArgument)  # another of same
     assert e0 != e1
 
 
-def test_pmap_no_raise():
+def test_pmap_list_no_raise():
 
     with pytest.raises(Exception) as exc:
-        pmap(_add1, [], raise_error=False, fail_fast=True)
+        pmap_list(_add1, [], raise_error=False, fail_fast=True)
     assert str(exc.value) == "raise_erorr cannot be false if fail_fast is true."
 
-    r1, r2 = pmap(_add1, [1, 'a'], raise_error=False, fail_fast=False)
+    r1, r2 = pmap_list(_add1, [1, 'a'], raise_error=False, fail_fast=False)
     assert r1 == 2
     assert isinstance(r2, _BadArgument)
 
-    r1, r2 = pmap(_add1, ['a', 'b'], raise_error=False, fail_fast=False)
+    r1, r2 = pmap_list(_add1, ['a', 'b'], raise_error=False, fail_fast=False)
     assert isinstance(r1, _BadArgument)
     assert isinstance(r2, _BadArgument)
 
 
-def test_pmap_fail_fast():
+def test_pmap_list_no_raise_chunked():
 
-    with pytest.raises(_BadArgument):
-        pmap(_add1, ['a', 'b'], fail_fast=True)  # just reports the first error it finds
+    with pytest.raises(Exception) as exc:
+        pmap_list(_add1, [], raise_error=False, fail_fast=True)
+    assert str(exc.value) == "raise_erorr cannot be false if fail_fast is true."
+
+    # These should behave the same for raise_error=False, fail_fast=False
+    for chunk_size in [2, 3]:
+        r1a, r1b, r2a, r2b, r3a, r3b, r4a = pmap_list(_add1, [1, 2, 3, 'a', 'b', 6, 'c'],
+                                                      raise_error=False, fail_fast=False, chunk_size=chunk_size)
+        assert r1a == 2
+        assert r1b == 3
+        assert r2a == 4
+        assert isinstance(r2b, _BadArgument)
+        assert isinstance(r3a, _BadArgument)
+        assert r3b == 7
+        assert isinstance(r4a, _BadArgument)
+
+
+def test_pmap_list_raise_fast_chunked():
+
+    # These should behave the same for raise_error=True, fail_fast=True
+    for chunk_size in [2, 3]:
+        with pytest.raises(Exception) as exc:
+            pmap_list(_add1, [1, 2, 3, 'a', 'b', 6, 'c'],
+                      raise_error=True, fail_fast=True, chunk_size=chunk_size)
+        error_object = exc.value
+        assert isinstance(error_object, _BadArgument)
+
+
+def test_pmap_list_raise_slow_chunked():
+
+    # The behavior for raise_error=True, fail_fast=False will be different for chunk_size=2 and chunk_size=3
+    # For chunk_size=2, there will be one error for 'a', so it will be raised as a regular error.
+    with pytest.raises(Exception) as exc:
+        pmap_list(_add1, [1, 2, 3, 'a', 'b', 6, 'c'],
+                  raise_error=True, fail_fast=False, chunk_size=2)
+    error_object = exc.value
+    assert isinstance(error_object, _BadArgument)
+    # For chunk_size=3, there will be two errors for 'a' and 'b', so they will be raised as a MultiError
+    with pytest.raises(Exception) as exc:
+        pmap_list(_add1, [1, 2, 3, 'a', 'b', 6, 'c'],
+                  raise_error=True, fail_fast=False, chunk_size=3)
+    error_object = exc.value
+    assert isinstance(error_object, MultiError)
+    assert all(isinstance(e, _BadArgument) for e in error_object.errors)
+
+
+def test_pmap_list_fail_fast():
+
+    with pytest.raises(_BadArgument) as exc:
+        pmap_list(_add1, ['a', 'b'], fail_fast=True)  # just reports the first error it finds
+    e = exc.value
+    print_error_message(e)
+    assert isinstance(e, _BadArgument)  # Note that we did not wait for a MultiError


### PR DESCRIPTION
* In ``exceptions``:

  * New class ``MultiError``

* In ``qa_utils``:

  * New class ``Timer``

* In ``misc_utils``:

  * New generator function ``chunked``

* New module ``task_utils``:

  * New class ``Task``
  * New class ``TaskManager``
  * New function ``pmap``
  * New function ``pmap_list``
  * New function ``pmap_chunked``

* Adjust expectations for environment ``hotseat`` in live ecosystem integration testing by ``tests/test_s3_utils.py``
