### PR TITLE
Support for getting a schema from a portal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Change Log
 
   * New function ``get_schema`` that will pull down an individual schema definition.
   * New function ``get_schemas`` that will pull down all schema definitions.
+  * New argument ``allow_abstract`` to ``get_schema_names``
+    for conceptual compatibility with ``get_schemas``.
   * Minor tweaks to ``dump_results_to_json`` for style reasons,
     and repairs to its overly complex and error-prone unit test.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Change Log
 
   * New function ``get_schema`` that will pull down an individual schema definition.
   * New function ``get_schemas`` that will pull down all schema definitions.
+  * Minor tweaks to ``dump_results_to_json`` for style reasons,
+    and repairs to its overly complex and error-prone unit test.
 
 
 7.8.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,23 @@ Change Log
 ----------
 
 
+7.9.0
+=====
+
+* In ``misc_utils``:
+
+  * New function ``to_camelcase`` that can take either snake_case or CamelCase input.
+
+* In ``qa_utils``:
+
+  * New function ``is_subdict`` for asymmetric testing of dictionary equivalence.
+
+* In ``ff_utils``:
+
+  * New function ``get_schema`` that will pull down an individual schema definition.
+  * New function ``get_schemas`` that will pull down all schema definitions.
+
+
 7.8.0
 =====
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1,4 +1,5 @@
 import boto3
+import io
 import json
 import os
 import random
@@ -1482,6 +1483,14 @@ def convert_param(parameter_dict, vals_as_string=False):
                 if v % 1 == 0:
                     v = int(v)
             except ValueError:
+                # TODO: Maybe just catch Exception, not ValueError?
+                # This is why I hate advice to people that they try to second-guess error types for which they
+                # don't have express guarantees about the kinds of errors that can happen.
+                # Does the code author really want to have other errors go unhandled, or did they just think this
+                # was the only possible error. If it's the only possible error, Exception is a find way to catch it.
+                # In fact, float('a') will raise ValueError, but float(['a']) will raise TypeError.
+                # I think this should probably treat both of those the same, but I'm not going to make that change
+                # for now.. -kmp 21-Aug-2023
                 v = str(v)
         else:
             v = str(v)
@@ -1512,8 +1521,8 @@ def dump_results_to_json(store, folder):
     if not os.path.exists(folder):
         os.makedirs(folder)
     for a_type in store:
-        filename = folder + '/' + a_type + '.json'
-        with open(filename, 'w') as outfile:
+        filename = os.path.join(folder, a_type + '.json')
+        with io.open(filename, 'w') as outfile:
             json.dump(store[a_type], outfile, indent=4)
 
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -969,7 +969,7 @@ def get_schemas(key=None, ff_env=None, *, allow_abstract=True, require_id=False)
         key (dict):               standard ff_utils authentication key
         ff_env (str):             standard ff environment string
         allow_abstract (boolean): controls whether abstract schemas can be returned (default True, return them)
-        require_id (boolean):     controls whether a $id field is required for schema to be included
+        require_id (boolean):     controls whether a '$id' field is required for schema to be included
                                   (default False, include even if no $id)
 
     Returns:

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1511,13 +1511,17 @@ def generate_rand_accession(project_prefix='4DN', item_prefix='FI'):
 
 
 def dump_results_to_json(store, folder):
