### PR TITLE
udn-browser license checker fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,19 @@ Change Log
 ----------
 
 
+7.7.2
+=====
+
+* In ``license_utils``:
+
+  * In ``license_utils.C4InfrastructureLicenseChecker``, allow exceptions for
+    libraries ``dnslib``, ``dnspython``, ``node-forge`` and ``udn-browser``.
+
+
 7.7.1
 =====
 
-* Fix Tests are failing on utils master branch (`C4-1081 <https://hms-dbmi.atlassian.net/browse/C4-1081>`_), a problem with the ``project_utils`` test named ``test_project_registry_make_project_autoload``.
+* Fix tests are failing on utils master branch (`C4-1081 <https://hms-dbmi.atlassian.net/browse/C4-1081>`_), a problem with the ``project_utils`` test named ``test_project_registry_make_project_autoload``.
 
 
 7.7.0

--- a/dcicutils/license_utils.py
+++ b/dcicutils/license_utils.py
@@ -657,6 +657,15 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
         'pyramid-translogger',
         'subprocess-middleware',
 
+        # This appears to be a BSD 2-Clause "Simplified" License, according to GitHub.
+        # PyPi also says it's a BSD license.
+        # Ref: https://github.com/paulc/dnslib/blob/master/LICENSE
+        'dnslib',
+
+        # This says it wants an ISC License, which we already have approval for but just isn't showing up.
+        # Ref: https://github.com/rthalley/dnspython/blob/master/LICENSE
+        'dnspython',
+
         # This appears to be a mostly-MIT-style license.
         # There are references to parts being in the public domain, though it's not obvious if that's meaningful.
         # It's probably sufficient for our purposes to treat this as a permissive license.

--- a/dcicutils/license_utils.py
+++ b/dcicutils/license_utils.py
@@ -680,6 +680,15 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
         # Ref: https://github.com/pkerpedjiev/negspy/blob/master/LICENSE
         'negspy',
 
+        # The license file for the node-forge javascript library says:
+        #
+        #   "You may use the Forge project under the terms of either the BSD License or the
+        #   GNU General Public License (GPL) Version 2."
+        #
+        # (We choose to use it under the BSD license.)
+        # Ref: https://www.npmjs.com/package/node-forge?activeTab=code
+        'node-forge',
+
         # This license statement is complicated, but seems adequately permissive.
         # Ref: https://foss.heptapod.net/python-libs/passlib/-/blob/branch/stable/LICENSE
         'passlib',
@@ -739,6 +748,10 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
         # This seems to be a BSD-3-Clause-Modification license.
         # Ref: https://github.com/Pylons/translationstring/blob/master/LICENSE.txt
         'translationstring',
+
+        # The udn-browser library is our own and may show up in some contexts as UNLICENSED, when really it's MIT.
+        # Ref: https://github.com/dbmi-bgm/udn-browser/blob/main/LICENSE
+        'udn-browser',
 
         # This seems to be a BSD-3-Clause-Modification license.
         # Ref: https://github.com/Pylons/venusian/blob/master/LICENSE.txt

--- a/dcicutils/license_utils.py
+++ b/dcicutils/license_utils.py
@@ -680,15 +680,6 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
         # Ref: https://github.com/pkerpedjiev/negspy/blob/master/LICENSE
         'negspy',
 
-        # The license file for the node-forge javascript library says:
-        #
-        #   "You may use the Forge project under the terms of either the BSD License or the
-        #   GNU General Public License (GPL) Version 2."
-        #
-        # (We choose to use it under the BSD license.)
-        # Ref: https://www.npmjs.com/package/node-forge?activeTab=code
-        'node-forge',
-
         # This license statement is complicated, but seems adequately permissive.
         # Ref: https://foss.heptapod.net/python-libs/passlib/-/blob/branch/stable/LICENSE
         'passlib',
@@ -748,10 +739,6 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
         # This seems to be a BSD-3-Clause-Modification license.
         # Ref: https://github.com/Pylons/translationstring/blob/master/LICENSE.txt
         'translationstring',
-
-        # The udn-browser library is our own and may show up in some contexts as UNLICENSED, when really it's MIT.
-        # Ref: https://github.com/dbmi-bgm/udn-browser/blob/main/LICENSE
-        'udn-browser',
 
         # This seems to be a BSD-3-Clause-Modification license.
         # Ref: https://github.com/Pylons/venusian/blob/master/LICENSE.txt
@@ -814,13 +801,6 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
             'turf-jsts'
         ],
 
-        # Linking = With Restrictions, Private Use = Yes
-        # Ref: https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses
-        'GNU Lesser General Public License v3 or later (LGPLv3+)': [
-            'pytest-redis',  # used only privately in testing, not used in server code, not modified, not distributed
-            'mirakuru',      # required by pytest-redis (used only where it's used)
-        ],
-
         # DFSG = Debian Free Software Guidelines
         # Ref: https://en.wikipedia.org/wiki/Debian_Free_Software_Guidelines
         # Used as an apparent modifier to other licenses, to say they are approved per Debian.
@@ -828,6 +808,13 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
         # but is really just an MIT License that someone has checked is DFSG approved.
         'DFSG approved': [
             'pytest-timeout',  # MIT Licensed
+        ],
+
+        # Linking = With Restrictions, Private Use = Yes
+        # Ref: https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses
+        'GNU Lesser General Public License v3 or later (LGPLv3+)': [
+            'pytest-redis',  # used only privately in testing, not used in server code, not modified, not distributed
+            'mirakuru',      # required by pytest-redis (used only where it's used)
         ],
 
         'GNU General Public License (GPL)': [
@@ -845,6 +832,17 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
             'psycopg2-binary',  # Used at runtime during server operation, but not modified or distributed
             'chardet',  # Potentially used downstream in loadxl to detect charset for text files
             'pyzmq',  # Used in post-deploy-perf-tests, not distributed, and not modified or distributed
+        ],
+
+        'GPL-2.0': [
+            # The license file for the node-forge javascript library says:
+            #
+            #   "You may use the Forge project under the terms of either the BSD License or the
+            #   GNU General Public License (GPL) Version 2."
+            #
+            # (We choose to use it under the BSD license.)
+            # Ref: https://www.npmjs.com/package/node-forge?activeTab=code
+            'node-forge',
         ],
 
         'MIT*': [
@@ -875,6 +873,14 @@ class C4InfrastructureLicenseChecker(LicenseChecker):
             'typed-function',  # LICENSE at https://www.npmjs.com/package/typed-function?activeTab=code
 
         ],
+
+        'UNLICENSED': [
+            # The udn-browser library is our own and has been observed to sometimes show up in some contexts
+            # as UNLICENSED, when really it's MIT.
+            # Ref: https://github.com/dbmi-bgm/udn-browser/blob/main/LICENSE
+            'udn-browser',
+        ],
+
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.7.1.0b1"
+version = "7.7.2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.7.1"
+version = "7.7.1.0b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
* Adds handling of dnslib and dnspython library licenses for @dmichaels-harvard.
* Adds handling of node-forge and udn-browser licenses for @alexander-veit.