### PR TITLE
Update ONLY Ubuntu (from 20.04) to 22.04 - see if there is any GA issue.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test dcicutils with Python ${{ matrix.python_version }}
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python_version: [3.7, 3.8, 3.9]


### PR DESCRIPTION
TEMPORARY: Experiment to see if updating to 22.04 (strictly off master with no other changes) causes GA test failures.