### PR TITLE
Add mocking of some s3 glacier capabilities

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,4 +56,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.python_version == '3.9' }}
         run: |
+          pip install coveralls
           poetry run coveralls --service=github

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,43 @@ Change Log
 7.3.0
 =====
 
-* New ``glacier_utils`` module
+* In ``dcicutils.command_utils``:
+
+  * New decorator ``require_confirmation``
+
+* In ``dcicutils.common``:
+
+  * New variable ``ALL_S3_STORAGE_CLASSES``
+  * New variable ``AVAILABLE_S3_STORAGE_CLASSES``
+  * New variable ``S3_GLACIER_CLASSES``
+  * New type hint ``S3GlacierClass``
+  * New type hint ``S3StorageClass``
+
+* New module ``dcicutils.glacier_utils``:
 
     * Class for interacting with/restoring files from Glacier
 
+* In ``dcicutils.misc_utils``:
+
+  * New function ``INPUT``
+  * New function ``future_datetime``
+  * New decorator ``managed_property``
+  * New function ``map_chunked``
+  * New function ``format_in_radix``
+  * New function ``parse_in_radix``
+
+* In ``dcicutils.qa_checkers``:
+
+  * Fix bug in ``print`` statement recognizer
+
+* In ``dcicutils.qa_utils``:
+
+  * Support for Glacier-related operations in ``MockBotoS3Client``:
+
+    * Method ``copy_object``
+    * Method ``delete_object``
+    * Method ``list_object_versions``
+    * Method ``restore_object``
 
 * Load ``coveralls`` dependency only dynamically in GA workflow, not in poetry,
   because it implicates ``docopt`` library, which needs ``2to3``, and would fail.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
     * Class for interacting with/restoring files from Glacier
 
 
+* Load ``coveralls`` dependency only dynamically in GA workflow, not in poetry,
+  because it implicates ``docopt`` library, which needs ``2to3``, and would fail.
+
+
 7.2.0
 =====
 

--- a/dcicutils/beanstalk_utils.py
+++ b/dcicutils/beanstalk_utils.py
@@ -39,27 +39,6 @@ logging.basicConfig()
 logger = logging.getLogger('logger')
 logger.setLevel(logging.INFO)
 
-# In Python 2, the safe 'input' function was called 'raw_input'.  Also in Python 2, there was a function
-# named 'input' that did eval(raw_input(...)).  Python 3 made an incompatible change, renaming 'raw_input'
-# to 'input', and it no longer has a function that does an unsafe eval.  When we supported both Python 2 & 3,
-# use a 'try' expression to sort things out and call the safe function 'use_input' to avoid confusion.
-# But PyCharm found that 'try' expression confusing, so now that we are Python 3 only, we're phasing that
-# out. For a time, we'll retain the transitional naming, though, along with an affirmative error check, so
-# we don't open any security holes.
-# TODO: We can remove this naming and check once we're we're only using Python 3.
-# -kmp 27-Mar-2020
-
-# The name whodaman was deprecated and has been removed as of dcicutils 3.0
-# Please use compute_ff_prd_env instead.
-#
-# whodaman = compute_ff_prd_env  # This naming is obsolete but retained for compatibility.
-
-# The legacy name MAGIC_CNAME was deprecated and is finally removed as of dcicutils 3.0.
-# MAGIC_CNAME = _FF_MAGIC_CNAME
-
-# The legacy name GOLDEN_DB was deprecated and is finally removed as of dcicutils 3.0.
-# GOLDEN_DB = _FF_GOLDEN_DB
-
 # identifier for locating environment variables in EB config
 ENV_VARIABLE_NAMESPACE = 'aws:elasticbeanstalk:application:environment'
 

--- a/dcicutils/command_utils.py
+++ b/dcicutils/command_utils.py
@@ -10,7 +10,7 @@ import subprocess
 from typing import Optional
 from .exceptions import InvalidParameterError
 from .lang_utils import there_are
-from .misc_utils import PRINT, environ_bool, print_error_message, decorator
+from .misc_utils import INPUT, PRINT, environ_bool, print_error_message, decorator
 
 
 def _ask_boolean_question(question, quick=None, default=None):
@@ -36,7 +36,7 @@ def _ask_boolean_question(question, quick=None, default=None):
                  affirmative.upper() if default is True else affirmative,
                  negative.upper() if default is False else negative))
     while True:
-        answer = input(prompt).strip().lower()
+        answer = INPUT(prompt).strip().lower()
         if answer in affirmatives:
             return True
         elif answer in negatives:
@@ -106,7 +106,7 @@ def require_confirmation(*, prompt=None, default=True, raise_error=True):
 
         @functools.wraps(func)
         def _func_with_confirmation(*args, confirm=default, **kwargs):
-            if not confirm or y_or_n(prompt or "Are you sure you want to proceed with {func_name}?"):
+            if not confirm or y_or_n(prompt or f"Are you sure you want to proceed with {func_name}?"):
                 return func(*args, **kwargs)
             elif raise_error:
                 raise ScriptFailure("Aborted by user.")

--- a/dcicutils/common.py
+++ b/dcicutils/common.py
@@ -67,3 +67,52 @@ S3BucketName = str
 UrlString = str
 
 PortalEnvName = str