-    """Takes resuls from expand_es_metadata, and dumps them into the given folder in json format.
+    """
+    Takes resuls from expand_es_metadata, and dumps them into the given folder in json format.
+
+    e.g., given a dictionary {'a': a_dict, 'b': b_dict, 'c': c_dict}
+    it will write files 'a', 'b', and 'c' to the given folder (creating it if need be),
+    containing a_dict, b_dict, and c_dict, respectively.
+
     Args:
         store (dict): results from expand_es_metadata
         folder:       folder for storing output
     """
-    if folder[-1] == '/':
-        folder = folder[:-1]
     if not os.path.exists(folder):
         os.makedirs(folder)
     for a_type in store:

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -1331,6 +1331,16 @@ def snake_case_to_camel_case(s, separator='_'):
     return s.title().replace(separator, '')
 
 
+def to_camel_case(s):
+    """
+    Converts a string that might be in snake_case or CamelCase into CamelCase.
+    """
+    if s[:1].isupper() and '_' not in s:
+        return s
+    else:
+        return snake_case_to_camel_case(s)
+
+
 def capitalize1(s):
     """
     Capitalizes the first letter of a string and leaves the others alone.

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -3543,7 +3543,7 @@ def is_subdict(json1, json2, desc1="json1", desc2="json2", verbose=True):
         else:
             result = False
             if not result:
-                out(f"Mismatch at {path}.")
+                out(f"Type mismatch ({json1.__class__.__name__} vs {json2.__class__.__name__}) at {path!r}:")
                 out(f" {desc1}: {json1}")
                 out(f" {desc2}: {json2}")
         return result

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -3499,7 +3499,6 @@ def is_subdict(json1, json2, desc1="json1", desc2="json2", verbose=True):
         output explaining failures or near-failures when True, and otherwise, if False, not showing such output.
     """
 
-
     def out(x):
         if verbose:
             PRINT(x)

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -3478,9 +3478,9 @@ def input_series(*items):
 def is_subdict(json1, json2, desc1="json1", desc2="json2", verbose=True):
     """
     Does asymmetric testing of dictionary equivalence, assuring json2 has all the content of json1,
-    even if not vice versa. In other words, the dictionary structure is equivalent to the extent
-    that (recursively) all dictionary keys on the left occur in the right hand side even if not
-    necessarily all dictionary keys on the right occur in the left.
+    even if not vice versa. In other words, the dictionary structure is equivalent, to the extent
+    that (recursively) all dictionary keys on the left hand side also occur on the right hand side
+    even if not necessarily all dictionary keys on the right occur in the left.
 
     For example,
        x = {"foo": 3}

--- a/dcicutils/qa_utils.py
+++ b/dcicutils/qa_utils.py
@@ -10,6 +10,7 @@ import dateutil.tz as dateutil_tz
 import functools
 import hashlib
 import io
+import json
 import logging
 import os
 import pytest
@@ -720,7 +721,7 @@ class _PrintCapturer:
         texts = remove_suffix('\n', text).split('\n')
         last_text = texts[-1]
         result = wrapped_action(text, **kwargs)  # noQA - This call to print is low-level implementation
-        # This only captures non-file output output.
+        # This only captures non-file output.
         file = kwargs.get('file')
         if file is None:
             file = sys.stdout
@@ -853,7 +854,7 @@ class MockBoto3Session:
         self._aws_secret_access_key = kwargs.get("aws_secret_access_key")
         self._aws_region = region_name
 
-        # These is specific for testing.
+        # This is specific for testing.
         self._aws_credentials_dir = None
 
     # FYI: Some things to note about how boto3 (and probably any AWS client) reads AWS credentials/region.
@@ -915,7 +916,7 @@ class MockBoto3Session:
         self._aws_secret_access_key = aws_secret_access_key
         self._aws_region = region_name
 
-        # These is specific for testing.
+        # This is specific for testing.
         self._aws_credentials_dir = aws_credentials_dir
 
     @staticmethod
