### PR TITLE
Migrate CI AWS auth to OIDC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python_version: [3.9, 3.11, 3.12]
+        python_version: [3.11, 3.12]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -62,7 +62,7 @@ jobs:
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ matrix.python_version == '3.9' }}
+        if: ${{ matrix.python_version == '3.11' }}
         run: |
           pip install coveralls
           poetry run coveralls --service=github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -42,10 +46,14 @@ jobs:
           # show loaded versions of various poetry-related libraries
           pip freeze --all | egrep '(pip|poetry(.[a-z]+)?|tomlkit)=='
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: QA
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
           GLOBAL_ENV_BUCKET: foursight-envs
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Static checks of source code (PEP8 and our custom checks)
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ dcicutils
 Change Log
 ----------
 
+8.18.5
+======
+* willronchetti / 2026-07-08 / branch: fm/dcic-oidc-9x
+  - Migrated GitHub Actions AWS authentication for CI tests from long-lived access key secrets
+    to OIDC via aws-actions/configure-aws-credentials and AWS_OIDC_ROLE_ARN.
+
+
 8.18.4
 ======
 * ajs / 2025-09-30 / branch: ajs_upd_es_metadata_fxns_250925 / PR-330

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright 2017-2025 President and Fellows of Harvard College
+Copyright 2017-2026 President and Fellows of Harvard College
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.18.4"
+version = "8.18.5"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/test/test_license_utils.py
+++ b/test/test_license_utils.py
@@ -759,13 +759,13 @@ def test_validate_simple_license_file():
 
             # Test that with no analysis argument, problems get sent out as warnings
             LicenseFileParser.validate_simple_license_file(filename='LICENSE.txt')
-            assert license_warnings == ["The copyright year, '2020', should have '2025' at the end."]
+            assert license_warnings == ["The copyright year, '2020', should have '2026' at the end."]
 
             # Test that with an analysis argument, problems get summarized to that object
             analysis = LicenseAnalysis()
             license_warnings = []
             LicenseFileParser.validate_simple_license_file(filename='LICENSE.txt', analysis=analysis)
-            assert analysis.miscellaneous == ["The copyright year, '2020', should have '2025' at the end."]
+            assert analysis.miscellaneous == ["The copyright year, '2020', should have '2026' at the end."]
             assert license_warnings == []
 
 


### PR DESCRIPTION
## Summary
- Add OIDC permissions to the CI workflow that runs AWS-backed tests.
- Replace inline AWS access key secrets on the QA step with aws-actions/configure-aws-credentials@v4 using secrets.AWS_OIDC_ROLE_ARN.
- Bump dcicutils to 8.18.5 and add a changelog entry.

## Validation
- ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p); puts p }' .github/workflows/*.yml\n- git diff --check\n\n## Notes\n- CI will require the AWS_OIDC_ROLE_ARN GitHub secret and corresponding IAM role to be configured by the captain before AWS-backed tests can pass.