+
+
+# ===== AWS Data =====
+
+# Refs:
+#  * https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
+#  * https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+#
+# We single out 'available' storage classes as the ones someone would expect to be readily
+# available in short time and not subject to catastrophe, so that an I/O error probably
+# isn't related to the storage class. In practice that's the two standard storage classes
+# plus the intelligent tiering.  Most of the others have a latency issue or are otherwise
+# fragile. In practice, we just want to not overly warn about normal kinds of storage.
+
+ALL_S3_STORAGE_CLASSES = [
+    'STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA', 'ONEZONE_IA', 'INTELLIGENT_TIERING',
+    'GLACIER', 'DEEP_ARCHIVE', 'OUTPOSTS', 'GLACIER_IR',
+]
+
+AVAILABLE_S3_STORAGE_CLASSES = [
+    'STANDARD', 'STANDARD_IA', 'INTELLIGENT_TIERING'
+]
+# Refs:
+#  * https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
+#
+# See boto3 docs for info on possible values, but these 3 are the current ones used for
+# glacier (that require restore calls) - Will 7 Apr 2023
+
+S3_GLACIER_CLASSES = [
+    'GLACIER_IR',  # Glacier Instant Retrieval
+    'GLACIER',  # Glacier Flexible Retrieval
+    'DEEP_ARCHIVE'  # Glacier Deep Archive
+]
+S3GlacierClass = Union[
+    Literal['GLACIER_IR'],
+    Literal['GLACIER'],
+    Literal['DEEP_ARCHIVE'],
+]
+S3StorageClass = Union[
+    Literal['STANDARD'],
+    Literal['REDUCED_REDUNDANCY'],
+    Literal['STANDARD_IA'],
+    Literal['ONEZONE_IA'],
+    Literal['INTELLIGENT_TIERING'],
+    Literal['GLACIER'],
+    Literal['DEEP_ARCHIVE'],
+    Literal['OUTPOSTS'],
+    Literal['GLACIER_IR'],
+]

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -21,7 +21,7 @@ from dcicutils.qa_utils import (
 from dcicutils.s3_utils import EnvManager
 from typing import Optional, TextIO
 from unittest import mock
-from . import beanstalk_utils, ff_utils, s3_utils, env_utils, env_base, env_manager
+from . import beanstalk_utils, ff_utils, s3_utils, env_utils, env_base, env_manager, glacier_utils
 from .common import LEGACY_GLOBAL_ENV_BUCKET
 
 
@@ -148,46 +148,47 @@ def mocked_s3utils(environments=None, require_sse=False, other_access_key_names=
         write_config(environment, record)
     write_config(ecosystem_file, {"is_legacy": True})
     # Now we arrange that s3_utils, ff_utils, etc. modules share the illusion that our mock IS the boto3 library
-    with mock.patch.object(s3_utils, "boto3", mock_boto3):
-        with mock.patch.object(ff_utils, "boto3", mock_boto3):
-            with mock.patch.object(beanstalk_utils, "boto3", mock_boto3):
-                with mock.patch.object(env_utils, "boto3", mock_boto3):
-                    with mock.patch.object(env_base, "boto3", mock_boto3):
-                        with mock.patch.object(env_manager, "boto3", mock_boto3):
-                            with mock.patch.object(s3_utils.EnvManager, "fetch_health_page_json") as mock_fetcher:
-                                # This is all that's needed for s3Utils to initialize an EnvManager.
-                                # We might have to add more later.
-                                def mocked_fetch_health_page_json(url, use_urllib=True):
-                                    ignored(use_urllib)  # we don't test this
-                                    m = re.match(r'.*(fourfront-[a-z0-9-]+)(?:[.]|$)', url)
-                                    if m:
-                                        env_name = m.group(1)  # we found it with a fourfront-prefix, so use as is
-                                        return make_mock_health_page(env_name)
-                                    m = re.match(r'(?:https?://)?([a-z0-9-]+)'
-                                                 r'(?:[.](4dnucleome[.]org|hms.harvard.edu)([/].*)|$)', url)
-                                    if m:
-                                        env_name = full_env_name(m.group(1))  # no fourfront- prefix, so add one
-                                        return make_mock_health_page(env_name)
-                                    raise NotImplementedError(f"Mock can't handle URL: {url}")
+    with mock.patch.object(glacier_utils, "boto3", mock_boto3):
+        with mock.patch.object(s3_utils, "boto3", mock_boto3):
+            with mock.patch.object(ff_utils, "boto3", mock_boto3):
+                with mock.patch.object(beanstalk_utils, "boto3", mock_boto3):
+                    with mock.patch.object(env_utils, "boto3", mock_boto3):
+                        with mock.patch.object(env_base, "boto3", mock_boto3):
+                            with mock.patch.object(env_manager, "boto3", mock_boto3):
+                                with mock.patch.object(s3_utils.EnvManager, "fetch_health_page_json") as mock_fetcher:
+                                    # This is all that's needed for s3Utils to initialize an EnvManager.
+                                    # We might have to add more later.
+                                    def mocked_fetch_health_page_json(url, use_urllib=True):
+                                        ignored(use_urllib)  # we don't test this
+                                        m = re.match(r'.*(fourfront-[a-z0-9-]+)(?:[.]|$)', url)
+                                        if m:
+                                            env_name = m.group(1)  # we found it with a fourfront-prefix, so use as is
+                                            return make_mock_health_page(env_name)
+                                        m = re.match(r'(?:https?://)?([a-z0-9-]+)'
+                                                     r'(?:[.](4dnucleome[.]org|hms.harvard.edu)([/].*)|$)', url)
+                                        if m:
+                                            env_name = full_env_name(m.group(1))  # no fourfront- prefix, so add one
+                                            return make_mock_health_page(env_name)
+                                        raise NotImplementedError(f"Mock can't handle URL: {url}")
 
-                                mock_fetcher.side_effect = mocked_fetch_health_page_json
-                                # The mocked encrypt key is expected by various tools in the s3_utils module
-                                # to be supplied as an environment variable (i.e., in os.environ), so this
-                                # sets up that environment variable.
-                                if require_sse:
-                                    with override_environ(S3_ENCRYPT_KEY=s3_class.SSE_ENCRYPT_KEY):
+                                    mock_fetcher.side_effect = mocked_fetch_health_page_json
+                                    # The mocked encrypt key is expected by various tools in the s3_utils module
+                                    # to be supplied as an environment variable (i.e., in os.environ), so this
+                                    # sets up that environment variable.
+                                    if require_sse:
+                                        with override_environ(S3_ENCRYPT_KEY=s3_class.SSE_ENCRYPT_KEY):
+                                            with EnvUtils.local_env_utils_for_testing(
+                                                    global_env_bucket=os.environ.get('GLOBAL_ENV_BUCKET'),
+                                                    env_name=(
+                                                            environments[0]
+                                                            if environments else
+                                                            os.environ.get('ENV_NAME'))):
+                                                yield mock_boto3
+                                    else:
                                         with EnvUtils.local_env_utils_for_testing(
                                                 global_env_bucket=os.environ.get('GLOBAL_ENV_BUCKET'),
-                                                env_name=(
-                                                        environments[0]
-                                                        if environments else
-                                                        os.environ.get('ENV_NAME'))):
+                                                env_name=os.environ.get('ENV_NAME')):
                                             yield mock_boto3
-                                else:
-                                    with EnvUtils.local_env_utils_for_testing(
-                                            global_env_bucket=os.environ.get('GLOBAL_ENV_BUCKET'),
-                                            env_name=os.environ.get('ENV_NAME')):
-                                        yield mock_boto3
 
 
 DEFAULT_SSE_ENVIRONMENTS_TO_MOCK = ['fourfront-foo', 'fourfront-bar']

--- a/dcicutils/ff_mocks.py
+++ b/dcicutils/ff_mocks.py
@@ -175,19 +175,15 @@ def mocked_s3utils(environments=None, require_sse=False, other_access_key_names=
                                     # The mocked encrypt key is expected by various tools in the s3_utils module
                                     # to be supplied as an environment variable (i.e., in os.environ), so this
                                     # sets up that environment variable.
+                                    overrides = {}
                                     if require_sse:
-                                        with override_environ(S3_ENCRYPT_KEY=s3_class.SSE_ENCRYPT_KEY):
-                                            with EnvUtils.local_env_utils_for_testing(
-                                                    global_env_bucket=os.environ.get('GLOBAL_ENV_BUCKET'),
-                                                    env_name=(
-                                                            environments[0]
-                                                            if environments else
-                                                            os.environ.get('ENV_NAME'))):
-                                                yield mock_boto3
-                                    else:
+                                        overrides['S3_ENCRYPT_KEY'] = s3_class.SSE_ENCRYPT_KEY
+                                    with override_environ(**overrides):
                                         with EnvUtils.local_env_utils_for_testing(
                                                 global_env_bucket=os.environ.get('GLOBAL_ENV_BUCKET'),
-                                                env_name=os.environ.get('ENV_NAME')):
+                                                env_name=(environments[0]
+                                                          if environments
+                                                          else os.environ.get('ENV_NAME'))):
                                             yield mock_boto3
 
 

--- a/dcicutils/glacier_utils.py
+++ b/dcicutils/glacier_utils.py
@@ -64,7 +64,8 @@ class GlacierUtils:
         return not cls.is_glacier_storage_class(storage_class)
 
     @classmethod
-    def is_delayed_storage_class_transition(cls, from_storage_class: S3StorageClass, to_storage_class: S3StorageClass):
+    def transition_involves_glacier_restoration(cls, from_storage_class: S3StorageClass,
+                                                to_storage_class: S3StorageClass):
         return cls.is_glacier_storage_class(from_storage_class) and cls.is_available_storage_class(to_storage_class)
 
     def resolve_possible_file_status(self) -> list:

--- a/dcicutils/glacier_utils.py
+++ b/dcicutils/glacier_utils.py
@@ -2,19 +2,10 @@ import boto3
 from typing import Union, List, Tuple
 from concurrent.futures import ThreadPoolExecutor
 from tqdm import tqdm
+from .common import S3_GLACIER_CLASSES, S3StorageClass
 from .misc_utils import PRINT
 from .ff_utils import get_metadata, search_metadata, get_health_page, patch_metadata
 from .creds_utils import CGAPKeyManager
-
-
-# See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
-# See boto3 docs for info on possible values, but these 3 are the current ones used for
-# glacier (that require restore calls) - Will 7 Apr 2023
-GLACIER_CLASSES = [
-    'GLACIER_IR',  # Glacier Instant Retrieval
-    'GLACIER',  # Glacier Flexible Retrieval
-    'DEEP_ARCHIVE'  # Glacier Deep Archive
-]
 
 
 class GlacierRestoreException(Exception):
@@ -62,6 +53,18 @@ class GlacierUtils:
         self.key_manager = CGAPKeyManager()
         self.env_key = self.key_manager.get_keydict_for_env(env_name)
         self.health_page = get_health_page(key=self.env_key, ff_env=env_name)
+
+    @classmethod
+    def is_glacier_storage_class(cls, storage_class: S3StorageClass):
+        return storage_class in S3_GLACIER_CLASSES
+
+    @classmethod
+    def is_available_storage_class(cls, storage_class: S3StorageClass):
+        return not cls.is_glacier_storage_class(storage_class)
+
+    @classmethod
+    def is_delayed_storage_class_transition(cls, from_storage_class: S3StorageClass, to_storage_class: S3StorageClass):
+        return cls.is_glacier_storage_class(from_storage_class) and cls.is_available_storage_class(to_storage_class)
 
     def resolve_possible_file_status(self) -> list:
         """ Checks the File.json profile to see valid status values for files """
@@ -205,7 +208,7 @@ class GlacierUtils:
             versions = sorted(response.get('Versions', []), key=lambda x: x['LastModified'], reverse=True)
             deleted = False
             for v in versions:
-                if v.get('StorageClass') in GLACIER_CLASSES:
+                if v.get('StorageClass') in S3_GLACIER_CLASSES:
                     response = self.s3.delete_object(Bucket=bucket, Key=key, VersionId=v.get('VersionId'))
                     PRINT(f'Object {bucket}/{key} Glacier version {v.get("VersionId")} deleted:\n{response}')
                     deleted = True
@@ -219,7 +222,7 @@ class GlacierUtils:
             PRINT(f'Error deleting Glacier versions of object {bucket}/{key}: {str(e)}')
             return False
 
-    def copy_object_back_to_original_location(self, bucket: str, key: str, storage_class: str = 'STANDARD',
+    def copy_object_back_to_original_location(self, bucket: str, key: str, storage_class: S3StorageClass = 'STANDARD',
                                               version_id: Union[str, None] = None) -> Union[dict, None]:
         """ Reads the temporary location from the restored object and copies it back to the original location
 
@@ -274,7 +277,8 @@ class GlacierUtils:
             PRINT(f'Successfully triggered restore requests for all @ids passed {success}')
         return success, errors
 
-    def restore_glacier_phase_two_copy(self, atid_list: List[Union[str, dict]], storage_class: str = 'STANDARD',
+    def restore_glacier_phase_two_copy(self, atid_list: List[Union[str, dict]],
+                                       storage_class: S3StorageClass = 'STANDARD',
                                        parallel: bool = False, num_threads: int = 4) -> (List[str], List[str]):
         """ Triggers a copy operation for all restored objects passed in @id list
 
@@ -326,7 +330,8 @@ class GlacierUtils:
             PRINT(f'Successfully triggered copy for all @ids passed {success}')
         return success, errors
 
-    def restore_glacier_phase_three_patch(self, atid_list: List[Union[str, dict]], status='uploaded') -> (List[str], List[str]):
+    def restore_glacier_phase_three_patch(self, atid_list: List[Union[str, dict]],
+                                          status='uploaded') -> (List[str], List[str]):
         """ Patches out lifecycle information for @ids we've transferred back to standard
 
         :param atid_list: list of @ids or actual file metadata objects to patch info on
@@ -376,7 +381,8 @@ class GlacierUtils:
         return success, errors
 
     def restore_all_from_search(self, *, search_query: str, page_limit: int = 50, search_generator: bool = False,
-                                restore_length: int = 7, new_status: str = 'uploaded', storage_class: str = 'STANDARD',
+                                restore_length: int = 7, new_status: str = 'uploaded',
+                                storage_class: S3StorageClass = 'STANDARD',
                                 parallel: bool = False, num_threads: int = 4, delete_all_versions: bool = False,
                                 phase: int = 1) -> (List[str], List[str]):
         """ Overarching method that will take a search query and loop through all files in the

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -68,6 +68,8 @@ def _mockable_input(*args):
     return input(*args)
 
 
+builtin_print = print
+
 PRINT = _MOCKABLE_IO(wrapped_action=print)
 PRINT.__name__ = 'PRINT'
 

--- a/dcicutils/qa_checkers.py
+++ b/dcicutils/qa_checkers.py
@@ -327,7 +327,7 @@ class DebuggingArtifactChecker(StaticSourcesChecker):
         {
             'key': 'print',
             'summary': "call to print",
-            'pattern': r"^[^#]*print[(]"
+            'pattern': r"^[^#]*\bprint[(]"
         },
         {
             'key': 'pdb',

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2315,7 +2315,7 @@ class MockBotoS3Client(MockBoto3Client):
                 if restoration.is_active():
                     result['Restore'] = f'ongoing-request="false", expiry-date="{restoration.available_until}"'
                 else:
-                    result['Restora'] = f'ongoing-request="true"'
+                    result['Restore'] = f'ongoing-request="true"'
             # if datetime.datetime.now() < attribute_block.available_after:
             #     result['Restore'] = 'ongoing-request="true"'
             return result

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -34,7 +34,7 @@ from .exceptions import ExpectedErrorNotSeen, WrongErrorSeen, UnexpectedErrorAft
 from .glacier_utils import GlacierUtils
 from .lang_utils import there_are
 from .misc_utils import (
-    PRINT, INPUT, ignored, Retry, remove_prefix, REF_TZ,
+    PRINT, INPUT, ignored, Retry, remove_prefix, REF_TZ, builtin_print,
     environ_bool, exported, override_environ, override_dict, local_attrs, full_class_name,
     find_associations, get_error_message, remove_suffix, format_in_radix, future_datetime,
     _mockable_input,  # noQA - need this to keep mocking consistent
@@ -2542,7 +2542,8 @@ class MockBotoS3Client(MockBoto3Client):
                 raise Exception(f"The Copy source {source_id}"
                                 f" is in storage class {source_storage_class!r} and must be restored first.")
             else:
-                print("Storage class is OK for copy.")
+                # print("Storage class is OK for copy.")
+                pass
             # now = datetime.datetime.now()
             # print(f"Checking availability")
             # print(f"Time now is {now}")
@@ -2557,19 +2558,19 @@ class MockBotoS3Client(MockBoto3Client):
         attribute_block = self._object_attribute_block(target_s3_filename)
         assert isinstance(attribute_block, MockObjectAttributeBlock)
         target_attribute_block: MockObjectAttributeBlock = attribute_block
-        target_attribute_block._storage_class = target_storage_class
+        target_attribute_block._storage_class = target_storage_class   # TODO: This seems suspect
         # else:
         #     attribute_block = self._object_attribute_block(target_s3_filename)
         #     assert isinstance(attribute_block, MockObjectAttributeBlock)
         #     target_attribute_block: MockObjectAttributeBlock = attribute_block
         #     target_attribute_block.storage_class = target_storage_class
-        print(f"Copied from {source_storage_class} to {target_storage_class}")
+        PRINT(f"Copied from {source_storage_class} to {target_storage_class}")
         if GlacierUtils.is_delayed_storage_class_transition(source_storage_class, target_storage_class):
             target_attribute_block.restore_temporarily(delay_seconds=self.RESTORATION_DELAY_SECONDS,
                                                        duration_days=1, storage_class=target_storage_class)
-            print(f"Set up restoration {target_attribute_block.restoration}")
+            PRINT(f"Set up restoration {target_attribute_block.restoration}")
         else:
-            print(f"No restoration performed")
+            PRINT(f"The copy was not a temporary restoration.")
 
     RESTORATION_DELAY_SECONDS = 2
 
@@ -3258,8 +3259,8 @@ def input_series(*items):
             if not inputs:
                 raise OutOfInputs()
             result = inputs.pop()
-            print(arg)
-            print(result)
+            builtin_print(arg)
+            builtin_print(result)
             return result
 
         mock_input.side_effect = mocked_input

--- a/poetry.lock
+++ b/poetry.lock
@@ -595,26 +595,6 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
-name = "coveralls"
-version = "3.3.1"
-description = "Show coverage stats online via coveralls.io"
-category = "dev"
-optional = false
-python-versions = ">= 3.5"
-files = [
-    {file = "coveralls-3.3.1-py2.py3-none-any.whl", hash = "sha256:f42015f31d386b351d4226389b387ae173207058832fbf5c8ec4b40e27b16026"},
-    {file = "coveralls-3.3.1.tar.gz", hash = "sha256:b32a8bb5d2df585207c119d6c01567b81fba690c9c10a753bfe27a335bfc43ea"},
-]
-
-[package.dependencies]
-coverage = ">=4.1,<6.0.0 || >6.1,<6.1.1 || >6.1.1,<7.0"
-docopt = ">=0.6.1"
-requests = ">=1.0.0"
-
-[package.extras]
-yaml = ["PyYAML (>=3.10)"]
-
-[[package]]
 name = "docker"
 version = "4.4.4"
 description = "A Python library for the Docker Engine API."
@@ -635,17 +615,6 @@ websocket-client = ">=0.32.0"
 [package.extras]
 ssh = ["paramiko (>=2.4.2)"]
 tls = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=17.5.0)"]
-
-[[package]]
-name = "docopt"
-version = "0.6.2"
-description = "Pythonic argument parser, that will make you smile"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
-]
 
 [[package]]
 name = "elasticsearch"
@@ -1449,4 +1418,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.10"
-content-hash = "70918852e48863460b45134a5e37fc47e1fc259c94c29f72cf0bd53ed8f01816"
+content-hash = "20187cb3287c6825e1d24b8bd61fe8cb4aabd973ee96914acdf50b650205c48d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ tqdm = "^4.65.0"
 botocore-stubs = "1.21.22"
 boto3-stubs = "1.18.23"
 coverage = ">=5.3.1"
-coveralls = ">=3.3.1"
+# Loaded manually in GA workflow for coverage because a dependency on 2to3
+# in its docopts dependency makes a problem for laoding it here in poetry. -kmp 7-Apr-2023
+# coveralls = ">=3.3.1"
 flake8 = ">=3.9.2"
 flaky = ">=3.7.0"
 pytest = ">=4.5.0"

--- a/test/test_command_utils.py
+++ b/test/test_command_utils.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import pytest
 import tempfile
@@ -8,45 +7,10 @@ from dcicutils import command_utils as command_utils_module
 from dcicutils.command_utils import (
     _ask_boolean_question,  # noQA - access to internal function is so we can test it
     yes_or_no, y_or_n, ShellScript, shell_script, script_catch_errors, DEBUG_SCRIPT, SCRIPT_ERROR_HERALD,
+    require_confirmation, ScriptFailure,
 )
-from dcicutils.misc_utils import ignored, file_contents, PRINT
-from dcicutils.qa_utils import printed_output
-
-
-@contextlib.contextmanager
-def print_expected(*expected):
-
-    def mocked_print(*what):
-        printed = " ".join(what)
-        assert printed in expected
-
-    with mock.patch.object(command_utils_module, "PRINT") as mock_print:
-        mock_print.side_effect = mocked_print
-        yield
-
-
-class OutOfInputs(Exception):
-    pass
-
-
-@contextlib.contextmanager
-def input_series(*items):
-    with mock.patch.object(command_utils_module, "input") as mock_input:
-
-        def mocked_input(*args, **kwargs):
-            ignored(args, kwargs)
-            if not inputs:
-                raise OutOfInputs()
-            return inputs.pop()
-
-        mock_input.side_effect = mocked_input
-
-        inputs = []
-
-        for item in reversed(items):
-            inputs.append(item)
-        yield
-        assert not inputs, "Did not use all inputs."
+from dcicutils.misc_utils import file_contents, PRINT
+from dcicutils.qa_utils import printed_output, print_expected, input_series, OutOfInputs
 
 
 def test_ask_boolean_question():
@@ -142,6 +106,83 @@ def test_y_or_n():
                         "Please answer 'y' or 'n'."):
         with input_series('foo', 'bar', ''):
             assert y_or_n("foo?", default=False) is False
+
+
+def test_require_confirmation():
+
+    print()  # Start on a fresh line
+
+    @require_confirmation
+    def carefully_add(x, y):
+        return x + y
+
+    explain_y_or_n = "Please answer 'y' or 'n'."
+    y_or_n_suffix = " [y/n]: "
+    default_prompt = "Are you sure you want to proceed with carefully_add?"
+
+    with printed_output() as printed:
+        assert carefully_add(3, 4, confirm=False) == 7
+    assert printed.lines == []
+
+    with printed_output() as printed:
+        with input_series("n"):
+            with pytest.raises(ScriptFailure):
+                carefully_add(3, 4)
+    assert printed.lines == [default_prompt + y_or_n_suffix]
+
+    with printed_output() as printed:
+        with input_series("x", "n"):
+            with pytest.raises(ScriptFailure):
+                carefully_add(3, 4)
+    assert printed.lines == [
+        default_prompt + y_or_n_suffix,
+        explain_y_or_n,
+        default_prompt + y_or_n_suffix,
+    ]
+
+    my_prompt = "Are you sure you want to do the add?"
+
+    @require_confirmation(raise_error=False, prompt=my_prompt)
+    def add_if_confirmed(x, y):
+        return x + y
+
+    with printed_output() as printed:
+        with input_series():
+            assert add_if_confirmed(3, 4, confirm=False) == 7
+    assert printed.lines == []
+
+    with printed_output() as printed:
+        with input_series("y"):
+            assert add_if_confirmed(3, 4, confirm=True) == 7
+    assert printed.lines == [my_prompt + y_or_n_suffix]
+
+    with printed_output() as printed:
+        with input_series("y"):
+            assert add_if_confirmed(3, 4) == 7
+    assert printed.lines == [my_prompt + y_or_n_suffix]
+
+    with printed_output() as printed:
+        with input_series("n"):
+            assert add_if_confirmed(3, 4) is None
+    assert printed.lines == [my_prompt + y_or_n_suffix]
+
+    @require_confirmation
+    def documented_add(x, y):
+        """
+        Adds x and y, returning their sum.
+        :param x: a number
+        :param y: a number
+        :return: the sum
+        """
+        return x + y
+
+    assert documented_add.__doc__ == """
+        Adds x and y, returning their sum.
+        :param x: a number
+        :param y: a number
+        :param confirm: whether to ask for confirmation
+        :return: the sum
+        """
 
 
 def test_shell_script_class():
@@ -371,7 +412,6 @@ def test_script_catch_errors():
     # Erring program explicitly fails, bypassing regular exception catches
     with printed_output() as printed:
         failure_message = "Foo! This failed."
-        failure_message_parts = failure_message.split(' ')
         with pytest.raises(SystemExit) as exit_exc:
             with script_catch_errors() as fail:
                 try:

--- a/test/test_glacier_utils.py
+++ b/test/test_glacier_utils.py
@@ -1,6 +1,12 @@
+# import io
+# import json
 import pytest
+
 from unittest import mock
 from dcicutils.glacier_utils import GlacierUtils, GlacierRestoreException
+# from dcicutils.ff_mocks import mocked_s3utils
+# from dcicutils.lang_utils import there_are
+# from dcicutils.qa_utils import MockFileSystem, MockBotoS3Client
 
 
 def mock_keydict() -> dict:
@@ -381,3 +387,51 @@ class TestGlacierUtils:
                 assert gu.restore_all_from_search(search_query='/search', phase=4) == (expected_success, [])
                 assert gu.restore_all_from_search(search_query='/search', phase=4,
                                                   search_generator=True) == (expected_success, [])
+
+
+# An equivalent test is now in test_qa_utils.py, but this code is kept here to give a sense of what would work.
+#
+# def test_glacier_utils_list_object_versions():
+#     # Output from this test is usefully viewed by doing:  pytest -s -vv -k test_glacier_utils_object_versions
+#     # In fact, this doesn't test any glacier_utils functionality, but just that a mock of this kind,
+#     # calling list_object_versions, would work. It is in some ways a better test of qa_utils.
+#     mfs = MockFileSystem()
+#     with mocked_s3utils(environments=['fourfront-mastertest']) as mock_boto3:
+#         with mfs.mock_exists_open_remove():
+#             s3: MockBotoS3Client = mock_boto3.client('s3')
+#             bucket_name = 'foo'
+#             key_name = 'file.txt'
+#             key2_name = 'file2.txt'
+#             with io.open(key_name, 'w') as fp:
+#                 fp.write("first contents")
+#             s3.upload_file(key_name, Bucket=bucket_name, Key=key_name)
+#             with io.open(key_name, 'w') as fp:
+#                 fp.write("second contents")
+#             s3.upload_file(key_name, Bucket=bucket_name, Key=key_name)
+#             with io.open(key2_name, 'w') as fp:
+#                 fp.write("other stuff")
+#             s3.upload_file(key2_name, Bucket=bucket_name, Key=key2_name)
+#             print("file system:")
+#             for file, data in mfs.files.items():
+#                 s3_filename = f'{bucket_name}/{file}'
+#                 all_versions = s3._object_attribute_blocks(s3_filename)
+#                 print(f" {file}[{s3._object_attribute_block(s3_filename).version_id}]:"
+#                       f" {data!r}  # length={len(data)}."
+#                       f" {there_are([x.version_id for x in all_versions[:-1]], kind='back version')}")
+#             version_info = s3.list_object_versions(Bucket=bucket_name)
+#             print(f"list_object_versions(Bucket={bucket_name!r}) =")
+#             print(json.dumps(version_info, indent=2))
+#             versions = version_info['Versions']
+#             assert len(versions) == 3
+#             version1, version2, version3 = versions
+#             # Back version of file.txt
+#             assert version1['Key'] == key_name
+#             assert version1['IsLatest'] is False
+#             # Current version of file.txt
+#             assert version2['Key'] == key_name
+#             assert version2['IsLatest'] is True
+#             # Current version of file2.txt
+#             assert version3['Key'] == key2_name
+#             assert version3['IsLatest'] is True
+#             assert all(version['StorageClass'] == 'STANDARD' for version in versions)
+#

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -25,28 +25,43 @@ from dcicutils.misc_utils import (
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
     capitalize1, local_attrs, dict_zip, json_leaf_subst, print_error_message, get_error_message, utc_now_str,
-    _is_function_of_exactly_one_required_arg, _apply_decorator,  _36_DIGITS, # noQA
+    _is_function_of_exactly_one_required_arg, _apply_decorator,  _36_DIGITS, _mockable_input, # noQA
     string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists, lines_printed_to,
     classproperty, classproperty_cached, classproperty_cached_each_subclass, Singleton, NamedObject, obsolete,
     ObsoleteError, CycleError, TopologicalSorter, keys_and_values_to_dict, dict_to_keys_and_values, is_c4_arn,
     deduplicate_list, chunked, parse_in_radix, format_in_radix, managed_property, future_datetime,
-    MIN_DATETIME, MIN_DATETIME_UTC,
+    MIN_DATETIME, MIN_DATETIME_UTC, INPUT,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output,
-    raises_regexp, MockId, MockLog,
+    raises_regexp, MockId, MockLog, input_series,
 )
 from unittest import mock
 
 
 def test_uppercase_print():
     # This is just a synonym, so the easiest thing is just to test that fact.
-    assert PRINT._printer == print
+    assert PRINT.wrapped_action == print
 
     # But also a basic test that it does something
     s = io.StringIO()
     PRINT("something", file=s)
     assert s.getvalue() == "something\n"
+
+
+def test_uppercase_input():
+    print()  # start on a fresh line
+
+    # This is just a synonym, so the easiest thing is just to test that fact.
+    assert INPUT.wrapped_action == _mockable_input
+
+    # But also a basic test that it does something
+    some_response = "some response"
+    some_prompt = "foo?"
+    with printed_output() as printed:
+        with input_series(some_response):
+            assert INPUT(some_prompt) == some_response
+    assert printed.lines == [some_prompt]
 
 
 def test_ignored():

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -30,7 +30,7 @@ from dcicutils.misc_utils import (
     classproperty, classproperty_cached, classproperty_cached_each_subclass, Singleton, NamedObject, obsolete,
     ObsoleteError, CycleError, TopologicalSorter, keys_and_values_to_dict, dict_to_keys_and_values, is_c4_arn,
     deduplicate_list, chunked, parse_in_radix, format_in_radix, managed_property, future_datetime,
-    MIN_DATETIME, MIN_DATETIME_UTC, INPUT, builtin_print,
+    MIN_DATETIME, MIN_DATETIME_UTC, INPUT, builtin_print, map_chunked,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output,
@@ -3435,3 +3435,19 @@ def test_future_datetime():
         two_hours_from_now = future_datetime(hours=2, now=now)  # this won't check the time, so no seconds consumed
 
         assert two_hours_from_now == now + datetime_module.timedelta(hours=2)
+
+
+def test_map_chunked():
+
+    res = map_chunked(lambda x: ''.join(x), "abcdefghij", chunk_size=4)
+    assert next(res) == 'abcd'
+    assert next(res) == 'efgh'
+    assert next(res) == 'ij'
+    with pytest.raises(StopIteration):
+        next(res)
+
+    res = map_chunked(lambda x: ''.join(x), "abcdefghij", chunk_size=4, reduce=list)
+    assert res == ['abcd', 'efgh', 'ij']
+
+    res = map_chunked(lambda x: ''.join(x), "abcdefghij", chunk_size=4, reduce=lambda x: '.'.join(x))
+    assert res == 'abcd.efgh.ij'

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -25,11 +25,12 @@ from dcicutils.misc_utils import (
     DatetimeCoercionFailure, remove_element, identity, count, count_if, find_association, find_associations,
     ancestor_classes, is_proper_subclass, decorator, is_valid_absolute_uri, override_environ, override_dict,
     capitalize1, local_attrs, dict_zip, json_leaf_subst, print_error_message, get_error_message, utc_now_str,
-    _is_function_of_exactly_one_required_arg, _apply_decorator,  # noQA
+    _is_function_of_exactly_one_required_arg, _apply_decorator,  _36_DIGITS, # noQA
     string_list, string_md5, SingletonManager, key_value_dict, merge_key_value_dict_lists, lines_printed_to,
     classproperty, classproperty_cached, classproperty_cached_each_subclass, Singleton, NamedObject, obsolete,
     ObsoleteError, CycleError, TopologicalSorter, keys_and_values_to_dict, dict_to_keys_and_values, is_c4_arn,
-    deduplicate_list, chunked,
+    deduplicate_list, chunked, parse_in_radix, format_in_radix, managed_property, future_datetime,
+    MIN_DATETIME, MIN_DATETIME_UTC,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output,
@@ -3274,3 +3275,139 @@ def test_chunked():
         for y in chunked(x, chunk_size=3):
             foo.append(y)
     assert foo == [[1, 2], [3, 4], [5, 6], [7]]
+
+
+def test_parse_in_radix():
+
+    # Just some random examples...
+    assert parse_in_radix("0", radix=17) == 0
+    assert parse_in_radix("1101", radix=2) == 13
+    assert parse_in_radix("123", radix=10) == 123
+    assert parse_in_radix("325", radix=8) == 3 * (8 * 8) + 2 * 8 + 5
+    assert parse_in_radix("dead", radix=16) == 13 * (16 ** 3) + 14 * (16 ** 2) + 10 * (16 ** 1) + 13 * (16 ** 0)
+    assert parse_in_radix("DEAD", radix=16) == 13 * (16 ** 3) + 14 * (16 ** 2) + 10 * (16 ** 1) + 13 * (16 ** 0)
+    assert parse_in_radix("10Z", radix=36) == 36 * 36 + 35
+    assert parse_in_radix("10z", radix=36) == 36 * 36 + 35
+
+    def char_range(lo, hi):
+        return ''.join(chr(c) for c in range(ord(lo), ord(hi) + 1))
+
+    assert char_range('b', 'e') == "bcde"  # just testing
+
+    all_digits = char_range('0', '9') + char_range('A', 'Z')
+    assert all_digits == _36_DIGITS
+
+    for r in range(2, 37):
+
+        assert parse_in_radix("0", radix=r) == 0
+
+        for i in range(1, r):
+            # All single-digits should parse to their string position.
+            assert parse_in_radix(_36_DIGITS[i], radix=r) == i
+            # Adding leading 0's shouldn't matter.
+            assert parse_in_radix("000" + _36_DIGITS[i], radix=r) == i
+
+        assert parse_in_radix("10", radix=r) == r
+
+        for i in range(2, 6):
+            # print(r"===== i={i}, radix={r} =====")
+            ri = r ** i
+            # 100=r^2, 1000=r^3, ...
+            n_str = "1" + ("0" * i)
+            # print(f"parsing n={n_str!r} in radix {r}, expecting {r}^{i}={ri}")
+            assert parse_in_radix(n_str, radix=r) == ri
+            # 11[2] + 1 = 100[2] = 2^2, 22[3] + 1 == 100[3] = 3^2,
+            # 111[2] + 1 = 1000[2] = 2^3, 222[3] + 1 = 1000[3] = 3^3
+            n_str = _36_DIGITS[r - 1] * i
+            # print(f"parsing n={n_str!r} in radix {r}, expecting {r}^{i}-1={ri - 1}")
+            assert parse_in_radix(n_str, radix=r) == ri - 1
+
+    with pytest.raises(ValueError):
+        parse_in_radix(" ", radix=10)  # bad character
+
+    with pytest.raises(ValueError):
+        parse_in_radix("", radix=10)  # empty string
+
+    with pytest.raises(ValueError):
+        parse_in_radix("0", radix=1)  # radix too low
+
+    with pytest.raises(ValueError):
+        parse_in_radix("0", radix=40)  # radix too high
+
+
+def test_format_in_radix():
+
+    # Just some random examples...
+    assert format_in_radix(0, radix=10) == "0"
+    assert format_in_radix(13, radix=2) == "1101"
+    assert format_in_radix(123, radix=10) == "123"
+    assert format_in_radix(3 * (8 * 8) + 2 * 8 + 5, radix=8) == "325"
+    assert format_in_radix(13 * (16 ** 3) + 14 * (16 ** 2) + 10 * (16 ** 1) + 13 * (16 ** 0), radix=16) == "DEAD"
+    assert format_in_radix(36 * 36 + 35, radix=36) == "10Z"
+
+    for r in range(2, 37):
+        for i in range(0, 6):
+            for n in [i, r ** i, r ** i - 1]:
+                assert parse_in_radix(format_in_radix(n, radix=r), radix=r) == n
+
+    with pytest.raises(ValueError):
+        assert format_in_radix(-27, radix=10)  # won't format negative number
+
+    with pytest.raises(ValueError):
+        format_in_radix(27, radix=1)  # radix too low
+
+    with pytest.raises(ValueError):
+        format_in_radix(27, radix=40)  # radix too high
+
+
+def test_managed_property():
+
+    class Temperature:
+
+        def __init__(self, fahrenheit=32):
+            self.fahrenheit = fahrenheit
+
+        @managed_property
+        def centigrade(self, degrees):
+            if degrees == managed_property.MISSING:
+                return (self.fahrenheit - 32) * 5 / 9.0
+            else:
+                self.fahrenheit = degrees * 9 / 5.0 + 32
+
+    t1 = Temperature()
+    assert t1.fahrenheit == 32
+    assert t1.centigrade == 0.0
+
+    t2 = Temperature(fahrenheit=68)
+    assert t2.fahrenheit == 68.0
+    assert t2.centigrade == 20.0
+    t2.centigrade = 5
+    assert t2.centigrade == 5.0
+    assert t2.fahrenheit == 41.0
+
+    t2.fahrenheit = -40
+    assert t2.centigrade == -40.0
+
+
+def test_min_datetime():
+
+    assert MIN_DATETIME == datetime_module.datetime(1, 1, 1, 0, 0, 0)
+
+    assert MIN_DATETIME.replace(tzinfo=pytz.UTC) == MIN_DATETIME_UTC
+
+
+def test_future_datetime():
+
+    dt = ControlledTime(tick_seconds=0.1)
+
+    now = dt.just_now()
+
+    with mock.patch.object(misc_utils_module, "datetime", dt):
+
+        an_hour_from_now = future_datetime(minutes=60)  # computing now() inside this will consume one tick = .1 second
+
+        assert an_hour_from_now == now + datetime_module.timedelta(hours=1, seconds=0.1)
+
+        two_hours_from_now = future_datetime(hours=2, now=now)  # this won't check the time, so no seconds consumed
+
+        assert two_hours_from_now == now + datetime_module.timedelta(hours=2)

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -30,7 +30,7 @@ from dcicutils.misc_utils import (
     classproperty, classproperty_cached, classproperty_cached_each_subclass, Singleton, NamedObject, obsolete,
     ObsoleteError, CycleError, TopologicalSorter, keys_and_values_to_dict, dict_to_keys_and_values, is_c4_arn,
     deduplicate_list, chunked, parse_in_radix, format_in_radix, managed_property, future_datetime,
-    MIN_DATETIME, MIN_DATETIME_UTC, INPUT,
+    MIN_DATETIME, MIN_DATETIME_UTC, INPUT, builtin_print,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output,
@@ -62,6 +62,15 @@ def test_uppercase_input():
         with input_series(some_response):
             assert INPUT(some_prompt) == some_response
     assert printed.lines == [some_prompt]
+
+
+def test_builtin_print():
+
+    with printed_output() as print:
+        s = io.StringIO()
+        builtin_print("foo", file=s)
+        assert s.getvalue() == "foo\n"
+    assert print.lines == []  # builtin_print does not cooperate in this stuff
 
 
 def test_ignored():

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -24,7 +24,7 @@ from dcicutils.qa_utils import (
     ControlledTime, Occasionally, RetryManager, MockFileSystem, NotReallyRandom, MockUUIDModule, MockedCommandArgs,
     MockResponse, printed_output, MockBotoS3Client, MockKeysNotImplemented, MockBoto3, known_bug_expected,
     raises_regexp, VersionChecker, check_duplicated_items_by_key, guess_local_timezone_for_testing,
-    logged_messages, input_mocked, ChangeLogChecker, MockLog, MockId, Eventually, Timer, MockObjectAttributeBlock,
+    logged_messages, input_mocked, ChangeLogChecker, MockLog, MockId, Eventually, Timer,
 )
 # The following line needs to be separate from other imports. It is PART OF A TEST.
 from dcicutils.qa_utils import notice_pytest_fixtures   # Use care if editing this line. It is PART OF A TEST.
@@ -1156,7 +1156,7 @@ def test_mock_boto3_client_use():
         assert isinstance(s3, MockBotoS3Client)
 
         assert s3._object_storage_class('foo/bar') == s3.DEFAULT_STORAGE_CLASS == 'STANDARD'
-        s3._set_object_storage_class('foo/bar', 'DEEP_ARCHIVE')
+        s3._set_object_storage_class_for_testing('foo/bar', 'DEEP_ARCHIVE')
         assert s3._object_storage_class('foo/bar') == 'DEEP_ARCHIVE'
         assert s3._object_storage_class('foo/baz') == 'STANDARD'
 
@@ -1953,7 +1953,7 @@ def test_s3_copy_object_restoring():
             # time.sleep(MockBotoS3Client.RESTORATION_DELAY_SECONDS)
             s3.hurry_restoration_for_testing(s3_filename)
             s3.copy_object(CopySource={'Bucket': bucket_name, 'Key': key_name, 'VersionId': existing_version_id},
-                           Bucket=bucket_name, Key=key_name+"_new", # CopySourceVersionId=existing_version_id,
+                           Bucket=bucket_name, Key=key_name + "_new",  # NOTE: Not using CopySourceVersionId here.
                            StorageClass='STANDARD')
             print("Step 6")
             show_s3_debugging_data(mfs=mfs, s3=s3, bucket_name=bucket_name)
@@ -1965,9 +1965,6 @@ def test_s3_copy_object_restoring():
             version_info = show_s3_list_object_version_data(s3=s3, bucket_name=bucket_name)
             versions = version_info['Versions']
             assert len(versions) == 2
-
-
-
 
 
 def test_s3_copy_object_new():

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -1390,7 +1390,6 @@ def test_object_basic_attribute_block():
 
 def test_object_delete_marker():
 
-    start_time = datetime.datetime.now()
     sample_filename = "foo"
     mock_boto3 = MockBoto3()
     s3 = mock_boto3.client('s3')
@@ -1438,32 +1437,33 @@ def test_object_attribute_block():
     assert b.tagset == []
     b.set_tagset(sample_tagset)
     assert b.tagset == sample_tagset
-    assert b.content == None
+    assert b.content is None
     b.set_content(sample_content)
     assert b.content == sample_content
     with pytest.raises(Exception):
         b.set_content(sample_content)
 
-    assert b.restoration == None
-    b.restore_temporarily(delay_seconds=sample_delay_seconds, duration_days=sample_duration_days, storage_class='STANDARD')
+    assert b.restoration is None
+    b.restore_temporarily(delay_seconds=sample_delay_seconds, duration_days=sample_duration_days,
+                          storage_class='STANDARD')
     assert isinstance(b.restoration, MockTemporaryRestoration)
     assert b.restoration.available_after > start_time
     assert b.restoration.available_after < datetime.datetime.now() + datetime.timedelta(seconds=sample_delay_seconds)
-    assert b.storage_class is 'STANDARD'
+    assert b.storage_class == 'STANDARD'
     b.hurry_restoration()
-    assert b.storage_class is 'STANDARD'
+    assert b.storage_class == 'STANDARD'
     assert b.restoration.available_after < datetime.datetime.now()
     assert b.restoration.available_until > datetime.datetime.now()
     assert b.restoration.available_until > datetime.datetime.now()
     assert b.restoration.available_until < datetime.datetime.now() + datetime.timedelta(days=sample_duration_days,
                                                                                         seconds=sample_delay_seconds)
-    assert b.storage_class is 'STANDARD'
+    assert b.storage_class == 'STANDARD'
     b.hurry_restoration_expiry()
     # We have to examine ._restoration because an expired restoration will disappear as soon as we check it
     assert b._restoration.available_until < datetime.datetime.now()
     # Here we see it goes away...
     assert b.restoration is None
-    assert b.storage_class is 'GLACIER'
+    assert b.storage_class == 'GLACIER'
 
 
 def test_mock_keys_not_implemented():

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -25,7 +25,7 @@ from dcicutils.env_utils_legacy import (
 from dcicutils.exceptions import SynonymousEnvironmentVariablesMismatched, CannotInferEnvFromManyGlobalEnvs
 from dcicutils.ff_mocks import make_mock_es_url, make_mock_portal_url
 from dcicutils.misc_utils import ignored, ignorable, override_environ, exported
-from dcicutils.qa_utils import MockBoto3, MockResponse, known_bug_expected
+from dcicutils.qa_utils import MockBoto3, MockResponse, known_bug_expected, MockBotoS3Client
 from dcicutils.s3_utils import s3Utils, HealthPageKey
 from requests.exceptions import ConnectionError
 from typing import Optional, Callable, Dict
@@ -1381,6 +1381,13 @@ def test_get_and_set_object_tags():
     with mock.patch.object(s3_utils_module, "boto3", mock_boto3):
 
         s3u = s3Utils(sys_bucket='irrelevant')
+
+        s3 = s3u.s3
+
+        assert isinstance(s3, MockBotoS3Client)
+
+        # An s3 file must exist for us to manipulate its tags
+        s3.create_object_for_testing("irrelevant", Bucket=bucket, Key=key)
 
         actual = s3u.get_object_tags(key=key, bucket=bucket)
         expected = []


### PR DESCRIPTION
* In ``dcicutils.command_utils``:

  * New decorator ``require_confirmation``

* In ``dcicutils.common``:

  * New variable ``ALL_S3_STORAGE_CLASSES``
  * New variable ``AVAILABLE_S3_STORAGE_CLASSES``
  * New variable ``S3_GLACIER_CLASSES``
  * New type hint ``S3GlacierClass``
  * New type hint ``S3StorageClass``

* In ``dcicutils.misc_utils``:

  * New function ``INPUT``
  * New function ``future_datetime``
  * New decorator ``managed_property``
  * New function ``map_chunked``
  * New function ``format_in_radix``
  * New function ``parse_in_radix``

* In ``dcicutils.qa_checkers``:

  * Fix bug in ``print`` statement recognizer

* In ``dcicutils.qa_utils``:

  * Support for Glacier-related operations in ``MockBotoS3Client``:

    * Method ``copy_object``
    * Method ``delete_object``
    * Method ``list_object_versions``
    * Method ``restore_object``

* Load ``coveralls`` dependency only dynamically in GA workflow, not in poetry, because it implicates ``docopt`` library, which needs ``2to3``, and would fail.