### PR TITLE
More schema parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ dcicutils
 Change Log
 ----------
 
+8.11.0
+======
+
+* Add more schema parsing functions to `schema_utils`, including for new properties for
+  generating submission templates
+
+
 8.10.0
 ======
 

--- a/dcicutils/schema_utils.py
+++ b/dcicutils/schema_utils.py
@@ -9,6 +9,7 @@ class JsonSchemaConstants:
     ARRAY = "array"
     BOOLEAN = "boolean"
     DEFAULT = "default"
+    DEPENDENT_REQUIRED = "dependentRequired"
     ENUM = "enum"
     FORMAT = "format"
     INTEGER = "integer"
@@ -31,8 +32,9 @@ class EncodedSchemaConstants:
     MERGE_REF = "$merge"
     MIXIN_PROPERTIES = "mixinProperties"
     SUBMISSION_COMMENT = "submissionComment"
-    SUBMISSION_EXAMPLE = "submissionExample"
+    SUBMISSION_EXAMPLES = "submissionExamples"
     SUBMITTER_REQUIRED = "submitterRequired"
+    SUGGESTED_ENUM = "suggested_enum"
     UNIQUE_KEY = "uniqueKey"
 
 
@@ -228,13 +230,27 @@ def get_submission_comment(schema: Dict[str, Any]) -> str:
     return schema.get(SchemaConstants.SUBMISSION_COMMENT, "")
 
 
-def get_submission_example(schema: Dict[str, Any]) -> str:
+def get_submission_examples(schema: Dict[str, Any]) -> List[str]:
     """Return the submission example for a property.
 
     Custom property that can be manually added to a schema to provide
     an example for submitters.
     """
