### PR TITLE
Add auto tag-and-publish-to-PyPI CI job on master merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,3 +66,65 @@ jobs:
         run: |
           pip install coveralls
           poetry run coveralls --service=github
+
+  # Tags and publishes the version declared in pyproject.toml after a successful test run on
+  # master. Runs in the same job as the tag push (rather than relying on main-publish.yml's
+  # tag-triggered `on: push: tags` event) because GitHub Actions does not start a new workflow
+  # run from a push made with the default GITHUB_TOKEN. The tag-push step is gated on the
+  # tag-existence check (only tag once per version). The publish step is independently gated
+  # on whether the version exists on PyPI, so it can self-heal if a prior run tagged
+  # successfully but crashed before publishing without failing for an already-published version.
+  publish:
+    name: Tag and Publish to PyPI
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: Install Deps
+        run: |
+          make configure
+          pip install requests toml
+
+      - name: Assert clean release checkout
+        run: git diff --exit-code
+
+      - name: Determine version and check for existing tag and PyPI release
+        id: version
+        run: |
+          VERSION=$(poetry version -s)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q "refs/tags/$VERSION$"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+          PYPI_STATUS=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            "https://pypi.org/pypi/dcicutils/${VERSION}/json")
+          case "$PYPI_STATUS" in
+            200) echo "pypi_exists=true" >> "$GITHUB_OUTPUT" ;;
+            404) echo "pypi_exists=false" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Unexpected PyPI status ${PYPI_STATUS} for ${VERSION}" >&2; exit 1 ;;
+          esac
+
+      - name: Create and push tag
+        if: ${{ steps.version.outputs.exists == 'false' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Publish to PyPI
+        if: ${{ steps.version.outputs.pypi_exists == 'false' }}
+        env:
+          PYPI_USER: ${{ secrets.PYPI_USER }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          make publish-for-ga

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Automatic tag-and-publish-on-master release workflow
+
+`.github/workflows/main.yml`'s `publish` job (`needs: build`, runs only on `push` to
+`master`) reads the version from `pyproject.toml` (`poetry version -s`) and checks both for
+its git tag and for an existing PyPI release. It creates the tag if missing and publishes
+only if PyPI does not already have the version, all **in the same job run**. It deliberately
+does not rely on `.github/workflows/main-publish.yml`'s tag-triggered `on: push: tags`
+event, because GitHub Actions does not start a new workflow run from a tag pushed using the
+default `GITHUB_TOKEN` (anti-recursion rule) - `main-publish.yml` remains only for manual/
+`workflow_dispatch` publishing.
+
+The "Create and push tag" step is gated on the tag-existence check (`exists == 'false'`) -
+tag once per version. The "Publish to PyPI" step instead uses the independently checked
+`pypi_exists == 'false'` condition. Its curl request treats only HTTP 200 (present) and 404
+(absent) as valid; any other status fails the job closed. This split preserves recovery from
+a tag-exists-but-never-published state, while avoiding a failing duplicate-upload attempt on
+later merges. `dcicutils/scripts/publish_to_pypi.py` itself also independently verifies the
+version isn't already published and refuses a dirty checkout, as defense-in-depth.
+
+Unlike snovault (which vendors this same job), this repo IS `dcicutils`, so `make
+publish-for-ga` invokes `python -m dcicutils.scripts.publish_to_pypi --noconfirm` directly
+against the checked-out source - no separate "install dcicutils" step is needed. The
+`publish` job's "Install Deps" step mirrors `main-publish.yml`'s: `make configure` (installs
+poetry) plus `pip install requests toml` (the modules `publish_to_pypi.py` imports outside
+of poetry's venv). The workflow asserts `git diff --exit-code` right after that install step
+so a future dependency-install change that dirties the tree fails loud with the filename,
+even though no known step currently does so here.
+
+The workflow-level `permissions:` block in `main.yml` stays `id-token: write` / `contents:
+read` (needed by the `build` job's AWS OIDC auth); `contents: write` (needed to push the
+tag) is scoped to the `publish` job only, since a job-level `permissions:` block replaces
+rather than merges with the workflow-level one.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ dcicutils
 Change Log
 ----------
 
+8.18.8
+======
+* willronchetti / 2026-07-10 / branch: fm/dcic-pubci-9m
+  - Added an automatic tag-and-publish-to-PyPI `publish` job to `.github/workflows/main.yml`,
+    gated on a successful `build` and a push to `master`. Determines the version from
+    `poetry version -s`, independently checks for an existing git tag and an existing PyPI
+    release (via the PyPI JSON API), tags only if the tag is missing, and publishes only if
+    the version is not yet on PyPI - so the job self-heals if tagging succeeds but a later
+    step fails. `main-publish.yml`'s tag-triggered workflow remains for manual/
+    `workflow_dispatch` publishing only, since GitHub Actions does not start a new workflow
+    run from a tag pushed with the default `GITHUB_TOKEN`.
+
 8.18.7
 ======
 * wrr / 2026-07-01 / branch: fm/sec-fix-util1 / PR-332

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicutils"
-version = "8.18.7"
+version = "8.18.8"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Ports snovault's fixed auto tag-and-publish-on-master-merge CI job (`4dn-dcic/snovault#326`, branch `fm/snov-pubfix2-8h`) to dcicutils.
- Adds a `publish` job to `.github/workflows/main.yml` (`needs: build`, only on `push` to `master`) that determines the version via `poetry version -s`, independently checks for an existing git tag and an existing PyPI release (fail-closed `curl` to the PyPI JSON API), tags only if missing, and publishes only if not already on PyPI - so it self-heals if tagging succeeds but publish later fails.
- Since dcicutils IS the package that provides `publish-to-pypi`, the job's install step reuses the same `make configure` + `pip install requests toml` that `main-publish.yml` already uses - no separate "install dcicutils" step, and no `poetry.toml` mutation bug exists here (unlike snovault, which needed a fix for that).
- Bumped version to 8.18.8 and added a `CHANGELOG.rst` entry.
- Added `AGENTS.md` (+ `CLAUDE.md` symlink) documenting the new workflow's design.

## Test plan
- [x] Validated `.github/workflows/main.yml` YAML parses correctly.
- [x] Verified the PyPI status-code branching logic against real endpoints: `https://pypi.org/pypi/dcicutils/8.18.3/json` → 200 (published version), `https://pypi.org/pypi/dcicutils/999999.0.0/json` → 404 (absent).
- [ ] Will be exercised for real on the next merge to `master` (no test tag/publish was performed, per safety constraints - live PyPI credentials were not exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
