### PR TITLE
Small fixes to glacier2 tests that got broken

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,38 @@ dcicutils
 Change Log
 ----------
 
+
+7.4.1
+=====
+
+* In ``glacier_utils.py``:
+
+  * Fix calls to ``self.copy_object_back_to_original_location``
+    in ``restore_glacier_phase_two_copy``.
+
+* In ``qa_utils.py``:
+
+  * Make ``boto3.client('s3').put_object`` handle either a string
+    or bytes object correctly.
+
+* Actively mark tests that are already marked with
+  ``pytest.mark.beanstalk_failure`` to also use ``pytest.mark.skip``
+  so they don't run and confuse things even when markers are not in play.
+
+* Update some live ecosystem expectations to match present real world state.
+
+* Separate tests of live ecosystem so that the parts that are supposed
+  to pass reliably are in a separate function from the parts that are
+  thought to be in legit transition.
+
+* Misc changes to satisfy various syntax checkers.
+
+  * One stray call to `print` changed to `PRINT`.
+
+  * Various grammar errors fixed in comment strings because
+    PyCharm now whines about that, and the suggestions seemed reasonable.
+
+
 7.4.0
 =====
 

--- a/dcicutils/env_utils.py
+++ b/dcicutils/env_utils.py
@@ -197,7 +197,7 @@ class EnvUtils:
     ORCHESTRATED_APP = None  # This allows us to tell 'cgap' from 'fourfront', in case there ever is one.
     PRD_ENV_NAME = None  # the name of the prod env
     PRODUCTION_ECR_REPOSITORY = None  # the name of an ecr repository shared between stg and prd
-    PUBLIC_URL_TABLE = None  # dictionary mapping envnames & pseudo_envnames to public urls
+    PUBLIC_URL_TABLE = None  # list of dictionaries mapping envnames & pseudo_envnames to public urls
     STG_ENV_NAME = None  # the name of the stage env (or None)
     TEST_ENVS = None  # a list of environments that are for testing
     WEBPROD_PSEUDO_ENV = None

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -2269,6 +2269,8 @@ class MockBotoS3Client(MockBoto3Client):
     }
 
     def put_object(self, *, Bucket, Key, Body, ContentType=None, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
+        # TODO: This is not mocking other args like ACL that we might use ACL='public-read' or ACL='private'
+        #       grep for ACL= in tibanna, tibanna_ff, or dcicutils for examples of these values.
         # TODO: Shouldn't this be checking for required arguments (e.g., for SSE)? -kmp 9-May-2022
         if ContentType is not None:
             exts = self.PUT_OBJECT_CONTENT_TYPES.get(ContentType)
@@ -2276,6 +2278,8 @@ class MockBotoS3Client(MockBoto3Client):
             assert any(Key.endswith(ext) for ext in exts), (
                     "mock .put_object expects Key=%s to end in one of %s for ContentType=%s" % (Key, exts, ContentType))
         assert not kwargs, "put_object mock doesn't support %s." % kwargs
+        if isinstance(Body, str):
+            Body = Body.encode('utf-8')  # we just assume utf-8, which AWS seems to as well
         self.s3_files.files[Bucket + "/" + Key] = Body
         return {
             'ETag': self._content_etag(Body)

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -407,10 +407,10 @@ class MockFileWriter:
         content = self.stream.getvalue()
         file_system = self.file_system
         if file_system.exists(self.file):
-            if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
+            if FILE_SYSTEM_VERBOSE:  # pragma: no cover - Debugging option. Doesn't need testing.
                 PRINT(f"Preparing to overwrite {self.file}.")
             file_system.prepare_for_overwrite(self.file)
-        if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
+        if FILE_SYSTEM_VERBOSE:  # pragma: no cover - Debugging option. Doesn't need testing.
             PRINT(f"Writing {content!r} to {self.file}.")
         file_system.files[self.file] = content if isinstance(content, bytes) else content.encode(self.encoding)
 
@@ -459,7 +459,7 @@ class MockFileSystem:
             raise FileNotFoundError("No such file or directory: %s" % file)
 
     def open(self, file, mode='r', encoding=None):
-        if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
+        if FILE_SYSTEM_VERBOSE:  # pragma: no cover - Debugging option. Doesn't need testing.
             PRINT("Opening %r in mode %r." % (file, mode))
         if mode in ('w', 'wt', 'w+', 'w+t', 'wt+'):
             return self._open_for_write(file_system=self, file=file, binary=False, encoding=encoding)
@@ -477,7 +477,7 @@ class MockFileSystem:
         content = self.files.get(file)
         if content is None:
             raise FileNotFoundError("No such file or directory: %s" % file)
-        if FILE_SYSTEM_VERBOSE:  # noQA - Debugging option. Doesn't need testing.
+        if FILE_SYSTEM_VERBOSE:  # pragma: no cover - Debugging option. Doesn't need testing.
             PRINT("Read %r from %s." % (content, file))
         return io.BytesIO(content) if binary else io.StringIO(content.decode(encoding or self.default_encoding))
 

--- a/dcicutils/scripts/publish_to_pypi.py
+++ b/dcicutils/scripts/publish_to_pypi.py
@@ -116,7 +116,7 @@ def verify_git_repo() -> bool:
     """
     _, status = execute_command("git rev-parse --is-inside-work-tree")
     if status != 0:
-        print("You are not in a git repo directory!")
+        PRINT("You are not in a git repo directory!")
         return False
     return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.4.0"
+version = "7.4.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This change is small. It only looks large if you haven't merged master (7.4.1) into `glacier2`.

* Merges master (7.4.1)
* Fixes existing tests `test_s3utils_s3_put` and `test_s3utils_s3_put_secret`
* Adds new test `test_s3utils_s3_put_with_mock_boto_s3` that does mocking differently, testing more aspects of `s3Utils.s3_put`.