-    return schema.get(SchemaConstants.SUBMISSION_EXAMPLE, "")
+    return schema.get(SchemaConstants.SUBMISSION_EXAMPLES, [])
+
+
+def get_suggested_enum(schema: Dict[str, Any]) -> List[str]:
+    """Return the suggested enum for a property.
+
+    Custom property that can be manually added to a schema to provide
+    a suggested list of values for submitters.
+    """
+    return schema.get(SchemaConstants.SUGGESTED_ENUM, [])
+
+
+def get_dependent_required(schema: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Return the dependent required properties of a schema."""
+    return schema.get(SchemaConstants.DEPENDENT_REQUIRED, {})
 
 
 class Schema:

--- a/dcicutils/schema_utils.py
+++ b/dcicutils/schema_utils.py
@@ -30,6 +30,7 @@ class EncodedSchemaConstants:
     LINK_TO = "linkTo"
     MERGE_REF = "$merge"
     MIXIN_PROPERTIES = "mixinProperties"
+    SUBMISSION_COMMENT = "submissionComment"
     SUBMITTER_REQUIRED = "submitterRequired"
     UNIQUE_KEY = "uniqueKey"
 
@@ -214,6 +215,15 @@ def is_submitter_required(schema: Dict[str, Any]) -> bool:
     or allOf schema, which is tricky to pick up on automatically.
     """
     return schema.get(SchemaConstants.SUBMITTER_REQUIRED, False)
+
+
+def get_submission_comment(schema: Dict[str, Any]) -> str:
+    """Return the submission comment of a schema.
+
+    Custom property that can be manually added to a schema to provide
+    additional context for submitters.
+    """
+    return schema.get(SchemaConstants.SUBMISSION_COMMENT, "")
 
 
 class Schema:

--- a/dcicutils/schema_utils.py
+++ b/dcicutils/schema_utils.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Dict, List, Optional, Tuple
+
 from dcicutils.misc_utils import to_camel_case
 
 
@@ -29,6 +30,7 @@ class EncodedSchemaConstants:
     LINK_TO = "linkTo"
     MERGE_REF = "$merge"
     MIXIN_PROPERTIES = "mixinProperties"
+    SUBMITTER_REQUIRED = "submitterRequired"
     UNIQUE_KEY = "uniqueKey"
 
 
@@ -201,6 +203,17 @@ def get_enum(property_schema: Dict[str, Any]) -> List[str]:
 def get_description(schema: Dict[str, Any]) -> str:
     """Return the description of a schema."""
     return schema.get(SchemaConstants.DESCRIPTION, "")
+
+
+def is_submitter_required(schema: Dict[str, Any]) -> bool:
+    """Return True if the schema is marked as required for submitters.
+
+    This is a custom property that can be manually added to a property
+    to designate explicitly it as required for external submitters.
+    This is typically validated within the context of a oneOf, anyOf,
+    or allOf schema, which is tricky to pick up on automatically.
+    """
+    return schema.get(SchemaConstants.SUBMITTER_REQUIRED, False)
 
 
 class Schema:

--- a/dcicutils/schema_utils.py
+++ b/dcicutils/schema_utils.py
@@ -31,6 +31,7 @@ class EncodedSchemaConstants:
     MERGE_REF = "$merge"
     MIXIN_PROPERTIES = "mixinProperties"
     SUBMISSION_COMMENT = "submissionComment"
+    SUBMISSION_EXAMPLE = "submissionExample"
     SUBMITTER_REQUIRED = "submitterRequired"
     UNIQUE_KEY = "uniqueKey"
 
@@ -209,21 +210,31 @@ def get_description(schema: Dict[str, Any]) -> str:
 def is_submitter_required(schema: Dict[str, Any]) -> bool:
     """Return True if the schema is marked as required for submitters.
 
-    This is a custom property that can be manually added to a property
-    to designate explicitly it as required for external submitters.
+    Specifically, required for external (i.e. non-admin) submitters.
+
     This is typically validated within the context of a oneOf, anyOf,
-    or allOf schema, which is tricky to pick up on automatically.
+    or allOf schema on an item type which is used within the team and
+    by external submitters, and is tricky to pick up on automatically.
     """
     return schema.get(SchemaConstants.SUBMITTER_REQUIRED, False)
 
 
 def get_submission_comment(schema: Dict[str, Any]) -> str:
-    """Return the submission comment of a schema.
+    """Return the submission comment for a property.
 
     Custom property that can be manually added to a schema to provide
     additional context for submitters.
     """
     return schema.get(SchemaConstants.SUBMISSION_COMMENT, "")
+
+
+def get_submission_example(schema: Dict[str, Any]) -> str:
+    """Return the submission example for a property.
+
+    Custom property that can be manually added to a schema to provide
+    an example for submitters.
+    """
+    return schema.get(SchemaConstants.SUBMISSION_EXAMPLE, "")
 
 
 class Schema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.10.0"
+version = "8.11.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.9.0"
+version = "8.10.0.0b0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_schema_utils.py
+++ b/test/test_schema_utils.py
@@ -43,6 +43,7 @@ FORMAT = "email"
 PATTERN = "some_regex"
 ENUM = ["foo", "bar"]
 DESCRIPTION = "foo"
+COMMENT = "bar"
 STRING_SCHEMA = {
     "type": "string",
     "format": FORMAT,
@@ -51,6 +52,7 @@ STRING_SCHEMA = {
     "enum": ENUM,
     "description": DESCRIPTION,
     "submitterRequired": True,
+    "submissionComment": COMMENT,
 }
 ARRAY_SCHEMA = {"type": "array", "items": [STRING_SCHEMA]}
 OBJECT_SCHEMA = {"type": "object", "properties": {"foo": STRING_SCHEMA}}
@@ -376,3 +378,14 @@ def test_get_description(schema: Dict[str, Any], expected: str) -> None:
 )
 def test_is_submitter_required(schema: Dict[str, Any], expected: bool) -> None:
     assert schema_utils.is_submitter_required(schema) == expected
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ({}, ""),
+        (STRING_SCHEMA, COMMENT),
+    ],
+)
+def test_get_submission_comment(schema: Dict[str, Any], expected: str) -> None:
+    assert schema_utils.get_submission_comment(schema) == expected

--- a/test/test_schema_utils.py
+++ b/test/test_schema_utils.py
@@ -31,6 +31,10 @@ PROPERTIES = {
     },
     "fun": {"type": "array", "items": {"type": "string"}},
 }
+DEPENDENT_REQUIRED = {
+    "bar": ["baz"],
+    "foo": ["fu"],
+}
 SCHEMA = {
     "required": REQUIRED,
     "anyOf": ANY_OF,
@@ -38,13 +42,14 @@ SCHEMA = {
     "identifyingProperties": IDENTIFYING_PROPERTIES,
     "mixinProperties": MIXIN_PROPERTIES,
     "properties": PROPERTIES,
+    "dependentRequired": DEPENDENT_REQUIRED,
 }
 FORMAT = "email"
 PATTERN = "some_regex"
 ENUM = ["foo", "bar"]
 DESCRIPTION = "foo"
 COMMENT = "bar"
-EXAMPLE = "baz"
+EXAMPLE = ENUM
 STRING_SCHEMA = {
     "type": "string",
     "format": FORMAT,
@@ -54,7 +59,8 @@ STRING_SCHEMA = {
     "description": DESCRIPTION,
     "submitterRequired": True,
     "submissionComment": COMMENT,
-    "submissionExample": EXAMPLE,
+    "submissionExamples": EXAMPLE,
+    "suggested_enum": ENUM,
 }
 ARRAY_SCHEMA = {"type": "array", "items": [STRING_SCHEMA]}
 OBJECT_SCHEMA = {"type": "object", "properties": {"foo": STRING_SCHEMA}}
@@ -396,9 +402,33 @@ def test_get_submission_comment(schema: Dict[str, Any], expected: str) -> None:
 @pytest.mark.parametrize(
     "schema,expected",
     [
-        ({}, ""),
+        ({}, []),
         (STRING_SCHEMA, EXAMPLE),
     ],
 )
-def test_get_submission_example(schema: Dict[str, Any], expected: str) -> None:
-    assert schema_utils.get_submission_example(schema) == expected
+def test_get_submission_examples(schema: Dict[str, Any], expected: List[str]) -> None:
+    assert schema_utils.get_submission_examples(schema) == expected
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ({}, []),
+        (STRING_SCHEMA, ENUM),
+    ],
+)
+def test_get_suggested_enum(schema: Dict[str, Any], expected: List[str]) -> None:
+    assert schema_utils.get_suggested_enum(schema) == expected
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ({}, {}),
+        (SCHEMA, DEPENDENT_REQUIRED),
+    ],
+)
+def test_get_dependent_required(
+    schema: Dict[str, Any], expected: Dict[str, List[str]]
+) -> None:
+    assert schema_utils.get_dependent_required(schema) == expected

--- a/test/test_schema_utils.py
+++ b/test/test_schema_utils.py
@@ -44,6 +44,7 @@ PATTERN = "some_regex"
 ENUM = ["foo", "bar"]
 DESCRIPTION = "foo"
 COMMENT = "bar"
+EXAMPLE = "baz"
 STRING_SCHEMA = {
     "type": "string",
     "format": FORMAT,
@@ -53,6 +54,7 @@ STRING_SCHEMA = {
     "description": DESCRIPTION,
     "submitterRequired": True,
     "submissionComment": COMMENT,
+    "submissionExample": EXAMPLE,
 }
 ARRAY_SCHEMA = {"type": "array", "items": [STRING_SCHEMA]}
 OBJECT_SCHEMA = {"type": "object", "properties": {"foo": STRING_SCHEMA}}
@@ -389,3 +391,14 @@ def test_is_submitter_required(schema: Dict[str, Any], expected: bool) -> None:
 )
 def test_get_submission_comment(schema: Dict[str, Any], expected: str) -> None:
     assert schema_utils.get_submission_comment(schema) == expected
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ({}, ""),
+        (STRING_SCHEMA, EXAMPLE),
+    ],
+)
+def test_get_submission_example(schema: Dict[str, Any], expected: str) -> None:
+    assert schema_utils.get_submission_example(schema) == expected

--- a/test/test_schema_utils.py
+++ b/test/test_schema_utils.py
@@ -50,6 +50,7 @@ STRING_SCHEMA = {
     "linkTo": "foo",
     "enum": ENUM,
     "description": DESCRIPTION,
+    "submitterRequired": True,
 }
 ARRAY_SCHEMA = {"type": "array", "items": [STRING_SCHEMA]}
 OBJECT_SCHEMA = {"type": "object", "properties": {"foo": STRING_SCHEMA}}
@@ -363,3 +364,15 @@ def test_get_enum(schema: Dict[str, Any], expected: List[str]) -> None:
 )
 def test_get_description(schema: Dict[str, Any], expected: str) -> None:
     assert schema_utils.get_description(schema) == expected
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ({}, False),
+        (NUMBER_SCHEMA, False),
+        (STRING_SCHEMA, True),
+    ],
+)
+def test_is_submitter_required(schema: Dict[str, Any], expected: bool) -> None:
+    assert schema_utils.is_submitter_required(schema) == expected


### PR DESCRIPTION
This PR adds schema parsing functions for existing properties as well as some new ones that are useful for providing more context to submitters, such as examples outside of (suggested) enums and comments specifically intended for the submission templates.

Related PRs:

- Snovault: https://github.com/4dn-dcic/snovault/pull/295
- SMaHT: https://github.com/smaht-dac/smaht-portal/pull/169