### PR TITLE
Fix broken project_utils test (C4-1081)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ dcicutils
 Change Log
 ----------
 
+
+7.7.1
+=====
+
+* Fix `Tests are failing on utils master branch (`C4-1081 <https://hms-dbmi.atlassian.net/browse/C4-1081>`_), a problem with the ``project_utils`` test named ``test_project_registry_make_project_autoload``.
+
+
 7.7.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 7.7.1
 =====
 
-* Fix `Tests are failing on utils master branch (`C4-1081 <https://hms-dbmi.atlassian.net/browse/C4-1081>`_), a problem with the ``project_utils`` test named ``test_project_registry_make_project_autoload``.
+* Fix Tests are failing on utils master branch (`C4-1081 <https://hms-dbmi.atlassian.net/browse/C4-1081>`_), a problem with the ``project_utils`` test named ``test_project_registry_make_project_autoload``.
 
 
 7.7.0

--- a/dcicutils/project_utils.py
+++ b/dcicutils/project_utils.py
@@ -522,7 +522,7 @@ class ProjectRegistry:
                                                            pyproject_name=cls.PYPROJECT_NAME)
             clarification = ""
             if package_name != cls.PYPROJECT_NAME:
-                clarification = f" (package {package_name})"
+                clarification = f" (package {package_name!r})"
             PRINT(f"Autoloading project_defs.py for pyproject {cls.PYPROJECT_NAME!r}{clarification}.")
             try:
                 # PRINT(f"package_name={package_name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.7.0"
+version = "7.7.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
* Fix Tests are failing on utils master branch ([C4-1081](https://hms-dbmi.atlassian.net/browse/C4-1081)), a problem with the `project_utils` test named `test_project_registry_make_project_autoload`.


[C4-1081]: https://hms-dbmi.atlassian.net/browse/C4-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