@@ -2270,8 +2271,7 @@ class MockBotoS3Client(MockBoto3Client):
     def upload_fileobj(self, Fileobj, Bucket, Key, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
         self.check_for_kwargs_required_by_mock("upload_fileobj", Bucket=Bucket, Key=Key, **kwargs)
         data = Fileobj.read()
-        PRINT("Uploading %s (%s bytes) to bucket %s key %s"
-              % (Fileobj, len(data), Bucket, Key))
+        PRINT(f"Uploading {Fileobj} ({len(data)} bytes) to bucket {Bucket} key {Key}")
         with self.s3_files.open(os.path.join(Bucket, Key), 'wb') as fp:
             fp.write(data)
 
@@ -2284,8 +2284,7 @@ class MockBotoS3Client(MockBoto3Client):
         self.check_for_kwargs_required_by_mock("download_fileobj", Bucket=Bucket, Key=Key, **kwargs)
         with self.s3_files.open(os.path.join(Bucket, Key), 'rb') as fp:
             data = fp.read()
-        PRINT("Downloading bucket %s key %s (%s bytes) to %s"
-              % (Bucket, Key, len(data), Fileobj))
+        PRINT(f"Downloading bucket {Bucket} key {Key} ({len(data)} bytes) to {Fileobj}")
         Fileobj.write(data)
 
     def download_file(self, Bucket, Key, Filename, **kwargs):  # noqa - Uppercase argument names are chosen by AWS
@@ -2382,7 +2381,7 @@ class MockBotoS3Client(MockBoto3Client):
         raise ClientError(operation_name='HeadBucket',
                           error_response={  # noQA - PyCharm wrongly complains about this dictionary
                               "Error": {"Code": "404", "Message": "Not Found"},
-                              "ResponseMetadata": {"HTTPStatusCode": 404},
+                              "ResponseMetadata": self.compute_mock_response_metadata(http_status_code=404),
                           })
 
     def get_object_tagging(self, Bucket, Key):
@@ -2645,7 +2644,7 @@ class MockBotoS3Client(MockBoto3Client):
         }
 
     def list_objects_v2(self, Bucket):  # noQA - AWS argument naming style
