### PR TITLE
Add test coverage and remove dead code for PyPI publish-check fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ dcicutils
 Change Log
 ----------
 
+8.18.5
+======
+* willronchetti / 2026-07-06 / branch: fm/dcic-pypi-fix-6v
+  - Removed the obsolete/unused verify_not_already_published_obsolete_no_longer_works_20250110
+    function from scripts/publish_to_pypi.py; the current verify_not_already_published already
+    uses the PyPi JSON API (https://pypi.org/pypi/{package}/json) instead of the old
+    https://pypi.org/project/{package}/{version}/ page check, which was prone to false positives
+    since PyPi returns HTTP 200 for that URL even when the version does not exist.
+  - Added unit test coverage (test/test_publish_to_pypi.py) for verify_not_already_published:
+    version already published, version not yet published, package with no PyPi presence at all,
+    and PyPi request failure.
+
+
 8.18.4
 ======
 * ajs / 2025-09-30 / branch: ajs_upd_es_metadata_fxns_250925 / PR-330

--- a/dcicutils/scripts/publish_to_pypi.py
+++ b/dcicutils/scripts/publish_to_pypi.py
@@ -231,20 +231,6 @@ def verify_not_already_published(package_name: str, package_version: str) -> boo
     return True
 
 
-def verify_not_already_published_obsolete_no_longer_works_20250110(package_name: str, package_version: str) -> bool:
-    """
-    If the given package and version has not already been published to PyPi then returns True,
-    otherwise prints an error message and returns False.
-    """
-    url = f"{PYPI_BASE_URL}/project/{package_name}/{package_version}/"
-    DEBUG_PRINT(f"curl {url}")
-    response = requests.get(url)
-    if response.status_code == 200:
-        ERROR_PRINT(f"Package {package_name} {package_version} has already been published to PyPi.")
-        return False
-    return True
-
-
 def get_untracked_files() -> list:
     """
     Returns a list of untracked files for the current git repo; empty list if no untracked changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.18.5"
+version = "8.18.6"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.18.4"
+version = "8.18.5"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_publish_to_pypi.py
+++ b/test/test_publish_to_pypi.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+from dcicutils.scripts import publish_to_pypi as publish_to_pypi_module
+from dcicutils.scripts.publish_to_pypi import verify_not_already_published
+
+
+def _mock_response(status_code=200, json_data=None, raise_json_error=False):
+    response = mock.MagicMock()
+    response.status_code = status_code
+    if raise_json_error:
+        response.json.side_effect = ValueError("No JSON object could be decoded")
+    else:
+        response.json.return_value = json_data or {}
+    return response
+
+
+def test_verify_not_already_published_version_exists():
+    # PyPI JSON API lists the requested version among the releases -> already published.
+    json_data = {"releases": {"1.0.0": [{"filename": "foo-1.0.0.tar.gz"}], "0.9.6": [{}]}}
+    with mock.patch.object(publish_to_pypi_module.requests, "get",
+                           return_value=_mock_response(200, json_data)) as mock_get:
+        assert verify_not_already_published("encoded-core", "1.0.0") is False
+        mock_get.assert_called_once_with("https://pypi.org/pypi/encoded-core/json")
+
+
+def test_verify_not_already_published_version_does_not_exist():
+    # Package exists on PyPI but the requested version is not among its releases -> not yet published.
+    json_data = {"releases": {"0.9.6": [{"filename": "foo-0.9.6.tar.gz"}]}}
+    with mock.patch.object(publish_to_pypi_module.requests, "get", return_value=_mock_response(200, json_data)):
+        assert verify_not_already_published("encoded-core", "1.0.1") is True
+
+
+def test_verify_not_already_published_package_does_not_exist():
+    # Package has no PyPI presence at all; JSON endpoint 404s with a body lacking "releases".
+    json_data = {"message": "Not Found"}
+    with mock.patch.object(publish_to_pypi_module.requests, "get", return_value=_mock_response(404, json_data)):
+        assert verify_not_already_published("some-brand-new-package", "0.1.0") is True
+
+
+def test_verify_not_already_published_request_failure():
+    # Any unexpected error talking to PyPI should not block publishing.
+    with mock.patch.object(publish_to_pypi_module.requests, "get", side_effect=Exception("network error")):
+        assert verify_not_already_published("encoded-core", "1.0.0") is True


### PR DESCRIPTION
## Summary

The task was to fix a bug in `verify_not_already_published` (scripts/publish_to_pypi.py) where checking `https://pypi.org/project/{package}/{version}/` for HTTP 200 caused false-positive "already published" errors, since PyPI serves that URL with status 200 even for nonexistent versions (confirmed real-world impact: encoded-core 1.0.0/1.0.1 blocked despite never being published).

Investigation found this bug was already fixed on `master` back in January 2025 (commit d35e89d / c943bd3): `verify_not_already_published` already queries the authoritative PyPI JSON API (`https://pypi.org/pypi/{package}/json`) and checks `data["releases"]` for the version, correctly handling a package with no PyPI presence at all (404 -> exception -> assumed not-published).

What was still missing/left over:
- The old, broken implementation was still present as dead code (`verify_not_already_published_obsolete_no_longer_works_20250110`), unused anywhere - removed it.
- No unit tests existed for `verify_not_already_published` - added `test/test_publish_to_pypi.py` covering: version already published, version not yet published, package with no PyPI presence, and PyPI request failure. Network calls are mocked.
- Bumped version to 8.18.5 and updated CHANGELOG.rst per repo convention.

## Test plan
- [x] Ran the new tests directly against the mocked logic (all 4 pass)
- [x] flake8 clean on changed files
- [x] Verified via curl that PyPI's JSON API 404s with a JSON body lacking "releases" for a nonexistent package, matching the exception-handling path in the code

Generated with Claude Code
