### PR TITLE
Fix to publish-to-pypi script in response to pypi api change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ dcicutils
 Change Log
 ----------
 
-8.16.5
+8.16.6
 ======
 * dmichaels / 2025-01-10
 * Fix to dcicutils/scripts/publish_to_pypy.py script. They (pypi) changed their API so this returns

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ dcicutils
 Change Log
 ----------
 
+8.16.5
+======
+* dmichaels / 2025-01-10
+* Fix to dcicutils/scripts/publish_to_pypy.py script. They (pypi) changed their API so this returns
+  HTTP 200 even if the package version does NOT exist: https://pypi.org/project/{package_name}/{package_version}
+  So without this fix this script thinks the version to publish already exists even when it does not.
+  Changed to use this instead: https://pypi.org/pypi/{package_name}/json which returns JSON for ALL versions.
+
+
 8.16.4
 ======
 * dmichaels / 2024-11-17

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright 2017-2024 President and Fellows of Harvard College
+Copyright 2017-2025 President and Fellows of Harvard College
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dcicutils/scripts/publish_to_pypi.py
+++ b/dcicutils/scripts/publish_to_pypi.py
@@ -214,6 +214,25 @@ def verify_untracked_files() -> bool:
 
 def verify_not_already_published(package_name: str, package_version: str) -> bool:
     """
+    If the given package and version has NOT already been published to PyPi then returns True,
+    otherwise prints an error message and returns False.
+    """
+    url = f"{PYPI_BASE_URL}/pypi/{package_name}/json"
+    DEBUG_PRINT(f"curl {url}")
+    try:
+        response = requests.get(url).json()["releases"]
+    except Exception:
+        WARNING_PRINT(f"Cannot determine if this package ({package_name} {package_version})"
+                      f" already been published; ASSUMING NOT.")
+        return True
+    if response.get(package_version):
+        ERROR_PRINT(f"Package {package_name} {package_version} has already been published to PyPi.")
+        return False
+    return True
+
+
+def verify_not_already_published_obsolete_no_longer_works_20250110(package_name: str, package_version: str) -> bool:
+    """
     If the given package and version has not already been published to PyPi then returns True,
     otherwise prints an error message and returns False.
     """

--- a/dcicutils/scripts/publish_to_pypi.py
+++ b/dcicutils/scripts/publish_to_pypi.py
@@ -223,7 +223,7 @@ def verify_not_already_published(package_name: str, package_version: str) -> boo
         response = requests.get(url).json()["releases"]
     except Exception:
         WARNING_PRINT(f"Cannot determine if this package ({package_name} {package_version})"
-                      f" already been published; ASSUMING NOT.")
+                      f" has already been published or not; ASSUMING NOT.")
         return True
     if response.get(package_version):
         ERROR_PRINT(f"Package {package_name} {package_version} has already been published to PyPi.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.16.4"
+version = "8.16.4.1b1"  # TODO: To become 8.16.5
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.16.4.1b1"  # TODO: To become 8.16.5
+version = "8.16.5"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.16.5"
+version = "8.16.6"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_license_utils.py
+++ b/test/test_license_utils.py
@@ -759,13 +759,13 @@ def test_validate_simple_license_file():
 
             # Test that with no analysis argument, problems get sent out as warnings
             LicenseFileParser.validate_simple_license_file(filename='LICENSE.txt')
-            assert license_warnings == ["The copyright year, '2020', should have '2024' at the end."]
+            assert license_warnings == ["The copyright year, '2020', should have '2025' at the end."]
 
             # Test that with an analysis argument, problems get summarized to that object
             analysis = LicenseAnalysis()
             license_warnings = []
             LicenseFileParser.validate_simple_license_file(filename='LICENSE.txt', analysis=analysis)
-            assert analysis.miscellaneous == ["The copyright year, '2020', should have '2024' at the end."]
+            assert analysis.miscellaneous == ["The copyright year, '2020', should have '2025' at the end."]
             assert license_warnings == []
 
 


### PR DESCRIPTION
* Fix to dcicutils/scripts/publish_to_pypy.py script. They (pypi) changed their API so this returns
  HTTP 200 even if the package version does NOT exist: https://pypi.org/project/{package_name}/{package_version}
  So without this fix this script thinks the version to publish already exists even when it does not.
  Changed to use this instead: https://pypi.org/pypi/{package_name}/json which returns JSON for ALL versions.