### PR TITLE
Fix to get_schema(s) to use URL prefixed with slash for vapp.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ Change Log
 ----------
 
 
+7.11.0
+======
+
+* In ``ff_utils``:
+
+  * Fix in ``get_schema`` and ``get_schemas`` for the ``portal_vapp`` case needing a leading slash on the URL.
+  * Fix in ``get_schema`` and ``get_schemas`` for the ``portal_vapp`` returning webtest.response.TestResponse
+    which has a ``json`` object property rather than a function.
+
 7.10.0
 ======
 

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -990,7 +990,7 @@ def get_schema(name, key=None, ff_env: Optional[str] = None, portal_env: Optiona
     base_url = f"profiles/{to_camel_case(name)}.json"
     add_on = 'frame=raw'
     if portal_vapp:
-        full_url = f"{base_url}?{add_on}"
+        full_url = f"/{base_url}?{add_on}"
         res = portal_vapp.get(full_url)
         return get_response_json(res)
     else:
@@ -1022,7 +1022,7 @@ def get_schemas(key=None, ff_env: Optional[str] = None, *, allow_abstract: bool 
     base_url = 'profiles/'
     add_on = 'frame=raw'
     if portal_vapp:
-        full_url = f"{base_url}?{add_on}"
+        full_url = f"/{base_url}?{add_on}"
         schemas: Dict[str, Dict] = portal_vapp.get(full_url)
     else:
         schemas: Dict[str, Dict] = get_metadata(obj_id=base_url, key=key, ff_env=portal_env, add_on=add_on)
@@ -1488,6 +1488,7 @@ def get_response_json(res):
     it is not present. Used with the metadata functions.
     """
     try:
+        # TODO: Fix for res being from vapp (webtest.response.TestRespons) call, using MockResponse ...
         res_json = res.json()
     except Exception:
         raise Exception('Cannot get json for request to %s. Status'

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -1488,7 +1488,7 @@ def get_response_json(res):
     it is not present. Used with the metadata functions.
     """
     try:
-        # TODO: Fix for res being from vapp (webtest.response.TestRespons) call, using MockResponse ...
+        # TODO: Fix for res being from vapp (webtest.response.TestResponse) call, using MockResponse ...
         res_json = res.json()
     except Exception:
         raise Exception('Cannot get json for request to %s. Status'

--- a/dcicutils/ff_utils.py
+++ b/dcicutils/ff_utils.py
@@ -17,7 +17,7 @@ from .common import (
     # S3BucketName, S3KeyName,
 )
 from .lang_utils import disjoined_list
-from .misc_utils import PRINT, to_camel_case, remove_suffix, VirtualApp
+from .misc_utils import PRINT, to_camel_case, remove_suffix, VirtualApp, VirtualAppResponse
 
 
 # TODO (C4-92, C4-102): Probably to centralize this information in env_utils. Also figure out relation to CGAP.
@@ -1488,8 +1488,10 @@ def get_response_json(res):
     it is not present. Used with the metadata functions.
     """
     try:
-        # TODO: Fix for res being from vapp (webtest.response.TestResponse) call, using MockResponse ...
-        res_json = res.json()
+        if isinstance(res, VirtualAppResponse):
+            res_json = res.json
+        else:
+            res_json = res.json()
     except Exception:
         raise Exception('Cannot get json for request to %s. Status'
                         ' code: %s. Response text: %s' %

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -295,7 +295,9 @@ class VirtualApp:
         """
         return self.wrapped_app.app
 
+
 VirtualAppResponse = webtest.response.TestResponse
+
 
 def exported(*variables):
     """

--- a/dcicutils/misc_utils.py
+++ b/dcicutils/misc_utils.py
@@ -295,6 +295,7 @@ class VirtualApp:
         """
         return self.wrapped_app.app
 
+VirtualAppResponse = webtest.response.TestResponse
 
 def exported(*variables):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "7.10.0"
+version = "7.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_ff_utils.py
+++ b/test/test_ff_utils.py
@@ -1366,7 +1366,7 @@ def test_get_schema_with_vapp():
             mock_get_authentication_with_server.assert_not_called()
             mock_get_metadata.assert_not_called()
 
-            sample_vapp.get.assert_called_once_with('profiles/User.json?frame=raw')
+            sample_vapp.get.assert_called_once_with('/profiles/User.json?frame=raw')
 
 
 @pytest.mark.unit
@@ -1418,7 +1418,7 @@ def test_get_schemas_with_vapp():
             mock_get_authentication_with_server.assert_not_called()
             mock_get_metadata.assert_not_called()
 
-            sample_vapp.get.assert_called_once_with('profiles/?frame=raw')
+            sample_vapp.get.assert_called_once_with('/profiles/?frame=raw')
 
 
 def test_get_schemas_options():


### PR DESCRIPTION
- For the vapp (portal_vapp) case, the URL for ff_utils.get_schema(s) needs to be prefixed with a slash; maybe true in general but nervous about changing that now for fear of wider breakage.
- Also, the response from vapp.get returns a webtest.response.TestResponse, which has a json property which is an object rather than a function; handling this in ff_utils.get_response_json.