-        # This is different but similar to list_objects. However we don't really care about that.
+        # This is different but similar to list_objects. However, we don't really care about that.
         return self.list_objects(Bucket=Bucket)
 
     def copy_object(self, CopySource, Bucket, Key, CopySourceVersionId=None,
@@ -2698,7 +2697,7 @@ class MockBotoS3Client(MockBoto3Client):
         new_storage_class = target_storage_class
         if (copy_in_place
                 and GlacierUtils.transition_involves_glacier_restoration(source_storage_class, target_storage_class)):
-            new_storage_class = None  # For a restoration, the don't update the glacier data. It's restored elsewhere.
+            new_storage_class = None  # For a restoration, don't update the glacier data. It's restored elsewhere.
             target_attribute_block.restore_temporarily(delay_seconds=self.RESTORATION_DELAY_SECONDS,
                                                        duration_days=1, storage_class=target_storage_class)
             PRINT(f"Set up restoration {target_attribute_block.restoration}")
@@ -2806,6 +2805,7 @@ class MockBotoS3Client(MockBoto3Client):
 
     def restore_object(self, Bucket, Key, RestoreRequest, VersionId: Optional[str] = None,
                        StorageClass: Optional[S3StorageClass] = None):
+        # TODO: VersionId is unused in the arglist. Is that OK? -kmp 19-Aug-2023
         duration_days: int = RestoreRequest.get('Days')
         storage_class: S3StorageClass = StorageClass or self.storage_class
         s3_filename = f"{Bucket}/{Key}"
@@ -3047,8 +3047,8 @@ def known_bug_expected(jira_ticket=None, fixed=False, error_class=None):
         with known_bug_expected(jira_ticket="TST-00001", error_class=RuntimeError, fixed=True):
             ... stuff that fails ...
 
-    If the previously-expected error (now thought to be fixed) happens, an error will result so it's easy to tell
-    if there's been a regression.
+    If the previously-expected error (now thought to be fixed) happens, an error will result
+    so that it's easy to tell if there's been a regression.
 
     Parameters:
 
@@ -3088,7 +3088,7 @@ def client_failer(operation_name, code=400):
     def fail(message, code=code):
         raise ClientError(
             {  # noQA - PyCharm wrongly complains about this dictionary
-                "Error": {"Message": message, "Code": code}
+                "Error": {"Message": message, "Code": code}  # noQA - Boto3 declares a string here but allows int code
             },
             operation_name=operation_name)
     return fail
@@ -3473,3 +3473,79 @@ def input_series(*items):
             inputs.append(item)
         yield
         assert not inputs, "Did not use all inputs."
+
+
+def is_subdict(json1, json2, desc1="json1", desc2="json2", verbose=True):
+    """
+    Does asymmetric testing of dictionary equivalence, assuring json2 has all the content of json1,
+    even if not vice versa. In other words, the dictionary structure is equivalent to the extent
+    that (recursively) all dictionary keys on the left occur in the right hand side even if not
+    necessarily all dictionary keys on the right occur in the left.
+
+    For example,
+       x = {"foo": 3}
+       y = {"foo": 3, "bar": 4}
+       is_subdict(x, y) is True
+       is_subdict(y, x) is False
+
+    The desc1 and desc2 can be provided to help with verbose mode, identifying what is on the left
+    and what is on the right.
+
+    :param json1: a JSON structure, the outer part of which is a dictionary
+    :param json2: a JSON structure, the outer part of which is a dictionary
+    :param desc1: a name or brief description for the json1 (default "json1")
+    :param desc2: a name or brief description for the json2 (default "json2")
+    :param verbose: a boolean (default True) that controls whether the comparison is verbose, showing
+        output explaining failures or near-failures when True, and otherwise, if False, not showing such output.
+    """
+
+
+    def out(x):
+        if verbose:
+            PRINT(x)
+
+    def sorted_set_repr(x):
+        return f"{{{repr(sorted(x))[1:-1]}}}"
+
+    def recurse(json1, json2, path=""):
+        if isinstance(json1, dict) and isinstance(json2, dict):
+            k1 = set(json1.keys())
+            k2 = set(json2.keys())
+            result = k1 <= k2
+            if result:
+                if k1 != k2:
+                    out(f"Non-fatal keyword mismatch at {path!r}:")
+                    out(f" {desc1} keys: {sorted_set_repr(k1)}")
+                    out(f" {desc2} keys: {sorted_set_repr(k2)}")
+                result = all(recurse(value, json2[key], path=f"{path}.{key}")
+                             for key, value in json1.items())
+                if not result:
+                    # out(f"Recursive failure at {path!r} in object comparison")
+                    pass
+            else:
+                out(f"Failed at {path!r} in object comparison due to key set mismatch:")
+                out(f" {desc1} keys: {sorted_set_repr(k1)}")
+                out(f" {desc2} keys: {sorted_set_repr(k2)}")
+        elif isinstance(json1, list) and isinstance(json2, list):
+            len1 = len(json1)
+            len2 = len(json2)
+            result = len1 == len2
+            if not result:
+                out(f"Failed at {path!r} in list comparison due to length mismatch: {len1} vs {len2}")
+            else:
+                result = all(recurse(json1[i], json2[i], path=f"{path}[{i}]") for i in range(len1))
+                if not result:
+                    # out(f"Recursive failure at {path!r} in list comparison")
+                    pass
+        elif type(json1) == type(json2):
+            result = json1 == json2
+            if not result:
+                out(f"Failed at {path!r} due to value mismatch: {json.dumps(json1)} != {json.dumps(json2)}")
+        else:
+            result = False
+            if not result:
+                out(f"Mismatch at {path}.")
+                out(f" {desc1}: {json1}")
+                out(f" {desc2}: {json2}")
+        return result
+    return recurse(json1, json2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.8.0.1b0"
+version = "7.9.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.9.0"
+version = "7.8.0.1b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.8.0"
+version = "7.9.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_misc_utils.py
+++ b/test/test_misc_utils.py
@@ -30,7 +30,7 @@ from dcicutils.misc_utils import (
     classproperty, classproperty_cached, classproperty_cached_each_subclass, Singleton, NamedObject, obsolete,
     ObsoleteError, CycleError, TopologicalSorter, keys_and_values_to_dict, dict_to_keys_and_values, is_c4_arn,
     deduplicate_list, chunked, parse_in_radix, format_in_radix, managed_property, future_datetime,
-    MIN_DATETIME, MIN_DATETIME_UTC, INPUT, builtin_print, map_chunked,
+    MIN_DATETIME, MIN_DATETIME_UTC, INPUT, builtin_print, map_chunked, to_camel_case,
 )
 from dcicutils.qa_utils import (
     Occasionally, ControlledTime, override_environ as qa_override_environ, MockFileSystem, printed_output,
@@ -1976,6 +1976,23 @@ def test_snake_case_to_camel_case(token, expected):
 ])
 def test_snake_case_to_camel_case_hyphenated(token, expected):
     assert snake_case_to_camel_case(token, separator='-') == expected
+
+
+@pytest.mark.parametrize('token, expected', [
+    ('variant_sample', 'VariantSample'),
+    ('variant', 'Variant'),
+    ('_variant_', 'Variant'),
+    ('__variant', 'Variant'),
+    ('higlass_view_config', 'HiglassViewConfig'),
+    ('a_b_c_d', 'ABCD'),
+    ('', ''),
+    ('oneverylongthing1234567895_d', 'Oneverylongthing1234567895D'),
+    ('x_m_l_container', 'XMLContainer'),
+    ('X_M_L_Container', 'XMLContainer'),
+])
+def test_to_camel_case_hyphenated(token, expected):
+    assert to_camel_case(token) == expected
+    assert to_camel_case(expected) == expected  # make sure it's stable
 
 
 @pytest.mark.parametrize('token, expected', [

--- a/test/test_qa_utils.py
+++ b/test/test_qa_utils.py
@@ -2319,3 +2319,16 @@ def test_is_subdict():
                 ]
             else:
                 assert printed.lines == []
+
+    for verbose in [True, False]:
+        with printed_output() as printed:
+            assert not is_subdict({"foo": [1, 2, 3]},
+                                  {"foo": 3}, verbose=verbose)
+            if verbose:
+                assert printed.lines == [
+                    "Type mismatch (list vs int) at '.foo':",
+                    " json1: [1, 2, 3]",
+                    " json2: 3",
+                ]
+            else:
+                assert printed.lines == []


### PR DESCRIPTION
* Add `misc_utils.to_camelcase`.
* Add `qa_utils.is_subdict`.
* Add `ff_utils.get_schema` and `ff_utils.get_schemas`.
* Add unit tests for bug [C4-1087](https://hms-dbmi.atlassian.net/browse/C4-1087) (marked `xfail`).

Other opportunistic changes:

* Minor tweaks to ``ff_utils.dump_results_to_json`` for style reasons, and repairs to its overly complex and error-prone unit test.
* Various tiny grammar changes comments and doc strings while I was in there in ``ff_utils`` because PyCharm grammar checker was fussing.

NOTES TO REVIEWERS:

* I am not sure why this endpoint is called profiles and not schemas, or what the difference is. So @willronchetti  had originally suggested some sort of `get_profile` function for `ff_utils` but I decided to call it `get_schema` instead since that better describes what I want. If there is a reason `get_profile` is a better name, that would be useful to know.
* Will had suggested a single function to get either a single schema or several, but that complicates the return type in the type hints, so I opted for separate functions to keep the simple function returning something that doesn't have to be peeled down further upon receipt. I don't really even need `get_schemas` so am open to a suggestion to just not include that, though I can see why it might be useful. It would be more useful if the profile operation took (maybe comma-separated?) several filenames.


[C4-1087]: https://hms-dbmi.atlassian.net/browse/C4-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