### PR TITLE
Make test_get_response_json a unit test (C4-1031)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 ----------
 
 
+7.4.2
+=====
+
+* Rewrite test ``test_get_response_json`` as a unit test to get around its flakiness.
+
+
 7.4.1
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.4.1"
+version = "7.4.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -121,7 +121,27 @@ def test_generate_rand_accession():
     assert '0' not in test_cgap
 
 
-def test_get_response_json():
+@pytest.mark.integratedx
+@pytest.mark.flaky
+def test_get_response_json_integrated():
+    check_get_response_json()
+
+
+@pytest.mark.unit
+def test_get_response_json_unit():
+    def mocked_get(url):
+        if url == "http://httpbin.org/json":
+            return MockResponse(200, content='{"one": 1, "two": 2, "three": 3}')
+        elif url == "http://httpbin.org/status/500":
+            return MockResponse(500, content="<html>Simulated failure</html>")
+        else:
+            raise Exception(f"Mock needs to be extended. URL argument to requests.get was {url!r}")
+    with mock.patch.object(requests, "get") as mock_get:
+        mock_get.side_effect = mocked_get
+        check_get_response_json()
+
+
+def check_get_response_json():
     # use responses from http://httpbin.org
     good_res = requests.get('http://httpbin.org/json')
     good_res_json = ff_utils.get_response_json(good_res)


### PR DESCRIPTION
* Make `test_get_response_json` be a unit test to avoid flakiness. (We've been getting 504 Gateway Timeout. See [C4-1031](https://hms-dbmi.atlassian.net/browse/C4-1031))

[C4-1031]: https://hms-dbmi.atlassian.net/browse/C4-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