### PR TITLE
Small Glacier Update

### DIFF
--- a/dcicutils/common.py
+++ b/dcicutils/common.py
@@ -94,7 +94,6 @@ AVAILABLE_S3_STORAGE_CLASSES = [
 #
 # See boto3 docs for info on possible values, but these 3 are the current ones used for
 # glacier (that require restore calls) - Will 7 Apr 2023
-
 S3_GLACIER_CLASSES = [
     'GLACIER_IR',  # Glacier Instant Retrieval
     'GLACIER',  # Glacier Flexible Retrieval
@@ -116,6 +115,10 @@ S3StorageClass = Union[
     Literal['OUTPOSTS'],
     Literal['GLACIER_IR'],
 ]
+
+
+# This constant is used in our Lifecycle management system to automatically transition objects
+ENCODED_LIFECYCLE_TAG_KEY = 'Lifecycle'
 
 
 # These numbers come from AWS and is the max size that can be copied with a single request

--- a/dcicutils/glacier_utils.py
+++ b/dcicutils/glacier_utils.py
@@ -2,7 +2,10 @@ import boto3
 from typing import Union, List, Tuple
 from concurrent.futures import ThreadPoolExecutor
 from tqdm import tqdm
-from .common import S3_GLACIER_CLASSES, S3StorageClass, MAX_MULTIPART_CHUNKS, MAX_STANDARD_COPY_SIZE
+from .common import (
+    S3_GLACIER_CLASSES, S3StorageClass, MAX_MULTIPART_CHUNKS, MAX_STANDARD_COPY_SIZE,
+    ENCODED_LIFECYCLE_TAG_KEY
+)
 from .command_utils import require_confirmation
 from .misc_utils import PRINT
 from .ff_utils import get_metadata, search_metadata, get_health_page, patch_metadata
@@ -255,8 +258,18 @@ class GlacierUtils:
             PRINT(f'Error deleting Glacier versions of object {bucket}/{key}: {str(e)}')
             return False
 
+    @staticmethod
+    def _format_tags(tags: List[dict]) -> str:
+        """ Helper method that formats tags so they match the format expected by the boto3 API
+
+        :param tags: array of dictionaries containing Key, Value mappings to be reformatted
+        :return: String formatted tag list ie:
+            [{Key: key1, Value: value1}, Key: key2, Value: value2}] --> 'key1=value1&key2=value2'
+        """
+        return '&'.join([f'{tag["Key"]}={tag["Value"]}' for tag in tags])
+
     def _do_multipart_upload(self, bucket: str, key: str, total_size: int, part_size: int = 200,
-                             storage_class: str = 'STANDARD', version_id: Union[str, None] = None) -> Union[dict, None]:
+                             storage_class: str = 'STANDARD', tags: str = '', version_id: Union[str, None] = None) -> Union[dict, None]:
         """ Helper function for copy_object_back_to_original_location, not intended to
             be called directly, will arrange for a multipart copy of large updates
             to change storage class
@@ -266,6 +279,7 @@ class GlacierUtils:
         :param total_size: total size of object
         :param part_size: what size to divide the object into when uploading the chunks
         :param storage_class: new storage class to use
+        :param tags: string of tags to apply
         :param version_id: object version Id, if applicable
         :return: response if successful, None otherwise
         """
@@ -275,7 +289,12 @@ class GlacierUtils:
             if num_parts > MAX_MULTIPART_CHUNKS:
                 raise GlacierRestoreException(f'Must user a part_size larger than {part_size}'
                                               f' that will result in fewer than {MAX_MULTIPART_CHUNKS} chunks')
-            mpu = self.s3.create_multipart_upload(Bucket=bucket, Key=key, StorageClass=storage_class)
+            cmu = {
+                'Bucket': bucket, 'Key': key, 'StorageClass': storage_class
+            }
+            if tags:
+                cmu['Tagging'] = tags
+            mpu = self.s3.create_multipart_upload(**cmu)
             mpu_upload_id = mpu['UploadId']
         except Exception as e:
             PRINT(f'Error creating multipart upload for {bucket}/{key} : {str(e)}')
@@ -327,6 +346,7 @@ class GlacierUtils:
 
     def copy_object_back_to_original_location(self, bucket: str, key: str, storage_class: str = 'STANDARD',
                                               part_size: int = 200,  # MB
+                                              preserve_lifecycle_tag: bool = False,
                                               version_id: Union[str, None] = None) -> Union[dict, None]:
         """ Reads the temporary location from the restored object and copies it back to the original location
 
@@ -334,6 +354,7 @@ class GlacierUtils:
         :param key: key within bucket where object is stored
         :param storage_class: new storage class for this object
         :param part_size: if doing a large copy, size of chunks to upload (in MB)
+        :param preserve_lifecycle_tag: whether to keep existing lifecycle tag on the object
         :param version_id: version of object, if applicable
         :return: boolean whether the copy was successful
         """
@@ -342,12 +363,18 @@ class GlacierUtils:
             response = self.s3.head_object(Bucket=bucket, Key=key)
             size = response['ContentLength']
             multipart = (size >= MAX_STANDARD_COPY_SIZE)
+            if not preserve_lifecycle_tag:  # default: preserve tags except 'Lifecycle'
+                tags = self.s3.get_object_tagging(Bucket=bucket, Key=key).get('TagSet', [])
+                tags = [tag for tag in tags if tag['Key'] != ENCODED_LIFECYCLE_TAG_KEY]
+                tags = self._format_tags(tags)
+            else:
+                tags = ''
         except Exception as e:
             PRINT(f'Could not retrieve metadata on file {bucket}/{key} : {str(e)}')
             return None
         try:
             if multipart:
-                return self._do_multipart_upload(bucket, key, size, part_size, storage_class, version_id)
+                return self._do_multipart_upload(bucket, key, size, part_size, storage_class, tags, version_id)
             else:
                 # Force copy the object into standard in a single operation
                 copy_source = {'Bucket': bucket, 'Key': key}
@@ -358,6 +385,8 @@ class GlacierUtils:
                 if version_id:
                     copy_source['VersionId'] = version_id
                     copy_target['CopySourceVersionId'] = version_id
+                if tags:
+                    copy_target['Tagging'] = tags
                 response = self.s3.copy_object(CopySource=copy_source, **copy_target)
                 PRINT(f'Response from boto3 copy:\n{response}')
                 PRINT(f'Object {bucket}/{key} copied back to its original location in S3')

--- a/dcicutils/s3_utils.py
+++ b/dcicutils/s3_utils.py
@@ -462,6 +462,8 @@ class s3Utils(s3Base):  # NOQA - This class name violates style rules, but a lot
         content_type = mimetypes.guess_type(upload_key)[0]
         if content_type is None:
             content_type = 'binary/octet-stream'
+        if isinstance(obj, dict):
+            obj = json.dumps(obj)
         if acl:
             # we use this to set some of the object as public
             return self.s3.put_object(Bucket=self.outfile_bucket,
@@ -480,6 +482,8 @@ class s3Utils(s3Base):  # NOQA - This class name violates style rules, but a lot
             bucket = self.sys_bucket
         if not secret:
             secret = os.environ["S3_ENCRYPT_KEY"]
+        if isinstance(data, dict):
+            data = json.dumps(data)
         return self.s3.put_object(Bucket=bucket,
                                   Key=keyname,
                                   Body=data,

--- a/test/test_glacier_utils.py
+++ b/test/test_glacier_utils.py
@@ -510,7 +510,7 @@ class TestGlacierUtils:
             with mock.patch.object(gu.s3, 'upload_part_copy', return_value={'CopyPartResult': {'ETag': 'abc'}}):
                 with mock.patch.object(gu.s3, 'complete_multipart_upload', return_value={'success': True}):
                     with mock.patch.object(gu.s3, 'head_object', return_value={'ContentLength': 600000000000}):
-                        assert gu.copy_object_back_to_original_location('bucket', 'key')
+                        assert gu.copy_object_back_to_original_location('bucket', 'key', preserve_lifecycle_tag=True)
 
     def test_glacier_utils_with_mock_s3(self, glacier_utils):
         """ Uses our mock_s3 system to test some operations with object versioning enabled """
@@ -525,7 +525,7 @@ class TestGlacierUtils:
                     key2_name = 'file2.txt'
                     with io.open(key_name, 'w') as fp:
                         fp.write("first contents")
-                    s3.upload_file(key_name, Bucket=bucket_name, Key=key_name,)
+                    s3.upload_file(key_name, Bucket=bucket_name, Key=key_name)
                     with io.open(key2_name, 'w') as fp:
                         fp.write("second contents")
                     s3.upload_file(key2_name, Bucket=bucket_name, Key=key2_name)

--- a/test/test_glacier_utils.py
+++ b/test/test_glacier_utils.py
@@ -535,4 +535,5 @@ class TestGlacierUtils:
                     versions = s3.list_object_versions(Bucket=bucket_name, Prefix=key2_name)
                     version_1 = versions['Versions'][0]['VersionId']
                     assert gu.restore_s3_from_glacier(bucket_name, key2_name, version_id=version_1)
-                    assert gu.copy_object_back_to_original_location(bucket_name, key2_name, version_id=version_1)
+                    assert gu.copy_object_back_to_original_location(bucket_name, key2_name, version_id=version_1,
+                                                                    preserve_lifecycle_tag=True)


### PR DESCRIPTION
- Updates `GlacierUtils` to remove `Lifecycle` tags from objects it is restoring (to prevent re-transfer by S3)